### PR TITLE
Added override for creating custom eloquent/model collection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ composer.lock
 *.sublime-project
 *.sublime-workspace
 *.project
+/.idea

--- a/src/Jenssegers/Mongodb/Model.php
+++ b/src/Jenssegers/Mongodb/Model.php
@@ -68,7 +68,7 @@ abstract class Model extends \Jenssegers\Eloquent\Model {
 
         return $value;
     }
-    
+
     /**
      * Get the table qualified key name.
      *
@@ -78,7 +78,7 @@ abstract class Model extends \Jenssegers\Eloquent\Model {
     {
     	return $this->getKeyName();
     }
-    
+
 
     /**
      * Define an embedded one-to-many relationship.
@@ -499,6 +499,17 @@ abstract class Model extends \Jenssegers\Eloquent\Model {
     public function newEloquentBuilder($query)
     {
         return new Builder($query);
+    }
+
+    /**
+     * Create a new Eloquent Collection instance.
+     *
+     * @param array $models
+     * @return \Jenssegers\Mongodb\Collection
+     */
+    public function newCollection(array $models = array())
+    {
+        return new Collection($models);
     }
 
     /**

--- a/src/Jenssegers/Mongodb/Relations/EmbedsOneOrMany.php
+++ b/src/Jenssegers/Mongodb/Relations/EmbedsOneOrMany.php
@@ -294,7 +294,7 @@ abstract class EmbedsOneOrMany extends Relation {
             $models = $this->eagerLoadRelations($models);
         }
 
-        return new Collection($models);
+        return $this->related->newCollection($models);
     }
 
     /**

--- a/tests/EmbeddedRelationsTest.php
+++ b/tests/EmbeddedRelationsTest.php
@@ -749,4 +749,17 @@ class EmbeddedRelationsTest extends TestCase {
         $this->assertEquals(3, $results->getTotal());
     }
 
+    public function testEmbedsOneOrManyCustomNewCollection()
+    {
+
+        $user = User::create(array('name' => 'John Doe'));
+        $user->addresses()->save(new Address(array('city' => 'Paris', 'country' => 'France', 'visited' => 4, 'created_at' => new DateTime('3 days ago'))));
+        $user->addresses()->save(new Address(array('city' => 'Bruges', 'country' => 'Belgium', 'visited' => 7, 'created_at' => new DateTime('5 days ago'))));
+        $user->addresses()->save(new Address(array('city' => 'Brussels', 'country' => 'Belgium', 'visited' => 2, 'created_at' => new DateTime('4 days ago'))));
+        $user->addresses()->save(new Address(array('city' => 'Ghent', 'country' => 'Belgium', 'visited' => 13, 'created_at' => new DateTime('2 days ago'))));
+
+        $user = User::where('name', 'John Doe')->first();
+        $this->assertTrue($user->addresses->notEmpty());
+    }
+
 }

--- a/tests/models/Address.php
+++ b/tests/models/Address.php
@@ -11,4 +11,10 @@ class Address extends Eloquent {
         return $this->embedsMany('Address');
     }
 
+    public function newCollection(array $models = array())
+    {
+
+        return new AddressCollection($models);
+    }
+
 }

--- a/tests/models/AddressCollection.php
+++ b/tests/models/AddressCollection.php
@@ -1,0 +1,11 @@
+<?php
+
+class AddressCollection extends \Jenssegers\Mongodb\Eloquent\Collection
+{
+
+    public function notEmpty()
+    {
+
+        return ! $this->isEmpty();
+    }
+}


### PR DESCRIPTION
Eloquent allows us to override the default Collection class for a given model by implementing a `newCollection` method in the model.

This merge request makes a minor change to allow that same functionality but default to an instance of `Jenssegers\Mongodb\Collection`.
