### PR TITLE
[Proposal] Add embedsMany relationship to Eloquent Model

### DIFF
--- a/src/Jenssegers/Mongodb/Relations/EmbeddedRelation.php
+++ b/src/Jenssegers/Mongodb/Relations/EmbeddedRelation.php
@@ -1,0 +1,42 @@
+<?php namespace Jenssegers\Mongodb\Relations;
+
+use Illuminate\Database\Eloquent\Model;
+
+abstract class EmbeddedRelation {
+
+    /**
+     * The parent model instance.
+     *
+     * @var \Illuminate\Database\Eloquent\Model
+     */
+    protected $parent;
+
+    /**
+     * The related model class name.
+     *
+     * @var string
+     */
+    protected $related;
+
+    /**
+     * Create a new has many relationship instance.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $parent
+     * @param  string  $related
+     * @param  string  $collection
+     * @return void
+     */
+    public function __construct(Model $parent, $related)
+    {
+        $this->parent = $parent;
+        $this->related = $related;
+    }
+
+    /**
+     * Get the results of the relationship.
+     *
+     * @return mixed
+     */
+    abstract public function getResults();
+
+}

--- a/src/Jenssegers/Mongodb/Relations/EmbedsMany.php
+++ b/src/Jenssegers/Mongodb/Relations/EmbedsMany.php
@@ -1,0 +1,185 @@
+<?php namespace Jenssegers\Mongodb\Relations;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Collection;
+
+use MongoId;
+
+class EmbedsMany extends EmbeddedRelation {
+
+    /**
+     * The parent collection attribute where the related are stored.
+     *
+     * @var string
+     */
+    protected $collection;
+
+    /**
+     * Create a new has many relationship instance.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $parent
+     * @param  string  $related
+     * @param  string  $collection
+     * @return void
+     */
+    public function __construct(Model $parent, $related, $collection)
+    {
+        $this->collection = $collection;
+
+        parent::__construct($parent, $related);
+    }
+
+    /**
+     * Get the results of the relationship.
+     *
+     * @return Illuminate\Database\Eloquent\Collection
+     */
+    public function getResults()
+    {
+        $models = new Collection();
+
+        $modelsAttributes = $this->parent->getAttribute($this->collection);
+
+        if (is_array($modelsAttributes))
+        {
+            foreach ($modelsAttributes as $attributes)
+            {
+                $models->push(new $this->related($attributes));
+            }
+        }
+
+        return $models;
+    }
+
+    /**
+     * Create a new instance and attach it to the parent model.
+     *
+     * @param  array  $attributes
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    public function build(array $attributes)
+    {
+        if ( ! isset($attributes['_id'])) $attributes['_id'] = new MongoId;
+
+        $collection = $this->parent->getAttribute($this->collection);
+        $collection[''.$attributes['_id']] = $attributes;
+        $this->parent->setAttribute($this->collection, $collection);
+
+        return new $this->related($attributes);
+    }
+
+    /**
+     * Attach an instance to the parent model.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    public function add($model)
+    {
+        return $this->build($model->toArray());
+    }
+
+    /**
+     * Create a new instance, attach it to the parent model and save this model.
+     *
+     * @param  array  $attributes
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    public function create(array $attributes)
+    {
+        $instance = $this->build($attributes);
+
+        $this->parent->save();
+
+        return $instance;
+    }
+
+    /**
+     * Attach a model instance to the parent model and save this model.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    public function push($model)
+    {
+        return $this->create($model->toArray());
+    }
+
+    /**
+     * Create an array of new instances and attach them to the parent model.
+     *
+     * @param  array|Traversable  $modelsAttributes
+     * @return array
+     */
+    public function buildMany($modelsAttributes)
+    {
+        $instances = array();
+
+        foreach ($modelsAttributes as $attributes)
+        {
+            $instances[] = $this->build($attributes);
+        }
+
+        return $instances;
+    }
+
+    /**
+     * Attach an array of new instances to the parent model.
+     *
+     * @param  array|Traversable  $models
+     * @return array
+     */
+    public function addMany($models)
+    {
+        $modelsAttributes = $this->getAttributesOf($models);
+
+        return $this->buildMany($modelsAttributes);
+    }
+
+    /**
+     * Create an array of new instances, attach them to the parent model and save this model.
+     *
+     * @param  array|Traversable  $modelsAttributes
+     * @return array
+     */
+    public function createMany($modelsAttributes)
+    {
+        $instances = $this->buildMany($modelsAttributes);
+
+        $this->parent->save();
+
+        return $instances;
+    }
+
+    /**
+     * Attach an array of new instances to the parent model and save this model.
+     *
+     * @param  array|Traversable  $models
+     * @return array
+     */
+    public function pushMany($models)
+    {
+        $modelsAttributes = $this->getAttributesOf($models);
+
+        return $this->createMany($modelsAttributes);
+    }
+
+    /**
+     * Transform a list of models to a list of models' attributes
+     *
+     * @param  array|Traversable  $models
+     * @return array
+     */
+    protected function getAttributesOf($models)
+    {
+        $modelsAttributes = array();
+
+        foreach ($models as $key => $model)
+        {
+            $modelsAttributes[$key] = $model->getAttributes();
+        }
+
+        return $modelsAttributes;
+    }
+
+}

--- a/tests/models/Address.php
+++ b/tests/models/Address.php
@@ -1,0 +1,9 @@
+<?php
+
+use Jenssegers\Mongodb\Model as Eloquent;
+
+class Address extends Eloquent {
+
+    protected static $unguarded = true;
+
+}

--- a/tests/models/User.php
+++ b/tests/models/User.php
@@ -51,6 +51,11 @@ class User extends Eloquent implements UserInterface, RemindableInterface {
         return $this->morphMany('Photo', 'imageable');
     }
 
+    public function addresses()
+    {
+        return $this->embedsMany('Address');
+    }
+
     /**
      * Get the unique identifier for the user.
      *


### PR DESCRIPTION
This pull request come from code that we are using in our Laravel projects. Because this package is not made to rewrite Eloquent, MongoDB specificities are generally not yet implemented. But the main difference, for web development, with a standard SQL driver is the ability to _embed_ documents inside other ones.

We can do that with this package but only with _manual_ data manipulations or quite a lot of custom code. That's why I have wrote an EmbedsMany class in order to deal with this specificity with a high level of abstraction.

In order to keep the spirit of this package, I tried to keep it as close as I can of Eloquent syntax. For example, the three lines below are exactly the same for a `hasMany` relationship than for a `embedsMany` relationship :

``` PHP
$address = new Address(array('city' => 'Paris'));
$user->addresses()->save($address);
$addresses = $user->addresses;
```

I also add several others methods that are basically shorthand to do the same things with raw data, with array of related models and without persistence. You can find that in the test cases.

The main difference from SQL Eloquent relationship is that this relationship is not, in fact, a query but directly an array of data. That's why I had to wrote an other relation parent class : `EmbeddedRelation`.

I just worked on adding an embedded model and retrieve the list of this models. More work could be done (method `remove` or `delete`, test edge cases...) but I want your opinion about that before.

What do you think about the idea, if we keep it simple and close to Eloquent syntax ? What do you think about the implementation (method naming, number of shorthand, architecture...) ?
