### PR TITLE
Change Connection to ConnectionContract

### DIFF
--- a/src/Jenssegers/Mongodb/Collection.php
+++ b/src/Jenssegers/Mongodb/Collection.php
@@ -2,6 +2,7 @@
 
 use Exception;
 use MongoDB\Collection as MongoCollection;
+use Jenssegers\Mongodb\Contracts\ConnectionContract;
 
 class Collection
 {
@@ -22,7 +23,7 @@ class Collection
     /**
      * Constructor.
      */
-    public function __construct(Connection $connection, MongoCollection $collection)
+    public function __construct(ConnectionContract $connection, MongoCollection $collection)
     {
         $this->connection = $connection;
         $this->collection = $collection;

--- a/src/Jenssegers/Mongodb/Connection.php
+++ b/src/Jenssegers/Mongodb/Connection.php
@@ -1,8 +1,9 @@
 <?php namespace Jenssegers\Mongodb;
 
+use Jenssegers\Mongodb\Contracts\ConnectionContract;
 use MongoDB\Client;
 
-class Connection extends \Illuminate\Database\Connection
+class Connection extends \Illuminate\Database\Connection implements ConnectionContract
 {
     /**
      * The MongoDB database handler.

--- a/src/Jenssegers/Mongodb/Contracts/ConnectionContract.php
+++ b/src/Jenssegers/Mongodb/Contracts/ConnectionContract.php
@@ -1,0 +1,74 @@
+<?php
+namespace Jenssegers\Mongodb\Contracts;
+
+use Jenssegers\Mongodb\Collection;
+use Jenssegers\Mongodb\Query;
+use Jenssegers\Mongodb\Schema;
+
+interface ConnectionContract
+{
+    /**
+     * Begin a fluent query against a database collection.
+     *
+     * @param  string $collection
+     * @return Query\Builder
+     */
+    public function collection($collection);
+
+    /**
+     * Begin a fluent query against a database collection.
+     *
+     * @param  string $table
+     * @return Query\Builder
+     */
+    public function table($table);
+
+    /**
+     * Get a MongoDB collection.
+     *
+     * @param  string $name
+     * @return Collection
+     */
+    public function getCollection($name);
+
+    /**
+     * Get a schema builder instance for the connection.
+     *
+     * @return Schema\Builder
+     */
+    public function getSchemaBuilder();
+
+    /**
+     * Get the MongoDB database object.
+     *
+     * @return \MongoDB\Database
+     */
+    public function getMongoDB();
+
+    /**
+     * return MongoDB object.
+     *
+     * @return \MongoDB\Client
+     */
+    public function getMongoClient();
+
+    /**
+     * Disconnect from the underlying MongoDB connection.
+     */
+    public function disconnect();
+
+    /**
+     * Get the elapsed time since a given starting point.
+     *
+     * @param  int $start
+     * @return float
+     */
+    public function getElapsedTime($start);
+
+    /**
+     * Get the PDO driver name.
+     *
+     * @return string
+     */
+    public function getDriverName();
+}

--- a/src/Jenssegers/Mongodb/Query/Builder.php
+++ b/src/Jenssegers/Mongodb/Query/Builder.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Query\Builder as BaseBuilder;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
-use Jenssegers\Mongodb\Connection;
+use Jenssegers\Mongodb\Contracts\ConnectionContract;
 use MongoDB\BSON\ObjectID;
 use MongoDB\BSON\Regex;
 use MongoDB\BSON\UTCDateTime;
@@ -81,9 +81,9 @@ class Builder extends BaseBuilder
     /**
      * Create a new query builder instance.
      *
-     * @param Connection $connection
+     * @param ConnectionContract $connection
      */
-    public function __construct(Connection $connection, Processor $processor)
+    public function __construct(ConnectionContract $connection, Processor $processor)
     {
         $this->grammar = new Grammar;
         $this->connection = $connection;


### PR DESCRIPTION
* Add an interface (`ConnectionContract`) so that an alternative class can be put in place of `Jenssegers\Mongodb\Connection`.

See https://github.com/timgws/QueryBuilderParser/commit/430e7c85739f072f459599891ae785b477961460#diff-ed82b7952fe1424f6b488f71c42cd7d4R1 for a use-case.