### PR TITLE
Added support for passing driver options to MongoClient (SSL support)

### DIFF
--- a/src/Jenssegers/Mongodb/Connection.php
+++ b/src/Jenssegers/Mongodb/Connection.php
@@ -142,7 +142,15 @@ class Connection extends \Illuminate\Database\Connection {
             $options['password'] = $config['password'];
         }
 
-        return new MongoClient($dsn, $options);
+        // By default driver options is an empty array.
+        $driverOptions = array();
+
+        if (isset($config['driver_options']) && is_array($config['driver_options']))
+        {
+            $driverOptions = $config['driver_options'];
+        }
+
+        return new MongoClient($dsn, $options, $driverOptions);
     }
 
     /**


### PR DESCRIPTION
With MongoDB v3.0 now supporting SSL out of the box, it would be really useful to be able to configure the MongoClient's driver options, where certificate details are set.

An example Laravel configuration file would then look like:
```
'mongodb' => array(
    'driver'   => 'mongodb',
    'host'     => 'mongodb.local',
    'port'     => 27017,
    'username' => 'username',
    'password' => 'password',
    'database' => 'database',
    'options'  => array(
        "ssl" => true,
    ),
    'driver_options' => array(
        'context' => stream_context_create(array(
            "ssl" => array(
                "local_cert"        => 'client.pem',
                "cafile"            => 'ca.crt',
                "allow_self_signed" => false,
                "verify_peer"       => true,
                "verify_peer_name"  => true,
                "verify_expiry"     => true,
            ),
        ))
    )
),
```