### PR TITLE
Where query not woking (Reference problem)

### DIFF
--- a/src/Jenssegers/Mongodb/Query/Builder.php
+++ b/src/Jenssegers/Mongodb/Query/Builder.php
@@ -804,7 +804,7 @@ class Builder extends BaseBuilder {
         // Remove the leading $ from operators.
         if (func_num_args() == 3)
         {
-            $operator = &$params[1];
+            $operator = $params[1]; //&$params[1];
 
             if (starts_with($operator, '$'))
             {


### PR DESCRIPTION
`$this->geoIP = IP2Nation::where('ip', '<', $iptlong)->first();`

`public function where($column, $operator = null, $value = null, $boolean = 'and')
    {
...
            $operator = &$params[1];
...
        var_dump($params);
        exit;`

`array(3) { [0]=> string(2) "ip" [1]=> &string(1) "<" [2]=> string(10) "3280885934" }`
