### PR TITLE
Update README.md to avoid installation problems

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Add the service provider in `app/config/app.php`:
 
     'Jenssegers\Mongodb\MongodbServiceProvider',
 
+> **Warning**: be sure to add it after `Illuminate\Database\DatabaseServiceProvider` otherwise you will get `Class db does not exist` error.
+
 The service provider will register a mongodb database extension with the original database manager. There is no need to register additional facades or objects. When using mongodb connections, Laravel will automatically provide you with the corresponding mongodb objects.
 
 Configuration


### PR DESCRIPTION
I think it's a good idea to inform that the service provider has to be added after `Illuminate\Database\DatabaseServiceProvider`

otherwise the following exception is thrown: `Class db does not exist`
