### PR TITLE
Pass credentials as parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,10 +117,10 @@ And add a new mongodb connection:
     'host'     => env('DB_HOST', 'localhost'),
     'port'     => env('DB_PORT', 27017),
     'database' => env('DB_DATABASE', ''),
+    'username' => env('DB_USERNAME', ''),
+    'password' => env('DB_PASSWORD', ''),
     'options' => [
-        'db' => 'admin', // sets the authentication database required by mongo 3
-        'username' => env('DB_USERNAME', ''),
-        'password' => env('DB_PASSWORD', ''),
+        'db' => 'admin' // sets the authentication database required by mongo 3
     ]
 ],
 ```
@@ -133,12 +133,9 @@ You can connect to multiple servers or replica sets with the following configura
     'host'     => ['server1', 'server2'],
     'port'     => env('DB_PORT', 27017),
     'database' => env('DB_DATABASE', ''),
-    'options'  => [
-        'replicaSet' => 'replicaSetName',
-        'db' => 'admin', // sets the authentication database required by mongo 3
-        'username' => env('DB_USERNAME', ''),
-        'password' => env('DB_PASSWORD', ''),
-    ]
+    'username' => env('DB_USERNAME', ''),
+    'password' => env('DB_PASSWORD', ''),
+    'options'  => ['replicaSet' => 'replicaSetName']
 ],
 ```
 

--- a/README.md
+++ b/README.md
@@ -117,10 +117,10 @@ And add a new mongodb connection:
     'host'     => env('DB_HOST', 'localhost'),
     'port'     => env('DB_PORT', 27017),
     'database' => env('DB_DATABASE', ''),
-    'username' => env('DB_USERNAME', ''),
-    'password' => env('DB_PASSWORD', ''),
     'options' => [
-        'db' => 'admin' // sets the authentication database required by mongo 3
+        'db' => 'admin', // sets the authentication database required by mongo 3
+        'username' => env('DB_USERNAME', ''),
+        'password' => env('DB_PASSWORD', ''),
     ]
 ],
 ```

--- a/README.md
+++ b/README.md
@@ -133,9 +133,12 @@ You can connect to multiple servers or replica sets with the following configura
     'host'     => ['server1', 'server2'],
     'port'     => env('DB_PORT', 27017),
     'database' => env('DB_DATABASE', ''),
-    'username' => env('DB_USERNAME', ''),
-    'password' => env('DB_PASSWORD', ''),
-    'options'  => ['replicaSet' => 'replicaSetName']
+    'options'  => [
+        'replicaSet' => 'replicaSetName',
+        'db' => 'admin', // sets the authentication database required by mongo 3
+        'username' => env('DB_USERNAME', ''),
+        'password' => env('DB_PASSWORD', ''),
+    ]
 ],
 ```
 

--- a/src/Jenssegers/Mongodb/Connection.php
+++ b/src/Jenssegers/Mongodb/Connection.php
@@ -137,11 +137,11 @@ class Connection extends \Illuminate\Database\Connection
         }
 
         // Check if the credentials are not already set in the options
-        if (!isset($options['username'])) {
-            $options['username'] = isset($config['username']) ? $config['username'] : '';
+        if (!isset($options['username']) && isset($config['username'])) {
+            $options['username'] = $config['username'];
         }
-        if (!isset($options['password'])) {
-            $options['password'] = isset($config['password']) ? $config['password'] : '';
+        if (!isset($options['password']) && isset($config['password'])) {
+            $options['password'] = $config['password'];
         }
 
         return new Client($dsn, $options, $driverOptions);

--- a/src/Jenssegers/Mongodb/Connection.php
+++ b/src/Jenssegers/Mongodb/Connection.php
@@ -136,6 +136,13 @@ class Connection extends \Illuminate\Database\Connection
             $driverOptions = $config['driver_options'];
         }
 
+        if (!isset($options['username'])){
+            $options['username'] = isset($config['username']) ? $config['username'] : '';
+        }
+        if (!isset($options['password'])){
+            $options['password'] = isset($config['password']) ? $config['password'] : '';
+        }
+
         return new Client($dsn, $options, $driverOptions);
     }
 

