### PR TITLE
Fix collections attachments.

### DIFF
--- a/src/Jenssegers/Mongodb/Relations/BelongsToMany.php
+++ b/src/Jenssegers/Mongodb/Relations/BelongsToMany.php
@@ -179,6 +179,10 @@ class BelongsToMany extends EloquentBelongsToMany
             // Attach the new parent id to the related model.
             $model->push($this->foreignKey, $this->parent->getKey(), true);
         } else {
+            if ($id instanceof Collection) {
+                $id = $id->modelKeys();
+            }
+
             $query = $this->newRelatedQuery();
 
             $query->whereIn($this->related->getKeyName(), (array) $id);

--- a/tests/RelationsTest.php
+++ b/tests/RelationsTest.php
@@ -296,7 +296,7 @@ class RelationsTest extends TestCase
         $user = User::create(['name' => 'John Doe']);
         $client1 = Client::create(['name' => 'Test 1']);
         $client2 = Client::create(['name' => 'Test 2']);
-        $collection = new \Illuminate\Database\Eloquent\Collection([$client1, $client2])
+        $collection = new \Illuminate\Database\Eloquent\Collection([$client1, $client2]);
 
         $user = User::where('name', '=', 'John Doe')->first();
         $user->clients()->attach($collection);

--- a/tests/RelationsTest.php
+++ b/tests/RelationsTest.php
@@ -291,6 +291,18 @@ class RelationsTest extends TestCase
         $this->assertCount(2, $user->clients);
     }
 
+    public function testBelongsToManyAttachEloquentCollection()
+    {
+        $user = User::create(['name' => 'John Doe']);
+        $client1 = Client::create(['name' => 'Test 1']);
+        $client2 = Client::create(['name' => 'Test 2']);
+        $collection = new \Illuminate\Database\Eloquent\Collection([$client1, $client2])
+
+        $user = User::where('name', '=', 'John Doe')->first();
+        $user->clients()->attach($collection);
+        $this->assertCount(2, $user->clients);
+    }
+
     public function testBelongsToManySyncAlreadyPresent()
     {
         $user = User::create(['name' => 'John Doe']);


### PR DESCRIPTION
If you will try to attach model simultaneously to a collection of related models, you'll crash your app, because this method will try to operate with models themselves but not with their ids.

This change considers every case and fixes collections relations.