### PR TITLE
allow to sort by $meta-projection

### DIFF
--- a/src/Jenssegers/Mongodb/Query/Builder.php
+++ b/src/Jenssegers/Mongodb/Query/Builder.php
@@ -385,7 +385,10 @@ class Builder extends BaseBuilder {
      */
     public function orderBy($column, $direction = 'asc')
     {
-        $direction = (strtolower($direction) == 'asc' ? 1 : -1);
+        if (is_string($direction))
+        {
+            $direction = (strtolower($direction) == 'asc' ? 1 : -1);
+        }
 
         if ($column == 'natural')
         {


### PR DESCRIPTION
Small fix to allow sorting by meta-projections. This is needed for full-text search and sort results by relevancy. For example:
```
$query = Models\News::whereRaw([
   '$text' => [ '$search' => $request->Input('q') ]
])->project([ 'score' => [ '$meta' => 'textScore' ] ]);

$query->orderBy('score', [ '$meta' => 'textScore' ]);
```
http://docs.mongodb.org/manual/reference/operator/query/text/