### PR TITLE
Fix belongsTo and belongToMany relations

### DIFF
--- a/src/Jenssegers/Eloquent/Model.php
+++ b/src/Jenssegers/Eloquent/Model.php
@@ -134,12 +134,6 @@ abstract class Model extends \Illuminate\Database\Eloquent\Model {
     */
     public function belongsTo($related, $foreignKey = null, $otherKey = null, $relation = null)
     {
-        // Check if it is a relation with an original model.
-        if (!is_subclass_of($related, 'Jenssegers\Mongodb\Model'))
-        {
-            return parent::belongsTo($related, $foreignKey, $otherKey, $relation);
-        }
-
         // If no relation name was given, we will use this debug backtrace to extract
         // the calling method's name and use that as the relationship name as most
         // of the time this will be what we desire to use for the relatinoships.
@@ -148,6 +142,12 @@ abstract class Model extends \Illuminate\Database\Eloquent\Model {
             list(, $caller) = debug_backtrace(false);
 
             $relation = $caller['function'];
+        }
+		
+        // Check if it is a relation with an original model.
+        if (!is_subclass_of($related, 'Jenssegers\Mongodb\Model'))
+        {
+            return parent::belongsTo($related, $foreignKey, $otherKey, $relation);
         }
 
         // If no foreign key was supplied, we can use a backtrace to guess the proper
@@ -227,18 +227,18 @@ abstract class Model extends \Illuminate\Database\Eloquent\Model {
      */
     public function belongsToMany($related, $collection = null, $foreignKey = null, $otherKey = null, $relation = null)
     {
-        // Check if it is a relation with an original model.
-        if (!is_subclass_of($related, 'Jenssegers\Mongodb\Model'))
-        {
-            return parent::belongsToMany($related, $collection, $foreignKey, $otherKey, $relation);
-        }
-
         // If no relationship name was passed, we will pull backtraces to get the
         // name of the calling function. We will use that function name as the
         // title of this relation since that is a great convention to apply.
         if (is_null($relation))
         {
             $relation = $this->getBelongsToManyCaller();
+        }
+		
+        // Check if it is a relation with an original model.
+        if (!is_subclass_of($related, 'Jenssegers\Mongodb\Model'))
+        {
+            return parent::belongsToMany($related, $collection, $foreignKey, $otherKey, $relation);
         }
 
         // First, we'll need to determine the foreign key and "other key" for the


### PR DESCRIPTION
belongsTo and belongToMany would resolve to an incorrect relation name
if it was a relation with a SQL model, due to MongoModel::belongsTo
being the caller instead of MongoModel::relation which makes foreignKey
become "belongs_to_id", the unit tests do not show this behavior because
foreignKey is set explicitly.
