### PR TITLE
Fix query select and query projection

### DIFF
--- a/src/Jenssegers/Mongodb/Query/Builder.php
+++ b/src/Jenssegers/Mongodb/Query/Builder.php
@@ -285,18 +285,14 @@ class Builder extends BaseBuilder {
                 $columns[$column] = true;
             }
 
-            // Add custom projections.
-            if ($this->projections)
-            {
-                $columns = array_merge($columns, $this->projections);
-            }
             $options = [];
 
-            // Apply order, offset, limit and hint
+            // Apply order, offset, limit and projection
             if ($this->timeout) $options['maxTimeMS'] = $this->timeout;
             if ($this->orders)  $options['sort'] = $this->orders;
             if ($this->offset)  $options['skip'] = $this->offset;
             if ($this->limit)   $options['limit'] = $this->limit;
+            if ($this->projections)   $options['projection'] = $this->projections;
             // if ($this->hint)    $cursor->hint($this->hint);
 
             // Fix for legacy support, converts the results to arrays instead of objects.

--- a/src/Jenssegers/Mongodb/Query/Builder.php
+++ b/src/Jenssegers/Mongodb/Query/Builder.php
@@ -892,7 +892,7 @@ class Builder extends BaseBuilder {
             // Convert DateTime values to UTCDateTime.
             if (isset($where['value']) and $where['value'] instanceof DateTime)
             {
-                $where['value'] = new UTCDateTime($where['value']->getTimestamp());
+                $where['value'] = new UTCDateTime($where['value']->getTimestamp() * 1000);
             }
 
             // The next item in a "chain" of wheres devices the boolean of the

--- a/src/Jenssegers/Mongodb/Query/Builder.php
+++ b/src/Jenssegers/Mongodb/Query/Builder.php
@@ -285,6 +285,11 @@ class Builder extends BaseBuilder {
                 $columns[$column] = true;
             }
 
+            // Add custom projections.
+            if ($this->projections)
+            {
+                $columns = array_merge($columns, $this->projections);
+            }
             $options = [];
 
             // Apply order, offset, limit and projection
@@ -292,7 +297,7 @@ class Builder extends BaseBuilder {
             if ($this->orders)  $options['sort'] = $this->orders;
             if ($this->offset)  $options['skip'] = $this->offset;
             if ($this->limit)   $options['limit'] = $this->limit;
-            if ($this->projections)   $options['projection'] = $this->projections;
+            if ($columns)   $options['projection'] = $columns;
             // if ($this->hint)    $cursor->hint($this->hint);
 
             // Fix for legacy support, converts the results to arrays instead of objects.


### PR DESCRIPTION
The following projection does not work
```
DB::collection('items')->project(['tags' => ['$slice' => 1]])->get();
```
Because the new query driver is using option for projection.

And since selecting columns is now using projection too, this will also fix
```
$user = User::where('name', 'John Doe')->select('name')->first();
```

Added one more fix: Query using datetime instance
Because MongoDB\BSON\UTCDateTime expecting milliseconds and `$datetime->getTimestamp` returns value in seconds. So multiplying `$datetime->getTimestamp` value with 1000 will fix this