### PR TITLE
Fix version Compatibility Table closes #936

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ composer require jenssegers/mongodb
  5.0.x    | 2.1.x
  5.1.x    | 2.2.x or 3.0.x
  5.2.x    | 2.3.x or 3.0.x
- 5.3.x    | 3.0.x
+ 5.3.x    | 3.1.x
 
 And add the service provider in `config/app.php`:
 


### PR DESCRIPTION
Laravel 5.3 support currently is available for 3.1.0-alpha release only!