### PR TITLE
Fix for #321 Problem after Laravel upgrade 4.2.8 to 4.2.9

### DIFF
--- a/src/Jenssegers/Mongodb/Model.php
+++ b/src/Jenssegers/Mongodb/Model.php
@@ -68,6 +68,17 @@ abstract class Model extends \Jenssegers\Eloquent\Model {
 
         return $value;
     }
+    
+    /**
+     * Get the table qualified key name.
+     *
+     * @return string
+     */
+    public function getQualifiedKeyName()
+    {
+    	return $this->getKeyName();
+    }
+    
 
     /**
      * Define an embedded one-to-many relationship.


### PR DESCRIPTION
There is a change in Illuminate/Database/Eloquent/Builder::find and findMany between those versions that changes $this->query->where($this->model->getKeyName(), '=', $id); into $this->query->where($this->model->getQualifiedKeyName(), '=', $id);`.

`getQualifiedKeyName` prepends the key name with collection name and a dot, which I'm assuming MongoDB has a problem with. 

This changes the behavior so that MongoDB models return pure key name as qualified name.
