### PR TITLE
[Closed][Stale Code] Fix working of unique and exists

### DIFF
--- a/src/Jenssegers/Mongodb/Validation/DatabasePresenceVerifier.php
+++ b/src/Jenssegers/Mongodb/Validation/DatabasePresenceVerifier.php
@@ -1,0 +1,54 @@
+<?php namespace Jenssegers\Mongodb\Validation;
+
+class DatabasePresenceVerifier extends \Illuminate\Validation\DatabasePresenceVerifier
+{
+    /**
+     * Count the number of objects in a collection having the given value.
+     *
+     * @param  string  $collection
+     * @param  string  $column
+     * @param  string  $value
+     * @param  int     $excludeId
+     * @param  string  $idColumn
+     * @param  array   $extra
+     * @return int
+     */
+    public function getCount($collection, $column, $value, $excludeId = null, $idColumn = null, array $extra = [])
+    {
+        $query = $this->table($collection)->where($column, 'regex', "/$value/i");
+
+        if (! is_null($excludeId) && $excludeId != 'NULL') {
+            $query->where($idColumn ?: 'id', '<>', $excludeId);
+        }
+
+        foreach ($extra as $key => $extraValue) {
+            $this->addWhere($query, $key, $extraValue);
+        }
+
+        return $query->count();
+    }
+
+    /**
+     * Count the number of objects in a collection with the given values.
+     *
+     * @param  string  $collection
+     * @param  string  $column
+     * @param  array   $values
+     * @param  array   $extra
+     * @return int
+     */
+    public function getMultiCount($collection, $column, array $values, array $extra = [])
+    {
+        foreach ($values as &$value) {
+           $value = new \MongoRegex("/$value/i");
+        }
+        
+        $query = $this->table($collection)->whereIn($column, $values);
+
+        foreach ($extra as $key => $extraValue) {
+            $this->addWhere($query, $key, $extraValue);
+        }
+
+        return $query->count();
+    }
+}

--- a/src/Jenssegers/Mongodb/Validation/DatabasePresenceVerifier.php
+++ b/src/Jenssegers/Mongodb/Validation/DatabasePresenceVerifier.php
@@ -40,7 +40,7 @@ class DatabasePresenceVerifier extends \Illuminate\Validation\DatabasePresenceVe
     public function getMultiCount($collection, $column, array $values, array $extra = [])
     {
         foreach ($values as &$value) {
-           $value = new \MongoRegex("/$value/i");
+            $value = new \MongoRegex("/$value/i");
         }
         
         $query = $this->table($collection)->whereIn($column, $values);

--- a/src/Jenssegers/Mongodb/Validation/MongodbValidationServiceProvider.php
+++ b/src/Jenssegers/Mongodb/Validation/MongodbValidationServiceProvider.php
@@ -10,5 +10,4 @@ class MongodbValidationServiceProvider extends ValidationServiceProvider
             return new DatabasePresenceVerifier($app['db']);
         });
     }
-
 }

--- a/src/Jenssegers/Mongodb/Validation/MongodbValidationServiceProvider.php
+++ b/src/Jenssegers/Mongodb/Validation/MongodbValidationServiceProvider.php
@@ -1,0 +1,14 @@
+<?php namespace Jenssegers\Mongodb\Validation;
+
+use Illuminate\Validation\ValidationServiceProvider;
+
+class MongodbValidationServiceProvider extends ValidationServiceProvider
+{
+    protected function registerPresenceVerifier()
+    {
+        $this->app->singleton('validation.presence', function ($app) {
+            return new DatabasePresenceVerifier($app['db']);
+        });
+    }
+
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -13,6 +13,7 @@ class TestCase extends Orchestra\Testbench\TestCase
         return [
             'Jenssegers\Mongodb\MongodbServiceProvider',
             'Jenssegers\Mongodb\Auth\PasswordResetServiceProvider',
+            'Jenssegers\Mongodb\Validation\MongodbValidationServiceProvider'
         ];
     }
 

--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -2,7 +2,6 @@
 
 class ValidationTest extends TestCase
 {
-
     public function tearDown()
     {
         User::truncate();

--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -23,5 +23,53 @@ class ValidationTest extends TestCase
             ['name' => 'required|unique:users']
         );
         $this->assertTrue($validator->fails());
+        
+        $validator = Validator::make(
+            ['name' => 'John doe'],
+            ['name' => 'required|unique:users']
+        );
+        $this->assertTrue($validator->fails());
+
+        $validator = Validator::make(
+            ['name' => 'john doe'],
+            ['name' => 'required|unique:users']
+        );
+        $this->assertTrue($validator->fails());
+
+        $validator = Validator::make(
+            ['name' => 'test doe'],
+            ['name' => 'required|unique:users']
+        );
+        $this->assertFalse($validator->fails());
+    }
+
+    public function testExists()
+    {
+        $validator = Validator::make(
+            ['name' => 'John Doe'],
+            ['name' => 'required|exists:users']
+        );
+        $this->assertTrue($validator->fails());
+
+        User::create(['name' => 'John Doe']);
+        User::create(['name' => 'Test Name']);
+
+        $validator = Validator::make(
+            ['name' => 'John Doe'],
+            ['name' => 'required|exists:users']
+        );
+        $this->assertFalse($validator->fails());
+
+        $validator = Validator::make(
+            ['name' => 'john Doe'],
+            ['name' => 'required|exists:users']
+        );
+        $this->assertFalse($validator->fails());
+
+        $validator = Validator::make(
+            ['name' => ['test name', 'john doe']],
+            ['name' => 'required|exists:users']
+        );
+        $this->assertFalse($validator->fails());
     }
 }


### PR DESCRIPTION
Before this, unique rule was case sensitive, that means it would pass strings with same chars but different case. Example, if curosmj@gmail.com exists in database, applying unique rule on curosMj@gmail.com SHOULD have failed, but it does not, since mongo is case sensitive, and case sensitiveness cannot be configured. See https://github.com/laravel/framework/issues/9430. Also seen in #528 

I've implemented a DatabasePresenceVerifier for mongodb, which overrides the default presence verifier, ONLY IF MongodbValidationServiceProvider is used. Also added test cases to make sure 'unique' and 'exists' validation rules function in a case insensitive manner.

This is an issue that affects almost all applications that would be using this plugin,  and it is pretty serious.

Ping @jenssegers.
