### PR TITLE
Remove unused imports from Model

### DIFF
--- a/src/Jenssegers/Mongodb/Model.php
+++ b/src/Jenssegers/Mongodb/Model.php
@@ -1,9 +1,7 @@
 <?php namespace Jenssegers\Mongodb;
 
-use Illuminate\Database\Eloquent\Collection;
 use Jenssegers\Mongodb\DatabaseManager as Resolver;
 use Jenssegers\Mongodb\Eloquent\Builder;
-use Jenssegers\Mongodb\Query\Builder as QueryBuilder;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Jenssegers\Mongodb\Relations\EmbedsOneOrMany;
 use Jenssegers\Mongodb\Relations\EmbedsMany;


### PR DESCRIPTION
It also fixes problem with:
> Cannot use Illuminate\Database\Eloquent\Collection as Collection because the name is already in use