### PR TITLE
Add job queue support for mongodb.

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,17 +105,7 @@ You can connect to multiple servers or replica sets with the following configura
 ),
 ```
 
-For job queue support add a mongodb connection in config/queue.php:
-```
-        'mongodb' => [
-            'driver' => 'mongodb',
-            'table' => 'jobs',
-            'queue' => 'default',
-            'expire' => 60,
-        ],
-```
-
-You also need to set your QUEUE_DRIVER to 'mongodb' in your environment or .env
+You also need to set your QUEUE_DRIVER to 'database' in your environment or .env
 
 Eloquent
 --------
@@ -934,4 +924,3 @@ DB::connection()->disableQueryLog();
 ```
 
 *From: http://laravel.com/docs/database#query-logging*
-

--- a/src/Jenssegers/Mongodb/MongodbQueueServiceProvider.php
+++ b/src/Jenssegers/Mongodb/MongodbQueueServiceProvider.php
@@ -1,0 +1,29 @@
+<?php namespace Jenssegers\Mongodb;
+
+use Illuminate\Support\ServiceProvider;
+use Jenssegers\Mongodb\Queue\MongodbConnector;
+
+class MongodbQueueServiceProvider extends ServiceProvider {
+
+    /**
+     * Bootstrap the application events.
+     */
+    public function boot()
+    {
+
+    }
+
+    /**
+     * Register the service provider.
+     */
+    public function register()
+    {
+        $this->app->resolving('queue', function($queue)
+        {
+          $queue->extend('mongodb', function() {
+            return new MongodbConnector($this->app['db']);
+          });
+        });
+    }
+
+}

