### PR TITLE
Fixed the connection string for master/slave set up

### DIFF
--- a/src/Jenssegers/Mongodb/Connection.php
+++ b/src/Jenssegers/Mongodb/Connection.php
@@ -111,6 +111,8 @@ class Connection extends \Illuminate\Database\Connection {
         // Treat host option as array of hosts
         $hosts = is_array($config['host']) ? $config['host'] : array($config['host']);
 
+        $credentials = null;
+
         if (isset($config['username']) and isset($config['password']))
         {
             $credentials = "{$username}:{$password}@";


### PR DESCRIPTION
The previous version was adding the user:password twice in the connection string resulting in an error. :v:
