### PR TITLE
Allow Query builder pluck to work with _id

### DIFF
--- a/src/Jenssegers/Mongodb/Query/Builder.php
+++ b/src/Jenssegers/Mongodb/Query/Builder.php
@@ -566,6 +566,19 @@ class Builder extends BaseBuilder
      */
     public function pluck($column, $key = null)
     {
+        if ($key == '_id') {
+            $results = new Collection($this->get([$column, $key]));
+
+            // Convert ObjectID's to strings so that lists can do its work.
+            $results = $results->map(function ($item) {
+                $item['_id'] = (string) $item['_id'];
+
+                return $item;
+            });
+
+            return $results->pluck($column, $key)->all();
+        }
+
         $results = $this->get(is_null($key) ? [$column] : [$column, $key]);
 
         // If the columns are qualified with a table or have an alias, we cannot use

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -360,6 +360,10 @@ class QueryBuilderTest extends TestCase
 
         $age = DB::collection('users')->where('name', 'John Doe')->pluck('age');
         $this->assertEquals([25], $age);
+
+        $list = DB::collection('users')->pluck('age', '_id');
+        $this->assertEquals(2, count($list));
+        $this->assertEquals(24, strlen(key($list)));
     }
 
     public function testList()


### PR DESCRIPTION
- As of 5.2 lists is deprecated so I moved the ObjectID to string code to pluck as well
  I kept pluck the same for backwards compatibility

If only Laravel 5.2 support is enough the lists method can be removed from the `Builder` class because the parent only calls pluck.
