### PR TITLE
Fix db options bug.

### DIFF
--- a/src/Jenssegers/Mongodb/Connection.php
+++ b/src/Jenssegers/Mongodb/Connection.php
@@ -183,7 +183,7 @@ class Connection extends \Illuminate\Database\Connection
             }
         }
 
-        return "mongodb://" . implode(',', $hosts) . "/{$database}";
+        return "mongodb://" . implode(',', $hosts) . "/{$options['db']}";
     }
 
     /**


### PR DESCRIPTION
This fixes the issue where the options.db is ignored. which causes the problem where the user table cannot be in a different database as the database which the user is connecting to.

e.g. user "pengkong" is store in database called "admin"
but "pengkong" does not have access to admin, rather it has access to "mydatabase"
