### PR TITLE
Add missing abstract methods from UserInterface in User test model

### DIFF
--- a/tests/models/User.php
+++ b/tests/models/User.php
@@ -85,6 +85,36 @@ class User extends Eloquent implements UserInterface, RemindableInterface {
         return $this->email;
     }
 
+    /**
+     * Get the token value for the "remember me" session.
+     *
+     * @return string
+     */
+    public function getRememberToken()
+    {
+        return $this->rememberToken;
+    }
+
+    /**
+     * Set the token value for the "remember me" session.
+     *
+     * @param string $value
+     * @return void
+     */
+    public function setRememberToken($value)
+    {
+        $this->rememberToken = $value;
+    }
+
+    /**
+     * Get the column name for the "remember me" token.
+     *
+     * @return string
+     */
+    public function getRememberTokenName() {
+        return 'remember_token';
+    }
+
     protected function getDateFormat()
     {
         return 'l jS \of F Y h:i:s A';


### PR DESCRIPTION
This allows to run Laravel-MongoDB tests without the following error:

"PHP Fatal error:  Class User contains 3 abstract methods and must therefore be declared abstract or implement the remaining methods (Illuminate\Auth\UserInterface::getRememberToken, Illuminate\Auth\UserInterface::setRememberToken, Illuminate\Auth\UserInterface::getRememberTokenName) in /.../Laravel-MongoDB/tests/models/User.php on line 92"
