### PR TITLE
If an attribute is a date; and used as a dot-notation key

### DIFF
--- a/src/Jenssegers/Mongodb/Model.php
+++ b/src/Jenssegers/Mongodb/Model.php
@@ -333,6 +333,15 @@ abstract class Model extends \Jenssegers\Eloquent\Model {
             }
         }
 
+        // If an attribute is a date; and used as a dot-notation date - fix it after parent
+        foreach ($this->getDates() as $key) {
+            // iterate over dates if dot-notation ONLY, and exists
+            if (!str_contains($key, '.') || !array_has($attributes, $key)) continue;
+
+            $value = (string)$this->asDateTime(array_get($attributes, $key));
+            array_set($attributes, $key, $value);
+        }
+
         return $attributes;
     }
 

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -402,6 +402,10 @@ class ModelTest extends TestCase {
 
 		$user->setAttribute('entry.date', new DateTime);
 		$this->assertInstanceOf('Carbon\Carbon', $user->getAttribute('entry.date'));
+
+        // test custom dot-date format for json output
+        $json = $user->toArray();
+        $this->assertEquals((string) $user->entry['date']->format('Y-m-d H:i:s'), $json['entry']['date']);
 	}
 
 	public function testIdAttribute()


### PR DESCRIPTION
fix it after parent attributeToArray.

as i've noticed fromDateTime behavior on setAttribute. i still don't get it, why it's not in the getAttributesToArray