### PR TITLE
Fix #556 Adding sparce & unique indices

### DIFF
--- a/src/Jenssegers/Mongodb/Schema/Blueprint.php
+++ b/src/Jenssegers/Mongodb/Schema/Blueprint.php
@@ -225,14 +225,14 @@ class Blueprint extends \Illuminate\Database\Schema\Blueprint
      */
     public function sparse_and_unique($columns = null, $options = [])
     {
-      $columns = $this->fluent($columns);
+        $columns = $this->fluent($columns);
 
-      $options['sparse'] = true;
-      $options['unique'] = true;
+        $options['sparse'] = true;
+        $options['unique'] = true;
 
-      $this->index($columns, $options);
+        $this->index($columns, $options);
 
-      return $this;
+        return $this;
     }
 
     /**

--- a/src/Jenssegers/Mongodb/Schema/Blueprint.php
+++ b/src/Jenssegers/Mongodb/Schema/Blueprint.php
@@ -217,6 +217,25 @@ class Blueprint extends \Illuminate\Database\Schema\Blueprint
     }
 
     /**
+     * Specify a sparse and unique index for the collection.
+     *
+     * @param  string|array  $columns
+     * @param  array         $options
+     * @return Blueprint
+     */
+    public function sparse_and_unique($columns = null, $options = [])
+    {
+      $columns = $this->fluent($columns);
+
+      $options['sparse'] = true;
+      $options['unique'] = true;
+
+      $this->index($columns, $options);
+
+      return $this;
+    }
+
+    /**
      * Allow fluent columns.
      *
      * @param  string|array  $columns

--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -176,6 +176,17 @@ class SchemaTest extends TestCase
         });
     }
 
+    public function testSparseUnique()
+    {
+      Schema::collection('newcollection', function ($collection) {
+          $collection->sparse_and_unique('sparseuniquekey');
+      });
+
+      $index = $this->getIndex('newcollection', 'sparseuniquekey');
+      $this->assertEquals(1, $index['sparse']);
+      $this->assertEquals(1, $index['unique']);
+    }
+
     protected function getIndex($collection, $name)
     {
         $collection = DB::getCollection($collection);

--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -178,13 +178,13 @@ class SchemaTest extends TestCase
 
     public function testSparseUnique()
     {
-      Schema::collection('newcollection', function ($collection) {
+        Schema::collection('newcollection', function ($collection) {
           $collection->sparse_and_unique('sparseuniquekey');
-      });
+        });
 
-      $index = $this->getIndex('newcollection', 'sparseuniquekey');
-      $this->assertEquals(1, $index['sparse']);
-      $this->assertEquals(1, $index['unique']);
+        $index = $this->getIndex('newcollection', 'sparseuniquekey');
+        $this->assertEquals(1, $index['sparse']);
+        $this->assertEquals(1, $index['unique']);
     }
 
     protected function getIndex($collection, $name)


### PR DESCRIPTION
Provides a handy shortcut for allowing both sparse and unique indices on columns. MongoDB provides a method of only checking unique values where the field is not null (or 'sparse'). At present, using the `unique` and `sparse` functions separately throws an `MongoDuplicateKeyException` (see issue #556). 

You can get around this by using the `index` function, but my understanding is this should be avoided (please correct me if I'm wrong).