### PR TITLE
fix the mutator method getIdAttribute() when there is another field w…

### DIFF
--- a/src/Jenssegers/Mongodb/Eloquent/Model.php
+++ b/src/Jenssegers/Mongodb/Eloquent/Model.php
@@ -39,7 +39,7 @@ abstract class Model extends BaseModel {
     {
         // If we don't have a value for 'id', we will use the Mongo '_id' value.
         // This allows us to work with models in a more sql-like way.
-        if ( ! $value and array_key_exists('_id', $this->attributes))
+        if ( isset($value) and array_key_exists('_id', $this->attributes))
         {
             $value = $this->attributes['_id'];
         }


### PR DESCRIPTION
Hi,

First i have a collection and have a field name id, then, when i use "getAttribute('id')" to get the value of id and the id equal to zero, i will get the value of _id. So if we should use "!isset($value)" instead of "! $value" in the mumator method getIdAttribute.

Thanks for your time.