### PR TITLE
Support queue.failer service to record failed jobs in mongo

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,31 @@ If you want to use Laravel's native Auth functionality, register this included s
 
 This service provider will slightly modify the internal DatabaseReminderRepository to add support for MongoDB based password reminders. If you don't use password reminders, you don't have to register this service provider and everything else should work just fine.
 
+
+### Queues
+
+If you want to use MongoDB as your database backend, change the the driver in `config/queue.php`:
+
+```php
+'connections' => [
+    'database' => [
+        'driver' => 'mongodb',
+        'table'  => 'jobs',
+        'queue'  => 'default',
+        'expire' => 60,
+    ],
+]
+```
+
+To log failed queue jobs to MongoDB, override `failed` in `config/queue.php` (appears at the end of `queue.php`):
+
+```php
+'failed' => [
+    'database' => 'mongodb', 
+    'collection' => 'failed_jobs',
+]
+```
+
 ### Sentry
 
 If you want to use this library with [Sentry](https://cartalyst.com/manual/sentry), then check out https://github.com/jenssegers/Laravel-MongoDB-Sentry

--- a/src/Jenssegers/Mongodb/MongodbServiceProvider.php
+++ b/src/Jenssegers/Mongodb/MongodbServiceProvider.php
@@ -33,5 +33,12 @@ class MongodbServiceProvider extends ServiceProvider
                 return new MongoConnector($this->app['db']);
             });
         });
+
+        // Support queue failer to record failed jobs
+        $this->app->bindShared('queue.failer', function($app)
+        {
+            $config = $app['config']['queue.failed'];
+            return new DatabaseFailedJobProvider($app['db'], $config['database'], $config['collection']);
+        });
     }
 }

--- a/src/Jenssegers/Mongodb/Queue/Failed/DatabaseFailedJobProvider.php
+++ b/src/Jenssegers/Mongodb/Queue/Failed/DatabaseFailedJobProvider.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Jenssegers\Mongodb\Queue\Failed;
+
+use Carbon\Carbon;
+use Illuminate\Database\ConnectionResolverInterface;
+use Illuminate\Queue\Failed\FailedJobProviderInterface;
+
+class DatabaseFailedJobProvider implements FailedJobProviderInterface {
+
+    /**
+     * The connection resolver implementation.
+     *
+     * @var \Illuminate\Database\ConnectionResolverInterface
+     */
+    protected $resolver;
+
+    /**
+     * The database connection name.
+     *
+     * @var string
+     */
+    protected $database;
+
+    /**
+     * The database table.
+     *
+     * @var string
+     */
+    protected $collection;
+
+    /**
+     * Create a new database failed job provider.
+     *
+     * @param  \Illuminate\Database\ConnectionResolverInterface  $resolver
+     * @param  string  $database
+     * @param  string  $collection
+     * @return void
+     */
+    public function __construct(ConnectionResolverInterface $resolver, $database, $collection) {
+        $this->collection = $collection;
+        $this->resolver = $resolver;
+        $this->database = $database;
+    }
+
+    /**
+     * Log a failed job into storage.
+     *
+     * @param  string  $connection
+     * @param  string  $queue
+     * @param  string  $payload
+     * @return void
+     */
+    public function log($connection, $queue, $payload) {
+        $failed_at = Carbon::now();
+        $this->getCollection()->insert(compact('connection', 'queue', 'payload', 'failed_at'));
+    }
+
+    /**
+     * Get a list of all of the failed jobs.
+     *
+     * @return array
+     */
+    public function all() {
+        $fails = $this->getCollection()->get();
+        $jobs = [];
+        foreach ($fails as $fail) {
+            $fail = ['id' => (string) $fail['_id']] + $fail;
+            unset($fail['_id']);
+            $failed = new Carbon($fail['failed_at']['date'], $fail['failed_at']['timezone']);
+            $fail['failed_at'] = (string) $failed;
+            $jobs[] = $fail;
+        }
+        return $jobs;
+    }
+
+    /**
+     * Get a single failed job.
+     *
+     * @param  mixed  $id
+     * @return array
+     */
+    public function find($id) {
+        $fail = $this->getCollection()->find($id);
+        if ($fail) {
+            $fail = ['id' => (string) $fail['_id']] + $fail;
+            unset($fail['_id']);
+            return (object) $fail;
+        }
+        return NULL;
+    }
+
+    /**
+     * Delete a single failed job from storage.
+     *
+     * @param  mixed  $id
+     * @return bool
+     */
+    public function forget($id) {
+        return $this->getCollection()->delete($id) > 0;
+    }
+
+    /**
+     * Flush all of the failed jobs from storage.
+     *
+     * @return void
+     */
+    public function flush() {
+        $this->getCollection()->truncate();
+    }
+
+    /**
+     * Get a new query builder instance for the table.
+     *
+     * @return \Jenssegers\Mongodb\Query\Builder
+     */
+    protected function getCollection() {
+        return $this->resolver->connection($this->database)->collection($this->collection);
+    }
+}


### PR DESCRIPTION
* Provide missing document for MongoDB queue backend
* Provide option for logging failed queue jobs in MongoDB (override `queue.failer` in laravel: https://github.com/laravel/framework/blob/4.2/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php)