### PR TITLE
Use the driver's native count() method where possible 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "illuminate/events": "4.2.*"
     },
     "require-dev": {
+        "phpunit/phpunit": "^4.0|^5.0",
         "orchestra/testbench": "2.2.*",
         "mockery/mockery": "*",
         "satooshi/php-coveralls": "*"

--- a/src/Jenssegers/Mongodb/Query/Builder.php
+++ b/src/Jenssegers/Mongodb/Query/Builder.php
@@ -298,7 +298,7 @@ class Builder extends QueryBuilder {
         ( !array_key_exists('$and', $wheres) && !array_key_exists('$or', $wheres) )
         ||
         //Otherwise, check that there is only one $and
-        ( array_key_exists('$and', $wheres) && sizeof(array_keys($wheres)) === 1 ) 
+        ( array_key_exists('$and', $wheres) && sizeof(array_keys($wheres)) === 1 )
         ){
 
         $valid = true;
@@ -316,7 +316,7 @@ class Builder extends QueryBuilder {
             }
 
             // if the value is an array, then unpack and use each key/value as wheres
-            foreach( $value as $k=>$v){
+            foreach( $value as $k => $v){
               // if any of the values are arrays then do not use the standard count
               if( is_array($v) ){
                 $valid = false;


### PR DESCRIPTION
We were running into real problems relating to using the aggregation pipeline to perform complex counts. As a result, this should attempt to use the MongoCollection's `count()` (
http://php.net/manual/en/mongocollection.count.php) method where the query is deemed simple enough to warrant it.

I've also included phpunit as a dependency as it was not being included by composer? I notice it is also included on your master branch, so I used the same as that.
