### PR TITLE
EmbedsOne relationship returns null when no model is associated

### DIFF
--- a/src/Jenssegers/Mongodb/Relations/EmbedsOneOrMany.php
+++ b/src/Jenssegers/Mongodb/Relations/EmbedsOneOrMany.php
@@ -233,7 +233,7 @@ abstract class EmbedsOneOrMany extends Relation
         // Get raw attributes to skip relations and accessors.
         $attributes = $this->parent->getAttributes();
 
-        $embedded = isset($attributes[$this->localKey]) ? (array) $attributes[$this->localKey] : [];
+        $embedded = isset($attributes[$this->localKey]) ? (array) $attributes[$this->localKey] : null;
 
         return $embedded;
     }

--- a/tests/EmbeddedRelationsTest.php
+++ b/tests/EmbeddedRelationsTest.php
@@ -505,6 +505,12 @@ class EmbeddedRelationsTest extends TestCase
         $this->assertEquals('Mark Doe', $user->father->name);
     }
 
+    public function testEmbedsOneNullAssociation()
+    {
+        $user = User::create();
+        $this->assertNull($user->father);
+    }
+
     public function testEmbedsOneDelete()
     {
         $user = User::create(['name' => 'John Doe']);


### PR DESCRIPTION
See issue #736 which has been closed yet was not resolved.