### PR TITLE
importing DateTime and DateTimeZone from the global namespace

### DIFF
--- a/src/Jenssegers/Mongodb/Auth/DatabaseTokenRepository.php
+++ b/src/Jenssegers/Mongodb/Auth/DatabaseTokenRepository.php
@@ -2,6 +2,8 @@
 
 use Illuminate\Auth\Passwords\DatabaseTokenRepository as BaseDatabaseTokenRepository;
 use MongoDB\BSON\UTCDateTime;
+use \DateTime;
+use \DateTimeZone;
 
 class DatabaseTokenRepository extends BaseDatabaseTokenRepository
 {
@@ -28,7 +30,7 @@ class DatabaseTokenRepository extends BaseDatabaseTokenRepository
         // Convert UTCDateTime to a date string.
         if ($token['created_at'] instanceof UTCDateTime) {
             $date = $token['created_at']->toDateTime();
-            $date->setTimezone(new \DateTimeZone(date_default_timezone_get()));
+            $date->setTimezone(new DateTimeZone(date_default_timezone_get()));
             $token['created_at'] = $date->format('Y-m-d H:i:s');
         } elseif (is_array($token['created_at']) and isset($token['created_at']['date'])) {
             $date = new DateTime($token['created_at']['date'], new DateTimeZone(isset($token['created_at']['timezone']) ? $token['created_at']['timezone'] : 'UTC'));

--- a/src/Jenssegers/Mongodb/Auth/DatabaseTokenRepository.php
+++ b/src/Jenssegers/Mongodb/Auth/DatabaseTokenRepository.php
@@ -2,8 +2,8 @@
 
 use Illuminate\Auth\Passwords\DatabaseTokenRepository as BaseDatabaseTokenRepository;
 use MongoDB\BSON\UTCDateTime;
-use \DateTime;
-use \DateTimeZone;
+use DateTime;
+use DateTimeZone;
 
 class DatabaseTokenRepository extends BaseDatabaseTokenRepository
 {


### PR DESCRIPTION
Looks like someone fixed one of the \DateTimeZone calls but missed the other global namespace classes. Placed use statements to include them, class no longer throws runtime exception. 