### PR TITLE
Filling with Dot-Notation

### DIFF
--- a/src/Jenssegers/Mongodb/Eloquent/Model.php
+++ b/src/Jenssegers/Mongodb/Eloquent/Model.php
@@ -537,11 +537,11 @@ abstract class Model extends BaseModel
     }
     
     /**
-    * We just return original key here in order to support keys in dot-notation 
-    *
-    * @param  string  $key
-    * @return string
-    */
+     * We just return original key here in order to support keys in dot-notation
+     *
+     * @param  string  $key
+     * @return string
+     */
     protected function removeTableFromKey($key)
     {
         return $key;

--- a/src/Jenssegers/Mongodb/Eloquent/Model.php
+++ b/src/Jenssegers/Mongodb/Eloquent/Model.php
@@ -535,6 +535,17 @@ abstract class Model extends BaseModel
 
         return new QueryBuilder($connection, $connection->getPostProcessor());
     }
+    
+    /**
+    * We just return original key here in order to support keys in dot-notation 
+    *
+    * @param  string  $key
+    * @return string
+    */
+    protected function removeTableFromKey($key)
+    {
+        return $key;
+    }
 
     /**
      * Handle dynamic method calls into the method.

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -486,6 +486,13 @@ class ModelTest extends TestCase
         $this->assertEquals('Paris', $user->getAttribute('address.city'));
         $this->assertEquals('Paris', $user['address.city']);
         $this->assertEquals('Paris', $user->{'address.city'});
+
+        // Fill
+        $user->fill([
+            'address.city' => 'Strasbourg',
+        ]);
+
+        $this->assertEquals('Strasbourg', $user['address.city']);
     }
 
     public function testGetDirtyDates()


### PR DESCRIPTION
Simply override `removeTableFromKey($key)` method and  just return original keys in order to support dot-notation when calling `fill` on model :)