### PR TITLE
$dates array support

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ All basic insert, update, delete and select methods should be implemented.
 
 ### Dates
 
-Eloquent allows you to work with Carbon/DateTime objects instead of MongoDate objects. Internally, these dates will be converted to MongoDate objects when saved to the database. If you wish to use this functionality on non-default date fields you will need to manually specify them as described here: http://laravel.com/docs/eloquent#date-mutators
+Eloquent allows you to work with Carbon/DateTime objects instead of MongoDate objects. Internally, these dates will be converted to MongoDate objects when saved to the database. If you wish to use this functionality on non-default date fields you will need to manually specify them as described here: http://laravel.com/docs/eloquent#date-mutators. Unlike Eloquent, any arrays specified will have their dates converted. You can also use dot notation to specify a specific date within an array.
 
 Example:
 
@@ -306,7 +306,7 @@ Example:
 
     class User extends Eloquent {
 
-        protected $dates = array('birthday');
+        protected $dates = array('birthday', 'children.birthday');
 
     }
 

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "kaamaru/mongodb",
+    "name": "jessegers/mongodb",
     "description": "A MongoDB based Eloquent model and Query builder for Laravel 4",
     "keywords": ["laravel","eloquent","mongodb","mongo","database","model"],
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "jessegers/mongodb",
+    "name": "jenssegers/mongodb",
     "description": "A MongoDB based Eloquent model and Query builder for Laravel 4",
     "keywords": ["laravel","eloquent","mongodb","mongo","database","model"],
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "jenssegers/mongodb",
+    "name": "kaamaru/mongodb",
     "description": "A MongoDB based Eloquent model and Query builder for Laravel 4",
     "keywords": ["laravel","eloquent","mongodb","mongo","database","model"],
     "authors": [

--- a/src/Jenssegers/Mongodb/Model.php
+++ b/src/Jenssegers/Mongodb/Model.php
@@ -129,9 +129,11 @@ abstract class Model extends \Jenssegers\Eloquent\Model {
      */
     public function fromDateTime($value)
     {
+        // Flatten $value so we can search through it
         $value = array($value);
         $items = $items = array_dot($value);
 
+        // Change all the dates in the value
         foreach ($items as $key => $item)
         {
             if ($item instanceof DateTime)
@@ -159,9 +161,11 @@ abstract class Model extends \Jenssegers\Eloquent\Model {
      */
     protected function asDateTime($value)
     {
+        // Flatten $value so we can search through it
         $value = array($value);
         $items = $items = array_dot($value);
 
+        // Change all the dates in the value
         foreach ($items as $key => $item)
         {
             if ($item instanceof MongoDate)

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -320,16 +320,19 @@ class ModelTest extends TestCase {
 	public function testDates()
 	{
 		$user = User::create(array(
-			'name' => 'John Doe',
-			'birthday' => new DateTime('1980/1/1'),
-			'visa' => array('expiry_date' => new DateTime('2018/4/3')))
+				'name' => 'John Doe',
+				'birthday' => new DateTime('1980/1/1'),
+				'visa' => array('expiry_date' => new DateTime('2018/4/3')),
+				'death' => new MongoDate(strtotime('2051/04/03')))
 		);
 		$this->assertInstanceOf('Carbon\Carbon', $user->birthday);
 		$this->assertInstanceOf('Carbon\Carbon', $user->visa['expiry_date']);
+		$this->assertInstanceOf('MongoDate', $user->death);
 
 		$check = User::find($user->_id);
 		$this->assertInstanceOf('Carbon\Carbon', $check->birthday);
 		$this->assertInstanceOf('Carbon\Carbon', $check->visa['expiry_date']);
+		$this->assertInstanceOf('MongoDate', $user->death);
 		$this->assertEquals($user->birthday, $check->birthday);
 		$this->assertEquals($user->visa['expiry_date'], $check->visa['expiry_date']);
 
@@ -350,28 +353,38 @@ class ModelTest extends TestCase {
 		$this->assertEquals($item->created_at->format('Y-m-d H:i:s'), $json['created_at']);
 
 		$user = User::create(array(
-			'name' => 'Jane Doe',
-			'birthday' => time(),
-			'visa' => array('expiry_date' => time()))
+				'name' => 'Jane Doe',
+				'birthday' => time(),
+				'visa' => array('expiry_date' => time()))
 		);
 		$this->assertInstanceOf('Carbon\Carbon', $user->birthday);
 		$this->assertInstanceOf('Carbon\Carbon', $user->visa['expiry_date']);
 
 		$user = User::create(array(
-			'name' => 'Jane Doe',
-			'birthday' => 'Monday 8th of August 2005 03:12:46 PM',
-			'visa' => array('expiry_date' => 'Monday 3th of August 2015 03:11:46 AM'))
+				'name' => 'Jane Doe',
+				'birthday' => 'Monday 8th of August 2005 03:12:46 PM',
+				'visa' => array('expiry_date' => 'Monday 3th of August 2015 03:11:46 AM'))
 		);
 		$this->assertInstanceOf('Carbon\Carbon', $user->birthday);
 		$this->assertInstanceOf('Carbon\Carbon', $user->visa['expiry_date']);
 
 		$user = User::create(array(
-			'name' => 'Jane Doe',
-			'birthday' => '2005-08-08',
-			'visa' => array('expiry_date' => '2018-03-03'))
+				'name' => 'Jane Doe',
+				'birthday' => '2005-08-08',
+				'visa' => array('expiry_date' => '2018-03-03'))
 		);
 		$this->assertInstanceOf('Carbon\Carbon', $user->birthday);
 		$this->assertInstanceOf('Carbon\Carbon', $user->visa['expiry_date']);
+
+		// Dot notation multiple dates check
+		$user = User::create(array(
+			'children' => array(
+				'bob' => array('birthday' => new DateTime('2008/4/3')),
+				'bill' => array('birthday' => new DateTime('2003/4/3'))
+			),
+		));
+		$this->assertInstanceOf('Carbon\Carbon', $user->children['bob']['birthday']);
+		$this->assertInstanceOf('Carbon\Carbon', $user->children['bill']['birthday']);
 	}
 
 	public function testIdAttribute()
@@ -398,7 +411,7 @@ class ModelTest extends TestCase {
 	public function testRaw()
 	{
 		User::create(array('name' => 'John Doe', 'age' => 35));
-		User::create(array('name' => 'Jane Doe', 'age' => 35));
+   User::create(array('name' => 'Jane Doe', 'age' => 35));
 		User::create(array('name' => 'Harry Hoe', 'age' => 15));
 
 		$users = User::raw(function($collection)

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -376,7 +376,7 @@ class ModelTest extends TestCase {
 		$this->assertInstanceOf('Carbon\Carbon', $user->birthday);
 		$this->assertInstanceOf('Carbon\Carbon', $user->visa['expiry_date']);
 
-		// Dot notation multiple dates check
+		// Multiple dates check
 		$user = User::create(array(
 			'children' => array(
 				'bob' => array('birthday' => new DateTime('2008/4/3')),
@@ -411,7 +411,7 @@ class ModelTest extends TestCase {
 	public function testRaw()
 	{
 		User::create(array('name' => 'John Doe', 'age' => 35));
-   User::create(array('name' => 'Jane Doe', 'age' => 35));
+		User::create(array('name' => 'Jane Doe', 'age' => 35));
 		User::create(array('name' => 'Harry Hoe', 'age' => 15));
 
 		$users = User::raw(function($collection)

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -319,35 +319,59 @@ class ModelTest extends TestCase {
 
 	public function testDates()
 	{
-		$birthday = new DateTime('1980/1/1');
-		$user = User::create(array('name' => 'John Doe', 'birthday' => $birthday));
+		$user = User::create(array(
+			'name' => 'John Doe',
+			'birthday' => new DateTime('1980/1/1'),
+			'visa' => array('expiry_date' => new DateTime('2018/4/3')))
+		);
 		$this->assertInstanceOf('Carbon\Carbon', $user->birthday);
+		$this->assertInstanceOf('Carbon\Carbon', $user->visa['expiry_date']);
 
 		$check = User::find($user->_id);
 		$this->assertInstanceOf('Carbon\Carbon', $check->birthday);
+		$this->assertInstanceOf('Carbon\Carbon', $check->visa['expiry_date']);
 		$this->assertEquals($user->birthday, $check->birthday);
+		$this->assertEquals($user->visa['expiry_date'], $check->visa['expiry_date']);
 
 		$user = User::where('birthday', '>', new DateTime('1975/1/1'))->first();
+		$this->assertEquals('John Doe', $user->name);
+		$user = User::where('visa.expiry_date', '>', new DateTime('2000/4/1'))->first();
 		$this->assertEquals('John Doe', $user->name);
 
 		// test custom date format for json output
 		$json = $user->toArray();
 		$this->assertEquals($user->birthday->format('l jS \of F Y h:i:s A'), $json['birthday']);
 		$this->assertEquals($user->created_at->format('l jS \of F Y h:i:s A'), $json['created_at']);
+		$this->assertEquals($user->visa['expiry_date']->format('l jS \of F Y h:i:s A'), $json['visa']['expiry_date']);
 
 		// test default date format for json output
 		$item = Item::create(array('name' => 'sword'));
 		$json = $item->toArray();
 		$this->assertEquals($item->created_at->format('Y-m-d H:i:s'), $json['created_at']);
 
-		$user = User::create(array('name' => 'Jane Doe', 'birthday' => time()));
+		$user = User::create(array(
+			'name' => 'Jane Doe',
+			'birthday' => time(),
+			'visa' => array('expiry_date' => time()))
+		);
 		$this->assertInstanceOf('Carbon\Carbon', $user->birthday);
+		$this->assertInstanceOf('Carbon\Carbon', $user->visa['expiry_date']);
 
-		$user = User::create(array('name' => 'Jane Doe', 'birthday' => 'Monday 8th of August 2005 03:12:46 PM'));
+		$user = User::create(array(
+			'name' => 'Jane Doe',
+			'birthday' => 'Monday 8th of August 2005 03:12:46 PM',
+			'visa' => array('expiry_date' => 'Monday 3th of August 2015 03:11:46 AM'))
+		);
 		$this->assertInstanceOf('Carbon\Carbon', $user->birthday);
+		$this->assertInstanceOf('Carbon\Carbon', $user->visa['expiry_date']);
 
-		$user = User::create(array('name' => 'Jane Doe', 'birthday' => '2005-08-08'));
+		$user = User::create(array(
+			'name' => 'Jane Doe',
+			'birthday' => '2005-08-08',
+			'visa' => array('expiry_date' => '2018-03-03'))
+		);
 		$this->assertInstanceOf('Carbon\Carbon', $user->birthday);
+		$this->assertInstanceOf('Carbon\Carbon', $user->visa['expiry_date']);
 	}
 
 	public function testIdAttribute()

--- a/tests/models/User.php
+++ b/tests/models/User.php
@@ -7,7 +7,7 @@ use Illuminate\Auth\Reminders\RemindableInterface;
 
 class User extends Eloquent implements UserInterface, RemindableInterface {
 
-    protected $dates = array('birthday', 'visa.expiry_date');
+    protected $dates = array('birthday', 'visa.expiry_date', 'children');
 	protected static $unguarded = true;
 
 	public function books()

--- a/tests/models/User.php
+++ b/tests/models/User.php
@@ -7,7 +7,7 @@ use Illuminate\Auth\Reminders\RemindableInterface;
 
 class User extends Eloquent implements UserInterface, RemindableInterface {
 
-	protected $dates = array('birthday');
+    protected $dates = array('birthday', 'visa.expiry_date');
 	protected static $unguarded = true;
 
 	public function books()

--- a/tests/models/User.php
+++ b/tests/models/User.php
@@ -8,9 +8,9 @@ use Illuminate\Auth\Reminders\RemindableInterface;
 class User extends Eloquent implements UserInterface, RemindableInterface {
 
     protected $dates = array('birthday', 'visa.expiry_date', 'children');
-	protected static $unguarded = true;
+    protected static $unguarded = true;
 
-	public function books()
+    public function books()
     {
         return $this->hasMany('Book', 'author_id');
     }
@@ -35,10 +35,10 @@ class User extends Eloquent implements UserInterface, RemindableInterface {
         return $this->hasOne('MysqlRole');
     }
 
-	public function clients()
-	{
-		return $this->belongsToMany('Client');
-	}
+    public function clients()
+    {
+        return $this->belongsToMany('Client');
+    }
 
     public function groups()
     {


### PR DESCRIPTION
Allows you to work with Carbon/DateTime objects instead of MongoDate objects within arrays.

If you specify a full array in $dates, any dates within will be converted into carbon objects. You can also use dot notation to specify dates within arrays.

Works with toArray() and any date that passes through asDateTime().

Resolves #109
