### PR TITLE
Fix toArray() infinite loop bug in embeds many relation

### DIFF
--- a/src/Jenssegers/Mongodb/Relations/EmbedsMany.php
+++ b/src/Jenssegers/Mongodb/Relations/EmbedsMany.php
@@ -487,6 +487,7 @@ class EmbedsMany extends Relation {
 
             // Attatch the parent relation to the embedded model.
             $model->setRelation($this->foreignKey, $this->parent);
+            $model->setHidden(array_merge($model->getHidden(), array($this->foreignKey)));
 
             $models[] = $model;
         }

--- a/tests/RelationsTest.php
+++ b/tests/RelationsTest.php
@@ -342,6 +342,7 @@ class RelationsTest extends PHPUnit_Framework_TestCase {
         $this->assertInstanceOf('DateTime', $address->created_at);
         $this->assertInstanceOf('DateTime', $address->updated_at);
         $this->assertInstanceOf('User', $address->user);
+        $this->assertEmpty($address->relationsToArray()); // prevent infinite loop
 
         $user = User::find($user->_id);
         $user->addresses()->save(new Address(array('city' => 'Bruxelles')));


### PR DESCRIPTION
Because both related and parent have the relation set, an infinite loop occured when we called `toArray()` or `relationsToArray()` methods.

That's fixed.
