### PR TITLE
Allow setting model attributes of array type.

### DIFF
--- a/src/Jenssegers/Mongodb/Model.php
+++ b/src/Jenssegers/Mongodb/Model.php
@@ -318,6 +318,12 @@ abstract class Model extends BaseModel {
 
             return;
         }
+        
+        // Support nested arrays/objects
+        if (is_array($value))
+        {
+            $value = json_decode(json_encode($value), false);
+        }
 
         parent::setAttribute($key, $value);
     }


### PR DESCRIPTION
Consider the following code:
```
$model = new ModelName;
$model->foo = [ [ 'foo' => 'bar', 'baz' => [ 'foo' => 'bar' ] ] ];
$model->save();
```
Here we are setting a nested array as a model attribute. 
Before this commit, the code above would have saved the "foo" property as an empty array.