### PR TITLE
Update QueryBuilder get method to run getFresh method

### DIFF
--- a/src/Jenssegers/Mongodb/Query/Builder.php
+++ b/src/Jenssegers/Mongodb/Query/Builder.php
@@ -147,7 +147,7 @@ class Builder extends BaseBuilder {
      */
     public function get($columns = [])
     {
-        return parent::get($columns);
+        return $this->getFresh($columns);
     }
 
     /**


### PR DESCRIPTION
Following the latest update of the laravel framework (5.1.20), the BaseQuery builder that used to just run the getFresh method (overriden by the mongodb child builder) in the get function, now calls the runSelect method that relies on the mysql Grammar object being present that this builder does not need to run.
This results in the error `` Call to a member function compileSelect() on null `` when trying to run a query.

This update simply removes the parent get() call and directly calls it's own getFresh method, thus return the functionality to what it was before the laravel update.

The particular change in laravel that causes this issue can be seen here:
https://github.com/laravel/framework/compare/v5.1.19...v5.1.20#diff-cc3d43e01028390141596ae0da939930L1373

Fixes #618