### PR TITLE
Only extend database when it is actually resolved.

### DIFF
--- a/src/Jenssegers/Mongodb/MongodbServiceProvider.php
+++ b/src/Jenssegers/Mongodb/MongodbServiceProvider.php
@@ -25,9 +25,11 @@ class MongodbServiceProvider extends ServiceProvider {
     public function register()
     {
         // Add a mongodb extension to the original database manager
-        $this->app['db']->extend('mongodb', function($config)
-        {
-            return new Connection($config);
+        $this->app->resolving('db', function($db) {
+            $db->extend('mongodb', function($config)
+            {
+                return new Connection($config);
+            });
         });
     }
 


### PR DESCRIPTION
This had the potential to cause complications in combination with other packages.

Resolving objects from the container should always be done in `boot()` or in some type of callback (such as the `resolving()` method), so that other packages have the chance to either use `Container::extend()` or `Container::resolving()` on these objects.