--- a/src/Jenssegers/Mongodb/MongodbQueueServiceProvider.php
+++ b/src/Jenssegers/Mongodb/MongodbQueueServiceProvider.php
@@ -18,9 +18,9 @@ class MongodbQueueServiceProvider extends ServiceProvider {
      */
     public function register()
     {
-        $this->app->resolving('queue', function($queue)
+        $this->app->resolving('queue', function ($queue)
         {
-          $queue->extend('mongodb', function() {
+          $queue->extend('mongodb', function () {
             return new MongodbConnector($this->app['db']);
           });
         });

--- a/src/Jenssegers/Mongodb/MongodbQueueServiceProvider.php
+++ b/src/Jenssegers/Mongodb/MongodbQueueServiceProvider.php
@@ -20,7 +20,7 @@ class MongodbQueueServiceProvider extends ServiceProvider {
     {
         $this->app->resolving('queue', function ($queue)
         {
-          $queue->extend('mongodb', function () {
+          $queue->extend('database', function () {
             return new MongodbConnector($this->app['db']);
           });
         });

--- a/src/Jenssegers/Mongodb/MongodbServiceProvider.php
+++ b/src/Jenssegers/Mongodb/MongodbServiceProvider.php
@@ -1,7 +1,6 @@
 <?php namespace Jenssegers\Mongodb;
 
 use Illuminate\Support\ServiceProvider;
-use Jenssegers\Mongodb\Queue\MongodbConnector;
 
 class MongodbServiceProvider extends ServiceProvider {
 
@@ -26,13 +25,6 @@ class MongodbServiceProvider extends ServiceProvider {
             {
                 return new Connection($config);
             });
-        });
-
-        $this->app->resolving('queue', function($queue)
-        {
-          $queue->addConnector('mongodb', function() {
-            return new MongodbConnector($this->app['db']);
-          });
         });
 
     }

--- a/src/Jenssegers/Mongodb/MongodbServiceProvider.php
+++ b/src/Jenssegers/Mongodb/MongodbServiceProvider.php
@@ -1,6 +1,7 @@
 <?php namespace Jenssegers\Mongodb;
 
 use Illuminate\Support\ServiceProvider;
+use Jenssegers\Mongodb\Queue\MongodbConnector;
 
 class MongodbServiceProvider extends ServiceProvider {
 
@@ -26,6 +27,14 @@ class MongodbServiceProvider extends ServiceProvider {
                 return new Connection($config);
             });
         });
+
+        $this->app->resolving('queue', function($queue)
+        {
+          $queue->addConnector('mongodb', function() {
+            return new MongodbConnector($this->app['db']);
+          });
+        });
+
     }
 
 }

--- a/src/Jenssegers/Mongodb/Queue/MongodbConnector.php
+++ b/src/Jenssegers/Mongodb/Queue/MongodbConnector.php
@@ -3,7 +3,6 @@
 namespace Jenssegers\Mongodb\Queue;
 
 use Illuminate\Support\Arr;
-use Jenssegers\Mongodb\Queue\MongodbQueue;
 use Illuminate\Database\ConnectionResolverInterface;
 use Illuminate\Queue\Connectors\ConnectorInterface;
 

--- a/src/Jenssegers/Mongodb/Queue/MongodbConnector.php
+++ b/src/Jenssegers/Mongodb/Queue/MongodbConnector.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Jenssegers\Mongodb\Queue;
+
+use Illuminate\Support\Arr;
+use Jenssegers\Mongodb\Queue\MongodbQueue;
+use Illuminate\Database\ConnectionResolverInterface;
+use Illuminate\Queue\Connectors\ConnectorInterface;
+
+class MongodbConnector implements ConnectorInterface
+{
+    /**
+     * Database connections.
+     *
+     * @var \Illuminate\Database\ConnectionResolverInterface
+     */
+    protected $connections;
+
+    /**
+     * Create a new connector instance.
+     *
+     * @param  \Illuminate\Database\ConnectionResolverInterface  $connections
+     * @return void
+     */
+    public function __construct(ConnectionResolverInterface $connections)
+    {
+        $this->connections = $connections;
+    }
+
+    /**
+     * Establish a queue connection.
+     *
+     * @param  array  $config
+     * @return \Illuminate\Contracts\Queue\Queue
+     */
+    public function connect(array $config)
+    {
+        return new MongodbQueue(
+            $this->connections->connection(Arr::get($config, 'connection')),
+            $config['table'],
+            $config['queue'],
+            Arr::get($config, 'expire', 60)
+        );
+    }
+}

--- a/src/Jenssegers/Mongodb/Queue/MongodbJob.php
+++ b/src/Jenssegers/Mongodb/Queue/MongodbJob.php
@@ -4,6 +4,7 @@ namespace Jenssegers\Mongodb\Queue;
 
 use Jenssegers\Mongodb\Queue\MongodbQueue;
 use Illuminate\Container\Container;
+use Illuminate\Queue\Jobs\Job;
 use Illuminate\Contracts\Queue\Job as JobContract;
 
 class MongodbJob extends Job implements JobContract

--- a/src/Jenssegers/Mongodb/Queue/MongodbJob.php
+++ b/src/Jenssegers/Mongodb/Queue/MongodbJob.php
@@ -2,7 +2,6 @@
 
 namespace Jenssegers\Mongodb\Queue;
 
-use Jenssegers\Mongodb\Queue\MongodbQueue;
 use Illuminate\Container\Container;
 use Illuminate\Queue\Jobs\Job;
 use Illuminate\Contracts\Queue\Job as JobContract;

--- a/src/Jenssegers/Mongodb/Queue/MongodbJob.php
+++ b/src/Jenssegers/Mongodb/Queue/MongodbJob.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Jenssegers\Mongodb\Queue;
+
+use Jenssegers\Mongodb\Queue\MongodbQueue;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Queue\Job as JobContract;
+
+class MongodbJob extends Job implements JobContract
+{
+    /**
+     * The database queue instance.
+     *
+     * @var \Illuminate\Queue\DatabaseQueue
+     */
+    protected $database;
+
+    /**
+     * The database job payload.
+     *
+     * @var \StdClass
+     */
+    protected $job;
+
+    /**
+     * Create a new job instance.
+     *
+     * @param  \Illuminate\Container\Container  $container
+     * @param  \Illuminate\Queue\DatabaseQueue  $database
+     * @param  \StdClass  $job
+     * @param  string  $queue
+     * @return void
+     */
+    public function __construct(Container $container, MongodbQueue $database, $job, $queue)
+    {
+        $this->job = $job;
+        $this->queue = $queue;
+        $this->database = $database;
+        $this->container = $container;
+        $this->job->attempts = $this->job->attempts + 1;
+    }
+
+    /**
+     * Fire the job.
+     *
+     * @return void
+     */
+    public function fire()
+    {
+        $this->resolveAndFire(json_decode($this->job->payload, true));
+    }
+
+    /**
+     * Delete the job from the queue.
+     *
+     * @return void
+     */
+    public function delete()
+    {
+        parent::delete();
+
+        $this->database->deleteReserved($this->queue, $this->job->_id);
+    }
+
+    /**
+     * Release the job back into the queue.
+     *
+     * @param  int  $delay
+     * @return void
+     */
+    public function release($delay = 0)
+    {
+        parent::release($delay);
+
+        $this->delete();
+
+        $this->database->release($this->queue, $this->job, $delay);
+    }
+
+    /**
+     * Get the number of times the job has been attempted.
+     *
+     * @return int
+     */
+    public function attempts()
+    {
+        return (int) $this->job->attempts;
+    }
+
+    /**
+     * Get the job identifier.
+     *
+     * @return string
+     */
+    public function getJobId()
+    {
+        return $this->job->id;
+    }
+
+    /**
+     * Get the raw body string for the job.
+     *
+     * @return string
+     */
+    public function getRawBody()
+    {
+        return $this->job->payload;
+    }
+
+    /**
+     * Get the IoC container instance.
+     *
+     * @return \Illuminate\Container\Container
+     */
+    public function getContainer()
+    {
+        return $this->container;
+    }
+
+    /**
+     * Get the underlying queue driver instance.
+     *
+     * @return \Illuminate\Queue\DatabaseQueue
+     */
+    public function getDatabaseQueue()
+    {
+        return $this->database;
+    }
+
+    /**
+     * Get the underlying database job.
+     *
+     * @return \StdClass
+     */
+    public function getDatabaseJob()
+    {
+        return $this->job;
+    }
+}

--- a/src/Jenssegers/Mongodb/Queue/MongodbQueue.php
+++ b/src/Jenssegers/Mongodb/Queue/MongodbQueue.php
@@ -5,7 +5,6 @@ namespace Jenssegers\Mongodb\Queue;
 use DateTime;
 use Carbon\Carbon;
 use Illuminate\Database\Connection;
-use Jenssegers\Mongodb\Queue\MongodbJob;
 use Illuminate\Queue\Queue;
 use Illuminate\Contracts\Queue\Queue as QueueContract;
 

--- a/src/Jenssegers/Mongodb/Queue/MongodbQueue.php
+++ b/src/Jenssegers/Mongodb/Queue/MongodbQueue.php
@@ -1,0 +1,333 @@
+<?php
+
+namespace Jenssegers\Mongodb\Queue;
+
+use DateTime;
+use Carbon\Carbon;
+use Illuminate\Database\Connection;
+use Jenssegers\Mongodb\Queue\MongodbJob;
+use Illuminate\Queue\Queue;
+use Illuminate\Contracts\Queue\Queue as QueueContract;
+
+class MongodbQueue extends Queue implements QueueContract
+{
+    /**
+     * The database connection instance.
+     *
+     * @var \Illuminate\Database\Connection
+     */
+    protected $database;
+
+    /**
+     * The database table that holds the jobs.
+     *
+     * @var string
+     */
+    protected $table;
+
+    /**
+     * The name of the default queue.
+     *
+     * @var string
+     */
+    protected $default;
+
+    /**
+     * The expiration time of a job.
+     *
+     * @var int|null
+     */
+    protected $expire = 60;
+
+    /**
+     * Create a new database queue instance.
+     *
+     * @param  \Illuminate\Database\Connection  $database
+     * @param  string  $table
+     * @param  string  $default
+     * @param  int  $expire
+     * @return void
+     */
+    public function __construct(Connection $database, $table, $default = 'default', $expire = 60)
+    {
+        $this->table = $table;
+        $this->expire = $expire;
+        $this->default = $default;
+        $this->database = $database;
+    }
+
+    /**
+     * Push a new job onto the queue.
+     *
+     * @param  string  $job
+     * @param  mixed   $data
+     * @param  string  $queue
+     * @return void
+     */
+    public function push($job, $data = '', $queue = null)
+    {
+        return $this->pushToDatabase(0, $queue, $this->createPayload($job, $data));
+    }
+
+    /**
+     * Push a raw payload onto the queue.
+     *
+     * @param  string  $payload
+     * @param  string  $queue
+     * @param  array   $options
+     * @return mixed
+     */
+    public function pushRaw($payload, $queue = null, array $options = [])
+    {
+        return $this->pushToDatabase(0, $queue, $payload);
+    }
+
+    /**
+     * Push a new job onto the queue after a delay.
+     *
+     * @param  \DateTime|int  $delay
+     * @param  string  $job
+     * @param  mixed   $data
+     * @param  string  $queue
+     * @return void
+     */
+    public function later($delay, $job, $data = '', $queue = null)
+    {
+        return $this->pushToDatabase($delay, $queue, $this->createPayload($job, $data));
+    }
+
+    /**
+     * Push an array of jobs onto the queue.
+     *
+     * @param  array   $jobs
+     * @param  mixed   $data
+     * @param  string  $queue
+     * @return mixed
+     */
+    public function bulk($jobs, $data = '', $queue = null)
+    {
+        $queue = $this->getQueue($queue);
+
+        $availableAt = $this->getAvailableAt(0);
+
+        $records = array_map(function ($job) use ($queue, $data, $availableAt) {
+            return $this->buildDatabaseRecord(
+                $queue, $this->createPayload($job, $data), $availableAt
+            );
+        }, (array) $jobs);
+
+        return $this->database->table($this->table)->insert($records);
+    }
+
+    /**
+     * Release a reserved job back onto the queue.
+     *
+     * @param  string  $queue
+     * @param  \StdClass  $job
+     * @param  int  $delay
+     * @return void
+     */
+    public function release($queue, $job, $delay)
+    {
+        return $this->pushToDatabase($delay, $queue, $job->payload, $job->attempts);
+    }
+
+    /**
+     * Push a raw payload to the database with a given delay.
+     *
+     * @param  \DateTime|int  $delay
+     * @param  string|null  $queue
+     * @param  string  $payload
+     * @param  int  $attempts
+     * @return mixed
+     */
+    protected function pushToDatabase($delay, $queue, $payload, $attempts = 0)
+    {
+        $attributes = $this->buildDatabaseRecord(
+            $this->getQueue($queue), $payload, $this->getAvailableAt($delay), $attempts
+        );
+
+        return $this->database->table($this->table)->insertGetId($attributes);
+    }
+
+    /**
+     * Pop the next job off of the queue.
+     *
+     * @param  string  $queue
+     * @return \Illuminate\Contracts\Queue\Job|null
+     */
+    public function pop($queue = null)
+    {
+        $queue = $this->getQueue($queue);
+
+        if (! is_null($this->expire)) {
+            $this->releaseJobsThatHaveBeenReservedTooLong($queue);
+        }
+
+        if ($job = $this->getNextAvailableJob($queue)) {
+            $this->markJobAsReserved($job->_id);
+
+            return new MongodbJob(
+                $this->container, $this, $job, $queue
+            );
+        }
+
+        $this->database->commit();
+    }
+
+    /**
+     * Release the jobs that have been reserved for too long.
+     *
+     * @param  string  $queue
+     * @return void
+     */
+    protected function releaseJobsThatHaveBeenReservedTooLong($queue)
+    {
+        $expired = Carbon::now()->subSeconds($this->expire)->getTimestamp();
+        $reserved = $this->database->collection($this->table)
+                    ->where('queue', $this->getQueue($queue))
+                    ->where('reserved', 1)
+                    ->where('reserved_at', '<=', $expired)->get();
+
+        foreach ($reserved as $job) {
+            $attempts = $job['attempts'] + 1;
+            $this->releaseJob($job['_id'], $attempts);
+        }
+    }
+
+    /**
+     * Get the next available job for the queue.
+     *
+     * @param  string|null  $queue
+     * @return \StdClass|null
+     */
+    protected function getNextAvailableJob($queue)
+    {
+        $job = $this->database->table($this->table)
+                    ->lockForUpdate()
+                    ->where('queue', $this->getQueue($queue))
+                    ->where('reserved', 0)
+                    ->where('available_at', '<=', $this->getTime())
+                    ->orderBy('_id', 'asc')
+                    ->first();
+
+        return $job ? (object) $job : null;
+    }
+
+    /**
+     * Mark the given job ID as reserved.
+     *
+     * @param  string  $id
+     * @return void
+     */
+    protected function markJobAsReserved($id)
+    {
+        $this->database->table($this->table)->where('_id', $id)->update([
+            'reserved' => 1, 'reserved_at' => $this->getTime(),
+        ]);
+    }
+
+    /**
+     * Release the given job ID from reservation.
+     *
+     * @param  string  $id
+     * @return void
+     */
+    protected function releaseJob($id, $attempts)
+    {
+        $this->database->table($this->table)->where('_id', $id)->update([
+          'reserved' => 0,
+          'reserved_at' => null,
+          'attempts' => $attempts,
+        ]);
+    }
+
+    /**
+     * Delete a reserved job from the queue.
+     *
+     * @param  string  $queue
+     * @param  string  $id
+     * @return void
+     */
+    public function deleteReserved($queue, $id)
+    {
+        $this->database->table($this->table)->where('_id', $id)->delete();
+    }
+
+    /**
+     * Get the "available at" UNIX timestamp.
+     *
+     * @param  \DateTime|int  $delay
+     * @return int
+     */
+    protected function getAvailableAt($delay)
+    {
+        $availableAt = $delay instanceof DateTime ? $delay : Carbon::now()->addSeconds($delay);
+
+        return $availableAt->getTimestamp();
+    }
+
+    /**
+     * Create an array to insert for the given job.
+     *
+     * @param  string|null  $queue
+     * @param  string  $payload
+     * @param  int  $availableAt
+     * @param  int  $attempts
+     * @return array
+     */
+    protected function buildDatabaseRecord($queue, $payload, $availableAt, $attempts = 0)
+    {
+        return [
+            'queue' => $queue,
+            'payload' => $payload,
+            'attempts' => $attempts,
+            'reserved' => 0,
+            'reserved_at' => null,
+            'available_at' => $availableAt,
+            'created_at' => $this->getTime(),
+        ];
+    }
+
+    /**
+     * Get the queue or return the default.
+     *
+     * @param  string|null  $queue
+     * @return string
+     */
+    protected function getQueue($queue)
+    {
+        return $queue ?: $this->default;
+    }
+
+    /**
+     * Get the underlying database instance.
+     *
+     * @return \Illuminate\Database\Connection
+     */
+    public function getDatabase()
+    {
+        return $this->database;
+    }
+
+    /**
+     * Get the expiration time in seconds.
+     *
+     * @return int|null
+     */
+    public function getExpire()
+    {
+        return $this->expire;
+    }
+
+    /**
+     * Set the expiration time in seconds.
+     *
+     * @param  int|null  $seconds
+     * @return void
+     */
+    public function setExpire($seconds)
+    {
+        $this->expire = $seconds;
+    }
+}


### PR DESCRIPTION
This adds job queue support by making a few small changes to the Database job queue libraries.  It has a separate service provider making it's usage completely optional.  