### PR TITLE
Fix #607 exists() bug and assure compatibility with Laravel 5.1.19

### DIFF
--- a/src/Jenssegers/Mongodb/Query/Builder.php
+++ b/src/Jenssegers/Mongodb/Query/Builder.php
@@ -350,6 +350,16 @@ class Builder extends BaseBuilder {
     }
 
     /**
+     * Determine if any rows exist for the current query.
+     *
+     * @return bool
+     */
+    public function exists()
+    {
+        return ! is_null($this->first());
+    }
+
+    /**
      * Force the query to only return distinct results.
      *
      * @return Builder

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -206,6 +206,12 @@ class QueryTest extends TestCase {
         $this->assertEquals(6, $count);
     }
 
+    public function testExists()
+    {
+        $this->assertFalse(User::where('age', '>', 37)->exists());
+        $this->assertTrue(User::where('age', '<', 37)->exists());
+    }
+
     public function testSubquery()
     {
         $users = User::where('title', 'admin')->orWhere(function ($query)


### PR DESCRIPTION
Laravel 5.1.19 version breaks the `exists()` method (see #607) because of a complete rewriting of the Laravel base method.

I think that the method should be rewrite in this package. This implementation is close to the best in term of performance but a small improvement can be done by using `db.collection.find().limit(1)->count(1)` but I don't know how to use the count method like that (if there is no argument, `count()` don't care about `limit()`).

If this pull request is accepted, a new release would be appreciated :)
