### PR TITLE
Added metadata sorting

### DIFF
--- a/src/Jenssegers/Mongodb/Query/Builder.php
+++ b/src/Jenssegers/Mongodb/Query/Builder.php
@@ -329,12 +329,14 @@ class Builder extends QueryBuilder {
      * Add an "order by" clause to the query.
      *
      * @param  string  $column
-     * @param  string  $direction
+     * @param  mixed   $direction Direction of soring or metadata sorting.
      * @return Builder
      */
     public function orderBy($column, $direction = 'asc')
     {
-        $direction = (strtolower($direction) == 'asc' ? 1 : -1);
+        if (!is_array($direction)) {
+            $direction = (strtolower($direction) == 'asc' ? 1 : -1);
+        }
 
         if ($column == 'natural')
         {


### PR DESCRIPTION
Here is my fix for https://github.com/jenssegers/laravel-mongodb/issues/358

Example:
```php
orderBy('score', ['$meta' => "textScore"])
```
http://docs.mongodb.org/manual/reference/method/cursor.sort/#metadata-sort