### PR TITLE
Fixes #743 for version 3.x

### DIFF
--- a/src/Jenssegers/Mongodb/Queue/MongoQueue.php
+++ b/src/Jenssegers/Mongodb/Queue/MongoQueue.php
@@ -19,13 +19,11 @@ class MongoQueue extends DatabaseQueue
     {
         $queue = $this->getQueue($queue);
 
-        if (!is_null($this->expire))
-        {
+        if (!is_null($this->expire)) {
             $this->releaseJobsThatHaveBeenReservedTooLong($queue);
         }
 
-        if ($job = $this->getNextAvailableJobAndReserve($queue))
-        {
+        if ($job = $this->getNextAvailableJobAndReserve($queue)) {
             return new DatabaseJob(
                 $this->container, $this, $job, $queue
             );
@@ -68,8 +66,7 @@ class MongoQueue extends DatabaseQueue
             ]
         );
 
-        if ($job)
-        {
+        if ($job) {
             $job->id = $job->_id;
         }
 

--- a/src/Jenssegers/Mongodb/Queue/MongoQueue.php
+++ b/src/Jenssegers/Mongodb/Queue/MongoQueue.php
@@ -111,19 +111,6 @@ class MongoQueue extends DatabaseQueue
     }
 
     /**
-     * Mark the given job ID as reserved.
-     *
-     * @param  string  $id
-     * @return void
-     */
-    protected function markJobAsReserved($id)
-    {
-        $this->database->collection($this->table)->where('_id', $id)->update([
-            'reserved' => 1, 'reserved_at' => $this->getTime(),
-        ]);
-    }
-
-    /**
      * Delete a reserved job from the queue.
      *
      * @param  string  $queue

--- a/src/Jenssegers/Mongodb/Queue/MongoQueue.php
+++ b/src/Jenssegers/Mongodb/Queue/MongoQueue.php
@@ -61,8 +61,8 @@ class MongoQueue extends DatabaseQueue
                 ],
             ],
             [
-                'returnNewDocument ' => true,
-                'sort'               => ['available_at' => 1],
+                'returnDocument' => FindOneAndUpdate::RETURN_DOCUMENT_AFTER,
+                'sort'           => ['available_at' => 1],
             ]
         );
 

--- a/tests/QueueTest.php
+++ b/tests/QueueTest.php
@@ -2,12 +2,46 @@
 
 class QueueTest extends TestCase
 {
-    public function testQueue()
+    public function setUp()
     {
-        $id = Queue::push('test', ['foo' => 'bar'], 'test');
+        parent::setUp();
+
+        // Always start with a clean slate
+        Queue::getDatabase()->table(Config::get('queue.connections.database.table'))->truncate();
+        Queue::getDatabase()->table(Config::get('queue.failed.table'))->truncate();
+    }
+
+    public function testQueueJobLifeCycle()
+    {
+        $id = Queue::push('test', ['action' => 'QueueJobLifeCycle'], 'test');
         $this->assertNotNull($id);
 
+        // Get and reserve the test job (next available)
         $job = Queue::pop('test');
         $this->assertInstanceOf('Illuminate\Queue\Jobs\DatabaseJob', $job);
+        $this->assertEquals(1, $job->getDatabaseJob()->reserved);
+        $this->assertEquals(json_encode(['job' => 'test', 'data' => ['action' => 'QueueJobLifeCycle']]), $job->getRawBody());
+
+        // Remove reserved job
+        $job->delete();
+        $this->assertEquals(0, Queue::getDatabase()->table(Config::get('queue.connections.database.table'))->count());
+    }
+
+    public function testQueueJobExpired()
+    {
+        $id = Queue::push('test', ['action' => 'QueueJobExpired'], 'test');
+        $this->assertNotNull($id);
+
+        // Expire the test job
+        $expiry = \Carbon\Carbon::now()->subSeconds(Config::get('queue.connections.database.expire'))->getTimestamp();
+        Queue::getDatabase()->table(Config::get('queue.connections.database.table'))->where('_id', $id)->update(['reserved' => 1, 'reserved_at' => $expiry]);
+
+        // Expect an attempted older job in the queue
+        $job = Queue::pop('test');
+        $this->assertEquals(2, $job->getDatabaseJob()->attempts);
+        $this->assertGreaterThan($expiry, $job->getDatabaseJob()->reserved_at);
+
+        $job->delete();
+        $this->assertEquals(0, Queue::getDatabase()->table(Config::get('queue.connections.database.table'))->count());
     }
 }

--- a/tests/config/queue.php
+++ b/tests/config/queue.php
@@ -1,0 +1,23 @@
+<?php
+
+return [
+
+    'default' => 'database',
+
+    'connections' => [
+
+        'database' => [
+            'driver' => 'mongodb',
+            'table'  => 'jobs',
+            'queue'  => 'default',
+            'expire' => 60,
+        ],
+
+    ],
+
+    'failed' => [
+        'database' => 'mongodb',
+        'table'    => 'failed_jobs',
+    ],
+
+];


### PR DESCRIPTION
Resolves issue where possible daemons could process the same record by using the  findOneAndUpdate to lock a job record while flagging it as reserved at the same time.