### PR TITLE
remove hidden attributes on embedded models

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,10 +11,10 @@
     "license" : "MIT",
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "5.0.*",
-        "illuminate/container": "5.0.*",
-        "illuminate/database": "5.0.*",
-        "illuminate/events": "5.0.*"
+        "illuminate/support": "4.2.*",
+        "illuminate/container": "4.2.*",
+        "illuminate/database": "4.2.*",
+        "illuminate/events": "4.2.*"
     },
     "require-dev": {
         "orchestra/testbench": "2.2.*",

--- a/composer.json
+++ b/composer.json
@@ -11,10 +11,10 @@
     "license" : "MIT",
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "4.2.*",
-        "illuminate/container": "4.2.*",
-        "illuminate/database": "4.2.*",
-        "illuminate/events": "4.2.*"
+        "illuminate/support": "5.0.*",
+        "illuminate/container": "5.0.*",
+        "illuminate/database": "5.0.*",
+        "illuminate/events": "5.0.*"
     },
     "require-dev": {
         "orchestra/testbench": "2.2.*",

--- a/src/Jenssegers/Mongodb/Model.php
+++ b/src/Jenssegers/Mongodb/Model.php
@@ -333,6 +333,56 @@ abstract class Model extends \Jenssegers\Eloquent\Model {
             {
                 $value = (string) $value;
             }
+
+            $camelKey = camel_case($key);
+
+            // If the "attribute" exists as a method on the model, it may be an
+            // embedded model. If so, we need to return the result before it
+            // is handled by the parent method.
+            if (method_exists($this, $camelKey))
+            {
+                $relations = $this->$camelKey();
+
+                // This attribute matches an embedsOne or embedsMany relation so we need
+                // to return the relation results instead of the internal attributes.
+                if ($relations instanceof EmbedsMany)
+                {
+                    // Check to see if any values matches hidden attribtues on
+                    // parent model
+                    $value = array_map(function($embedded) use($camelKey) {
+
+                        return $this->removeEmbeddedHiddenAttrs($camelKey, $embedded);
+
+                    }, $value);
+                }
+                elseif($relations instanceof EmbedsOne)
+                {
+                    $value = $this->removeEmbeddedHiddenAttrs($camelKey, $value);
+                }
+            }
+        }
+
+        return $attributes;
+    }
+
+    /**
+     * Remove hidden attributes from embedded model
+     *
+     * @param $camelKey
+     * @param $embedded
+     * @return array
+     */
+    protected function removeEmbeddedHiddenAttrs($camelKey, $embedded)
+    {
+        $attributes = array();
+
+        foreach($embedded as $key => $value)
+        {
+            $hidden = $camelKey . '.' . $key;
+
+            if(in_array($hidden, $this->hidden)) continue;
+
+            $attributes[$key] = $value;
         }
 
         return $attributes;

--- a/tests/EmbeddedRelationsTest.php
+++ b/tests/EmbeddedRelationsTest.php
@@ -749,4 +749,25 @@ class EmbeddedRelationsTest extends TestCase {
         $this->assertEquals(3, $results->getTotal());
     }
 
+    public function testHiddenAttributesEmbedsMany()
+    {
+        $user = User::create(array('name' => 'John Doe'));
+        $user->addresses()->save(new Address(array('city' => 'New York', 'ownership' => 'own')));
+
+        $user = User::find($user->_id);
+
+        $this->assertFalse(array_key_exists('ownership', $user->toArray()['addresses'][0]));
+        $this->assertFalse(array_key_exists('ownership', $user->addresses()->first()->toArray()));
+    }
+
+    public function testHiddenAttributeEmbedsOne()
+    {
+        $user = User::create(array('name' => 'John Doe', 'ssn' => '123456789'));
+        $user->father()->save(new User(array('name' => 'Mark Doe', 'ssn' => '123456789')));
+
+        $user = User::find($user->_id);
+
+        $this->assertFalse(array_key_exists('ssn', $user->toArray()['father']));
+    }
+
 }

--- a/tests/models/Address.php
+++ b/tests/models/Address.php
@@ -5,6 +5,7 @@ use Jenssegers\Mongodb\Model as Eloquent;
 class Address extends Eloquent {
 
     protected static $unguarded = true;
+    protected $hidden = array('ownership');
 
     public function addresses()
     {

--- a/tests/models/User.php
+++ b/tests/models/User.php
@@ -13,6 +13,7 @@ class User extends Eloquent implements UserInterface, RemindableInterface {
 
 	protected $dates = array('birthday', 'entry.date');
 	protected static $unguarded = true;
+    protected $hidden = array('ssn', 'father.ssn', 'addresses.ownership');
 
 	public function books()
     {


### PR DESCRIPTION
When a model is saved with an embedded relation, the embedded model will display its hidden attributes when converting to JSON or an Array.

This allows for dot notation on hidden attributes of the parent model.
