### PR TITLE
Backport Eloquent BelongsToMany::sync function signature

### DIFF
--- a/src/Jenssegers/Mongodb/Relations/BelongsToMany.php
+++ b/src/Jenssegers/Mongodb/Relations/BelongsToMany.php
@@ -47,7 +47,7 @@ class BelongsToMany extends EloquentBelongsToMany {
 	 * @param  bool   $detaching
 	 * @return void
 	 */
-	public function sync(array $ids, $detaching = true)
+	public function sync($ids, $detaching = true)
 	{
 		if ($ids instanceof Collection) $ids = $ids->modelKeys();
 


### PR DESCRIPTION
Backport new \Illuminate\Database\Eloquent\Relations\BelongsToMany::sync function signature from commit https://github.com/laravel/framework/commit/ac5c270151c7d646e698391e1bd921e054e66299 (included in Laravel v4.1.26)

This allows to fix the following errors when using a BelongsToMany relation:

"[ErrorException]  
Declaration of Jenssegers\Mongodb\Relations\BelongsToMany::sync() should be compatible with Illuminate\Database\Eloquent\Relations\BelongsToMany::sync($ids, $detaching = true)"
