### PR TITLE
Adding a check for exposable json attributes.

### DIFF
--- a/src/Jenssegers/Mongodb/Model.php
+++ b/src/Jenssegers/Mongodb/Model.php
@@ -34,7 +34,7 @@ abstract class Model extends \Jenssegers\Eloquent\Model {
      *
      * @var array
      */
-    protected $exposeJsonAttributes = [];
+    protected $expose = [];
 
     /**
      * The connection resolver instance.
@@ -292,7 +292,7 @@ abstract class Model extends \Jenssegers\Eloquent\Model {
             // internal array of embedded documents. In that case, we need
             // to hide these from the output so that the relation-based
             // attribute can take over.
-            else if (starts_with($key, '_') and ! in_array($key, $this->exposeJsonAttributes))
+            else if (starts_with($key, '_') and ! in_array($key, $this->expose))
             {
                 $camelKey = camel_case($key);
 


### PR DESCRIPTION
In ticket #229 you removed the ability to output the relations as Array or JSON, which is fine, however you left no way to keep them in. This pull allows the user to specify an `$exposeJsonAttributes` array on the class to include the relations in a toArray or toJson call.
