### PR TITLE
Aggregate subdocument arrays

### DIFF
--- a/src/Jenssegers/Mongodb/Query/Builder.php
+++ b/src/Jenssegers/Mongodb/Query/Builder.php
@@ -251,7 +251,7 @@ class Builder extends BaseBuilder
             }
 
             // apply unwinds for subdocument array aggregation
-            foreach($unwinds as $unwind){
+            foreach ($unwinds as $unwind) {
                 $pipeline[] = ['$unwind' => '$' . $unwind];
             }
 

--- a/src/Jenssegers/Mongodb/Query/Builder.php
+++ b/src/Jenssegers/Mongodb/Query/Builder.php
@@ -187,6 +187,7 @@ class Builder extends BaseBuilder
         // Use MongoDB's aggregation framework when using grouping or aggregation functions.
         if ($this->groups or $this->aggregate or $this->paginating) {
             $group = [];
+            $unwinds = [];
 
             // Add grouping columns to the $group part of the aggregation pipeline.
             if ($this->groups) {
@@ -212,6 +213,13 @@ class Builder extends BaseBuilder
                 $function = $this->aggregate['function'];
 
                 foreach ($this->aggregate['columns'] as $column) {
+                    // Add unwind if a subdocument array should be aggregated
+                    // column: subarray.price => {$unwind: '$subarray'}
+                    if (count($splitColumns = explode('.*.', $column)) == 2) {
+                        $unwinds[] = $splitColumns[0];
+                        $column = implode('.', $splitColumns);
+                    }
+
                     // Translate count into sum.
                     if ($function == 'count') {
                         $group['aggregate'] = ['$sum' => 1];
@@ -241,6 +249,12 @@ class Builder extends BaseBuilder
             if ($wheres) {
                 $pipeline[] = ['$match' => $wheres];
             }
+
+            // apply unwinds for subdocument array aggregation
+            foreach($unwinds as $unwind){
+                $pipeline[] = ['$unwind' => '$' . $unwind];
+            }
+
             if ($group) {
                 $pipeline[] = ['$group' => $group];
             }

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -422,17 +422,17 @@ class QueryBuilderTest extends TestCase
     public function testSubdocumentArrayAggregate()
     {
         DB::collection('items')->insert([
-            ['name' => 'knife', 'amount' => [['hidden' => 10, 'found' => 3]]],
-            ['name' => 'fork',  'amount' => [['hidden' => 35, 'found' => 12]]],
+            ['name' => 'knife', 'amount' => [['hidden' => 10, 'found' => 3],['hidden' => 5, 'found' => 2]]],
+            ['name' => 'fork',  'amount' => [['hidden' => 35, 'found' => 12],['hidden' => 7, 'found' => 17],['hidden' => 1, 'found' => 19]]],
             ['name' => 'spoon', 'amount' => [['hidden' => 14, 'found' => 21]]],
-            ['name' => 'spoon', 'amount' => [['hidden' => 6, 'found' => 4]]],
+            ['name' => 'teaspoon', 'amount' => []],
         ]);
 
-        $this->assertEquals(65, DB::collection('items')->sum('amount.*.hidden'));
-        $this->assertEquals(4, DB::collection('items')->count('amount.*.hidden'));
-        $this->assertEquals(6, DB::collection('items')->min('amount.*.hidden'));
+        $this->assertEquals(72, DB::collection('items')->sum('amount.*.hidden'));
+        $this->assertEquals(6, DB::collection('items')->count('amount.*.hidden'));
+        $this->assertEquals(1, DB::collection('items')->min('amount.*.hidden'));
         $this->assertEquals(35, DB::collection('items')->max('amount.*.hidden'));
-        $this->assertEquals(16.25, DB::collection('items')->avg('amount.*.hidden'));
+        $this->assertEquals(12, DB::collection('items')->avg('amount.*.hidden'));
     }
 
     public function testUpsert()

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -419,6 +419,22 @@ class QueryBuilderTest extends TestCase
         $this->assertEquals(16.25, DB::collection('items')->avg('amount.hidden'));
     }
 
+    public function testSubdocumentArrayAggregate()
+    {
+        DB::collection('items')->insert([
+            ['name' => 'knife', 'amount' => [['hidden' => 10, 'found' => 3]]],
+            ['name' => 'fork',  'amount' => [['hidden' => 35, 'found' => 12]]],
+            ['name' => 'spoon', 'amount' => [['hidden' => 14, 'found' => 21]]],
+            ['name' => 'spoon', 'amount' => [['hidden' => 6, 'found' => 4]]],
+        ]);
+
+        $this->assertEquals(65, DB::collection('items')->sum('amount.*.hidden'));
+        $this->assertEquals(4, DB::collection('items')->count('amount.*.hidden'));
+        $this->assertEquals(6, DB::collection('items')->min('amount.*.hidden'));
+        $this->assertEquals(35, DB::collection('items')->max('amount.*.hidden'));
+        $this->assertEquals(16.25, DB::collection('items')->avg('amount.*.hidden'));
+    }
+
     public function testUpsert()
     {
         DB::collection('items')->where('name', 'knife')


### PR DESCRIPTION
With this code it is possible to use aggregation functions (sum, count, max, min, avg, ...) on subdocument arrays (embedsMany). To use this functionality you have to pass `array.*.field` to the corresponding aggregation function.

Check out the code example in `testSubdocumentArrayAggregate` in `QueryBuilderTest.php`.

As you can see with this solution it is very simple to apply the aggregation functions instead of writing complex raw aggregations. In my scenario, the code is much simpler and cleaner.

I would be glad to get feedback if you are interested to this functionality, or if you have suggestions for improvements or alternatives.