--- a/src/Jenssegers/Mongodb/Connection.php
+++ b/src/Jenssegers/Mongodb/Connection.php
@@ -136,10 +136,11 @@ class Connection extends \Illuminate\Database\Connection
             $driverOptions = $config['driver_options'];
         }
 
-        if (!isset($options['username'])){
+        // Check if the credentials are not already set in the options
+        if (!isset($options['username'])) {
             $options['username'] = isset($config['username']) ? $config['username'] : '';
         }
-        if (!isset($options['password'])){
+        if (!isset($options['password'])) {
             $options['password'] = isset($config['password']) ? $config['password'] : '';
         }
 

--- a/src/Jenssegers/Mongodb/Connection.php
+++ b/src/Jenssegers/Mongodb/Connection.php
@@ -135,10 +135,6 @@ class Connection extends \Illuminate\Database\Connection
         if (isset($config['driver_options']) && is_array($config['driver_options'])) {
             $driverOptions = $config['driver_options'];
         }
-        
-        // Get the credentials from the config and check if they are set
-        $options['username'] = isset($options['username']) ? $config['username'] : '';
-        $options['password'] = isset($options['password']) ? $config['password'] : '';
 
         return new Client($dsn, $options, $driverOptions);
     }

--- a/src/Jenssegers/Mongodb/Connection.php
+++ b/src/Jenssegers/Mongodb/Connection.php
@@ -135,9 +135,10 @@ class Connection extends \Illuminate\Database\Connection
         if (isset($config['driver_options']) && is_array($config['driver_options'])) {
             $driverOptions = $config['driver_options'];
         }
-
-        $options['username'] = $config['username'];
-        $options['password'] = $config['password'];
+        
+        // Get the credentials from the config and check if they are set
+        $options['username'] = isset($options['username']) ? $config['username'] : '';
+        $options['password'] = isset($options['password']) ? $config['password'] : '';
 
         return new Client($dsn, $options, $driverOptions);
     }

--- a/src/Jenssegers/Mongodb/Connection.php
+++ b/src/Jenssegers/Mongodb/Connection.php
@@ -136,6 +136,9 @@ class Connection extends \Illuminate\Database\Connection
             $driverOptions = $config['driver_options'];
         }
 
+        $options['username'] = $config['username'];
+        $options['password'] = $config['password'];
+
         return new Client($dsn, $options, $driverOptions);
     }
 
@@ -175,20 +178,7 @@ class Connection extends \Illuminate\Database\Connection
             }
         }
 
-        // The database name needs to be in the connection string, otherwise it will
-        // authenticate to the admin database, which may result in permission errors.
-        $auth = '';
-        if (! empty($username)) {
-            $auth .= $username;
-        }
-        if (! empty($password)) {
-            $auth .= ':' . urlencode($password);
-        }
-        if ($auth) {
-            $auth .= '@';
-        }
-
-        return "mongodb://" . $auth . implode(',', $hosts) . "/{$database}";
+        return "mongodb://" . implode(',', $hosts) . "/{$database}";
     }
 
     /**

--- a/src/Jenssegers/Mongodb/Schema/Blueprint.php
+++ b/src/Jenssegers/Mongodb/Schema/Blueprint.php
@@ -209,7 +209,7 @@ class Blueprint extends \Illuminate\Database\Schema\Blueprint
      * @param  array   $parameters
      * @return Blueprint
      */
-    protected function addColumn($type, $name, array $parameters = [])
+    public function addColumn($type, $name, array $parameters = [])
     {
         $this->fluent($name);
 


### PR DESCRIPTION
These changes will pass the credentials as parameters at the creation of a new MongoDB connection instead of passing them on the DSN.

reference: https://github.com/jenssegers/laravel-mongodb/pull/748

**Username and password now need to be in the options section of the DB config**