### PR TITLE
Overwrite transaction functions to avoid errors

### DIFF
--- a/src/Jenssegers/Mongodb/Connection.php
+++ b/src/Jenssegers/Mongodb/Connection.php
@@ -208,6 +208,43 @@ class Connection extends \Illuminate\Database\Connection
     }
 
     /**
+     * Start a new database transaction.
+     *
+     * @return void
+     * @throws Exception
+     */
+    public function beginTransaction()
+    {
+        ++$this->transactions;
+
+        $this->fireConnectionEvent('beganTransaction');
+    }
+
+    /**
+     * Commit the active database transaction.
+     *
+     * @return void
+     */
+    public function commit()
+    {
+        --$this->transactions;
+
+        $this->fireConnectionEvent('committed');
+    }
+
+    /**
+     * Rollback the active database transaction.
+     *
+     * @return void
+     */
+    public function rollBack()
+    {
+        $this->transactions = max(0, $this->transactions - 1);
+
+        $this->fireConnectionEvent('rollingBack');
+    }
+
+    /**
      * Dynamically pass methods to the connection.
      *
      * @param  string  $method

--- a/src/Jenssegers/Mongodb/Eloquent/Model.php
+++ b/src/Jenssegers/Mongodb/Eloquent/Model.php
@@ -14,7 +14,6 @@ use ReflectionMethod;
 
 abstract class Model extends BaseModel
 {
-
     use HybridRelations;
 
     /**

--- a/src/Jenssegers/Mongodb/Eloquent/SoftDeletes.php
+++ b/src/Jenssegers/Mongodb/Eloquent/SoftDeletes.php
@@ -2,7 +2,6 @@
 
 trait SoftDeletes
 {
-
     use \Illuminate\Database\Eloquent\SoftDeletes;
 
     /**

--- a/tests/AuthTest.php
+++ b/tests/AuthTest.php
@@ -5,7 +5,6 @@ use Illuminate\Foundation\Application;
 
 class AuthTest extends TestCase
 {
-
     public function tearDown()
     {
         User::truncate();

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -2,7 +2,6 @@
 
 class ConnectionTest extends TestCase
 {
-
     public function testConnection()
     {
         $connection = DB::connection('mongodb');

--- a/tests/EmbeddedRelationsTest.php
+++ b/tests/EmbeddedRelationsTest.php
@@ -2,7 +2,6 @@
 
 class EmbeddedRelationsTest extends TestCase
 {
-
     public function tearDown()
     {
         Mockery::close();

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -2,7 +2,6 @@
 
 class ModelTest extends TestCase
 {
-
     public function tearDown()
     {
         User::truncate();

--- a/tests/MysqlRelationsTest.php
+++ b/tests/MysqlRelationsTest.php
@@ -2,7 +2,6 @@
 
 class MysqlRelationsTest extends TestCase
 {
-
     public function setUp()
     {
         parent::setUp();

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -5,7 +5,6 @@ use MongoDB\BSON\Regex;
 
 class QueryBuilderTest extends TestCase
 {
-
     public function tearDown()
     {
         DB::collection('users')->truncate();

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -2,7 +2,6 @@
 
 class QueryTest extends TestCase
 {
-
     protected static $started = false;
 
     public function setUp()
@@ -216,10 +215,10 @@ class QueryTest extends TestCase
     public function testSubquery()
     {
         $users = User::where('title', 'admin')->orWhere(function ($query) {
-                $query->where('name', 'Tommy Toe')
+            $query->where('name', 'Tommy Toe')
                       ->orWhere('name', 'Error');
-            })
-            ->get();
+        })
+        ->get();
 
         $this->assertEquals(5, count($users));
 

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -223,18 +223,18 @@ class QueryTest extends TestCase
         $this->assertEquals(5, count($users));
 
         $users = User::where('title', 'user')->where(function ($query) {
-                $query->where('age', 35)
+            $query->where('age', 35)
                       ->orWhere('name', 'like', '%harry%');
-            })
-            ->get();
+        })
+        ->get();
 
         $this->assertEquals(2, count($users));
 
         $users = User::where('age', 35)->orWhere(function ($query) {
-                $query->where('title', 'admin')
+            $query->where('title', 'admin')
                       ->orWhere('name', 'Error');
-            })
-            ->get();
+        })
+        ->get();
 
         $this->assertEquals(5, count($users));
 

--- a/tests/RelationsTest.php
+++ b/tests/RelationsTest.php
@@ -2,7 +2,6 @@
 
 class RelationsTest extends TestCase
 {
-
     public function tearDown()
     {
         Mockery::close();
@@ -413,13 +412,11 @@ class RelationsTest extends TestCase
 
         $authors = User::whereHas('books', function ($query) {
             $query->where('rating', 5);
-
         })->get();
         $this->assertCount(1, $authors);
 
         $authors = User::whereHas('books', function ($query) {
             $query->where('rating', '<', 5);
-
         })->get();
         $this->assertCount(1, $authors);
     }

--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -2,7 +2,6 @@
 
 class SchemaTest extends TestCase
 {
-
     public function tearDown()
     {
         Schema::drop('newcollection');

--- a/tests/SeederTest.php
+++ b/tests/SeederTest.php
@@ -2,7 +2,6 @@
 
 class SeederTest extends TestCase
 {
-
     public function tearDown()
     {
         User::truncate();

--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -2,7 +2,6 @@
 
 class ValidationTest extends TestCase
 {
-
     public function tearDown()
     {
         User::truncate();

--- a/tests/seeds/UserTableSeeder.php
+++ b/tests/seeds/UserTableSeeder.php
@@ -5,7 +5,6 @@ use Illuminate\Support\Facades\DB;
 
 class UserTableSeeder extends Seeder
 {
-
     public function run()
     {
         DB::collection('users')->delete();


### PR DESCRIPTION
MongoDB do not have transactions, so when Laravel tries to begin one an exception is throwed. Fix #854.

To avoid it this PR overwrites trnasactions functions, removing the lines that call PDO transaction at original code. This only preserves flag propertie increments and decrements, also the events fired.