### PR TITLE
Fix broken tests and a bug about relations

### DIFF
--- a/src/Jenssegers/Eloquent/Model.php
+++ b/src/Jenssegers/Eloquent/Model.php
@@ -191,9 +191,7 @@ abstract class Model extends \Illuminate\Database\Eloquent\Model {
         // title of this relation since that is a great convention to apply.
         if (is_null($relation))
         {
-            $caller = $this->getBelongsToManyCaller();
-
-            $name = $caller['function'];
+            $relation = $this->getBelongsToManyCaller();
         }
 
         // First, we'll need to determine the foreign key and "other key" for the

--- a/tests/RelationsTest.php
+++ b/tests/RelationsTest.php
@@ -68,7 +68,7 @@ class RelationsTest extends PHPUnit_Framework_TestCase {
         Item::create(array('type' => 'sword', 'user_id' => $user->_id));
         Item::create(array('type' => 'bag', 'user_id' => null));
 
-        $items = Item::with('user')->get();
+        $items = Item::with('user')->orderBy('user_id', 'desc')->get();
 
         $user = $items[0]->getRelation('user');
         $this->assertInstanceOf('User', $user);


### PR DESCRIPTION
##### `testWithBelongsTo()`

Should be broken only with some MongoDB config or context. By using `orderBy` it will work everywhere.
##### `testBelongsToMany()`

Some changes have been made in the Laravel Core Model class recently like this one : https://github.com/laravel/framework/commit/cd4e0ca54d42f7737e166b71dbbf7d8881323a5f. I don't completely understand what happened here but everything should be ok now !
