### PR TITLE
Changed compileWhereIn function

### DIFF
--- a/src/Jenssegers/Mongodb/Query/Builder.php
+++ b/src/Jenssegers/Mongodb/Query/Builder.php
@@ -894,7 +894,7 @@ class Builder extends QueryBuilder {
     {
         extract($where);
 
-        return array($column => array('$nin' => $values));
+        return array($column => array('$nin' => array_values($values)));
     }
 
     protected function compileWhereNull($where)


### PR DESCRIPTION
MongoDB 2.6.0, no longer accepting bson object in the $in clause. To fix this, the values need to be numerically indexed starting from zero and have consecutive values.

Adding array_values fixed this issue.

This fix was not tested on a previous MongoDB version.
