### PR TITLE
Fix #175 : embedsMany duplicates are identified by key

### DIFF
--- a/src/Jenssegers/Mongodb/Relations/EmbedsMany.php
+++ b/src/Jenssegers/Mongodb/Relations/EmbedsMany.php
@@ -166,7 +166,7 @@ class EmbedsMany extends Relation {
         $this->updateTimestamps($model);
 
         // Insert a new document.
-        if ( ! $model->exists)
+        if ( ! $this->contains($model))
         {
             $result = $this->performInsert($model);
         }
@@ -197,6 +197,22 @@ class EmbedsMany extends Relation {
     }
 
     /**
+     * Indicate if a model is already contained in the embedded documents
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return bool
+     */
+    public function contains(Model $model)
+    {
+        foreach ($this->getEmbeddedRecords() as $record)
+        {
+            if ($record[$model->getKeyName()] == $model->getKey()) return true;
+        }
+
+        return false;
+    }
+
+    /**
      * Attach a model instance to the parent model without persistence.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model
@@ -205,7 +221,7 @@ class EmbedsMany extends Relation {
     public function associate(Model $model)
     {
         // Insert the related model in the parent instance
-        if ( ! $model->exists)
+        if ( ! $this->contains($model))
         {
             return $this->associateNew($model);
         }

--- a/tests/RelationsTest.php
+++ b/tests/RelationsTest.php
@@ -399,6 +399,10 @@ class RelationsTest extends TestCase {
         $user->addresses()->save($address);
         $this->assertEquals(1, $user->addresses->count());
         $this->assertEquals(array('Paris'), $user->addresses->lists('city'));
+
+        $user->addresses()->create(array('_id' => $address->_id, 'city' => 'Bruxelles'));
+        $this->assertEquals(1, $user->addresses->count());
+        $this->assertEquals(array('Bruxelles'), $user->addresses->lists('city'));
     }
 
     public function testEmbedsManyCreate()
@@ -521,7 +525,7 @@ class RelationsTest extends TestCase {
     {
         $user = User::create(array('name' => 'John Doe'));
         $address = new Address(array('city' => 'New York'));
-        $address->exists = true;
+        $user->addresses()->save($address);
 
         $address->setEventDispatcher($events = Mockery::mock('Illuminate\Events\Dispatcher'));
         $events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($address), $address)->andReturn(true);


### PR DESCRIPTION
The `exists` attribute is not enough reliable to detect duplicates in embedsMany documents. I just wrote a small `contains()` method that is used instead.
