### PR TITLE
The referenced Laravel Libraries to point to 4.x and not 4.0.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,9 @@
     "license" : "MIT",
     "require": {
         "php": ">=5.3.0",
-        "illuminate/support": "4.0.x",
-        "illuminate/database": "4.0.x",
-        "illuminate/events": "4.0.x"
+        "illuminate/support": "4.x",
+        "illuminate/database": "4.x",
+        "illuminate/events": "4.x"
     },
     "require-dev": {
         "illuminate/cache": "4.0.x",


### PR DESCRIPTION
Libraries for Laravel 4.1
- Update composer.json
