### PR TITLE
Make test cases more robust by not using natural ordering

### DIFF
--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -104,8 +104,8 @@ class ModelTest extends PHPUnit_Framework_TestCase {
 		$all = User::all();
 
 		$this->assertEquals(2, count($all));
-		$this->assertEquals('John Doe', $all[0]->name);
-		$this->assertEquals('Jane Doe', $all[1]->name);
+		$this->assertContains('John Doe', $all->lists('name'));
+		$this->assertContains('Jane Doe', $all->lists('name'));
 	}
 
 	public function testFind()

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -312,9 +312,9 @@ class QueryBuilderTest extends PHPUnit_Framework_TestCase {
 			array('name' => 'spoon', 'type' => 'round', 'amount' => 14)
 		));
 
-		$items = DB::collection('items')->take(2)->get();
+		$items = DB::collection('items')->orderBy('name')->take(2)->get();
 		$this->assertEquals(2, count($items));
-		$this->assertEquals('knife', $items[0]['name']);
+		$this->assertEquals('fork', $items[0]['name']);
 	}
 
 	public function testSkip()
@@ -352,8 +352,9 @@ class QueryBuilderTest extends PHPUnit_Framework_TestCase {
 		));
 
 		$list = DB::collection('items')->lists('name');
+		sort($list);
 		$this->assertEquals(4, count($list));
-		$this->assertEquals(array('knife', 'fork', 'spoon', 'spoon'), $list);
+		$this->assertEquals(array('fork', 'knife', 'spoon', 'spoon'), $list);
 
 		$list = DB::collection('items')->lists('type', 'name');
 		$this->assertEquals(3, count($list));

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -70,18 +70,18 @@ class QueryTest extends PHPUnit_Framework_TestCase {
 
 	public function testSelect()
 	{
-		$user = User::select('name')->first();
+		$user = User::where('name', 'John Doe')->select('name')->first();
 
 		$this->assertEquals('John Doe', $user->name);
 		$this->assertEquals(null, $user->age);
 
-		$user = User::select('name', 'title')->first();
+		$user = User::where('name', 'John Doe')->select('name', 'title')->first();
 
 		$this->assertEquals('John Doe', $user->name);
 		$this->assertEquals('admin', $user->title);
 		$this->assertEquals(null, $user->age);
 
-		$user = User::get(array('name'))->first();
+		$user = User::where('name', 'John Doe')->get(array('name'))->first();
 
 		$this->assertEquals('John Doe', $user->name);
 		$this->assertEquals(null, $user->age);


### PR DESCRIPTION
When we don't set an order in a query, the _natural order_ is used. Most of the times, it represents the insertion order but it's not reliable. I don't know why but, in my configuration, I can't trust this ordering.

More explanations in the MongoDB doc : http://docs.mongodb.org/manual/reference/glossary/#term-natural-order
