### PR TITLE
orderBy() should accept uppercase order direction

### DIFF
--- a/src/Jenssegers/Mongodb/Builder.php
+++ b/src/Jenssegers/Mongodb/Builder.php
@@ -268,7 +268,7 @@ class Builder extends \Illuminate\Database\Query\Builder {
      */
     public function orderBy($column, $direction = 'asc')
     {
-        $this->orders[$column] = ($direction == 'asc' ? 1 : -1);
+        $this->orders[$column] = (strtolower($direction) == 'asc' ? 1 : -1);
 
         return $this;
     }

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -142,6 +142,9 @@ class QueryTest extends PHPUnit_Framework_TestCase {
 		$user = User::whereNotNull('age')->orderBy('age', 'asc')->first();
 		$this->assertEquals(13, $user->age);
 
+		$user = User::whereNotNull('age')->orderBy('age', 'ASC')->first();
+		$this->assertEquals(13, $user->age);
+
 		$user = User::whereNotNull('age')->orderBy('age', 'desc')->first();
 		$this->assertEquals(37, $user->age);
 	}


### PR DESCRIPTION
`query->orderBy()` should accept an uppercase parameter for the direction because it is the SQL convention and because it is the initial behavior in Laravel.

``` PHP
// Illuminate\Database\Query\Builder
public function orderBy($column, $direction = 'asc')
{
    $direction = strtolower($direction) == 'asc' ? 'asc' : 'desc';

    $this->orders[] = compact('column', 'direction');

    return $this;
}
```
