### PR TITLE
#752: Override DatabaseQueue's deleteReserved function to use Mongo _id.

### DIFF
--- a/src/Jenssegers/Mongodb/Queue/MongoQueue.php
+++ b/src/Jenssegers/Mongodb/Queue/MongoQueue.php
@@ -49,4 +49,16 @@ class MongoQueue extends DatabaseQueue
             $this->releaseJob($job['_id'], $attempts);
         }
     }
+
+    /**
+     * Delete a reserved job from the queue.
+     *
+     * @param  string  $queue
+     * @param  string  $id
+     * @return void
+     */
+    public function deleteReserved($queue, $id)
+    {
+        $this->database->table($this->table)->where('_id', $id)->delete();
+    }
 }


### PR DESCRIPTION
The default deleteReserved query checks the jobs table for records by id instead of _id. We can address this issue by overriding this method in MongoQueue.php.

This addresses the issue mentioned in #752.