### PR TITLE
Eager loading with belongsTo array

### DIFF
--- a/src/Jenssegers/Mongodb/Relations/BelongsTo.php
+++ b/src/Jenssegers/Mongodb/Relations/BelongsTo.php
@@ -1,5 +1,7 @@
 <?php namespace Jenssegers\Mongodb\Relations;
 
+use Illuminate\Database\Eloquent\Collection;
+
 class BelongsTo extends \Illuminate\Database\Eloquent\Relations\BelongsTo {
 
     /**

--- a/src/Jenssegers/Mongodb/Relations/BelongsTo.php
+++ b/src/Jenssegers/Mongodb/Relations/BelongsTo.php
@@ -34,4 +34,45 @@ class BelongsTo extends \Illuminate\Database\Eloquent\Relations\BelongsTo {
         $this->query->whereIn($key, $this->getEagerModelKeys($models));
     }
 
+    public function match ( array $models, Collection $results, $relation )
+    {
+        $foreign = $this->foreignKey;
+
+        $other = $this->otherKey;
+
+        // First we will get to build a dictionary of the child models by their primary
+        // key of the relationship, then we can easily match the children back onto
+        // the parents using that dictionary and the primary key of the children.
+        $dictionary = [];
+
+        foreach ( $results as $result )
+        {
+            $res = $result->getAttribute($other);
+            if ( is_array($res) )
+            {
+                foreach ( $res as $r )
+                {
+                    $dictionary[$r] = $result;
+                }
+            }
+            else
+            {
+                $dictionary[$res] = $result;
+            }
+        }
+
+        // Once we have the dictionary constructed, we can loop through all the parents
+        // and match back onto their children using these keys of the dictionary and
+        // the primary key of the children to map them onto the correct instances.
+        foreach ( $models as $model )
+        {
+            if ( isset( $dictionary[$model->$foreign] ) )
+            {
+                $model->setRelation($relation, $dictionary[$model->$foreign]);
+            }
+        }
+
+        return $models;
+    }
+
 }

--- a/src/Jenssegers/Mongodb/Relations/BelongsTo.php
+++ b/src/Jenssegers/Mongodb/Relations/BelongsTo.php
@@ -36,7 +36,7 @@ class BelongsTo extends \Illuminate\Database\Eloquent\Relations\BelongsTo {
         $this->query->whereIn($key, $this->getEagerModelKeys($models));
     }
 
-    public function match ( array $models, Collection $results, $relation )
+    public function match(array $models, Collection $results, $relation)
     {
         $foreign = $this->foreignKey;
 


### PR DESCRIPTION
First lets assume a few things

**Document in the languages collection**
```json
{
    "name": "English",
    "codes": [
        "en",
        "en-US",
        "en-GB"
    ]
}
```

**Model for that languages collection**
```php
<?php namespace App;

class Language extends Model {

}
```

**Document in the pages collection**
```json
{
    "name": "Test page",
    "language_id": "en"
}
```

**Model for that pages collection**
```php
<?php namespace App;

class Page extends Model {

    function language() {
        return $this->belongsTo('App\Language', 'language_id', 'codes');
    }

}
```

Then running `Page::with('language')->get()` would eager load it and create a query like `languages.find({"codes":{"$in":["en"]}})`. This is where the issue (**Illegal offset type**) comes in, since it extends the Eloquent class, it uses the `otherKey` value as the key in the array; this, however, is not possible because you cannot use an array as an array key.

So far I have managed to solve the BelongsTo relation by putting each value of the array in the dictionary. I have not looked at the others (yet) as I don't have a scenario in which I can test it.