### PR TITLE
Convert whereBetween values to UTCDateTime

### DIFF
--- a/src/Jenssegers/Mongodb/Query/Builder.php
+++ b/src/Jenssegers/Mongodb/Query/Builder.php
@@ -866,7 +866,16 @@ class Builder extends BaseBuilder
 
             // Convert DateTime values to UTCDateTime.
             if (isset($where['value']) and $where['value'] instanceof DateTime) {
-                $where['value'] = new UTCDateTime($where['value']->getTimestamp() * 1000);
+                $where['value'] = $this->dateTimeConvertion($where['value']);
+            }
+
+            // Convert DateTime values to UTCDateTime in $where['values'] key.
+            if (isset($where['values'])) {
+                foreach ($where['values'] as $key => $value) {
+                    if ($value instanceof DateTime) {
+                        $where['values'][$key] = $this->dateTimeConvertion($value);
+                    }
+                }
             }
 
             // The next item in a "chain" of wheres devices the boolean of the
@@ -894,7 +903,7 @@ class Builder extends BaseBuilder
             // Merge the compiled where with the others.
             $compiled = array_merge_recursive($compiled, $result);
         }
-
+        
         return $compiled;
     }
 
@@ -1017,6 +1026,20 @@ class Builder extends BaseBuilder
     protected function compileWhereRaw($where)
     {
         return $where['sql'];
+    }
+    
+    /**
+     * Convert to MongoDB\BSON\UTCDateTime if $value is a DateTime object.
+     *
+     * @param  mixed   $value
+     * @return mixed
+     */
+    protected function dateTimeConvertion($value)
+    {
+        if ($value instanceof DateTime) {
+            return new UTCDateTime($value->getTimestamp() * 1000);
+        }
+        return $value;
     }
 
     /**

--- a/src/Jenssegers/Mongodb/Query/Builder.php
+++ b/src/Jenssegers/Mongodb/Query/Builder.php
@@ -870,10 +870,12 @@ class Builder extends BaseBuilder
             }
 
             // Convert DateTime values to UTCDateTime in $where['values'] key.
-            if (isset($where['values'])) {
-                foreach ($where['values'] as $key => $value) {
-                    if ($value instanceof DateTime) {
-                        $where['values'][$key] = $this->dateTimeConvertion($value);
+            if (array_key_exists('values', $where)) {
+                if (is_array($where['values']) && !empty($where['values'])) {
+                    foreach ($where['values'] as $keyWhere => $valueWhere) {
+                        if ($valueWhere instanceof DateTime) {
+                            $where['values'][$keyWhere] = $this->dateTimeConvertion($valueWhere);
+                        }
                     }
                 }
             }

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -490,6 +490,13 @@ class QueryBuilderTest extends TestCase
 
         $users = DB::collection('users')->whereBetween('birthday', [$start, $stop])->get();
         $this->assertEquals(2, count($users));
+
+        $dateTimeStart  = new DateTime("1981-01-01 00:00:00");
+        $dateTimeStop   = new DateTime("1982-01-01 00:00:00");
+
+        $usersWithDateTimeFilter = DB::collection('users')->whereBetween('birthday', [$dateTimeStart, $dateTimeStop])->get();
+        $this->assertEquals(2, count($usersWithDateTimeFilter));
+
     }
 
     public function testOperators()

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -496,7 +496,6 @@ class QueryBuilderTest extends TestCase
 
         $usersWithDateTimeFilter = DB::collection('users')->whereBetween('birthday', [$dateTimeStart, $dateTimeStop])->get();
         $this->assertEquals(2, count($usersWithDateTimeFilter));
-
     }
 
     public function testOperators()


### PR DESCRIPTION
Added a protected method (dateTimeConvertion) to convert DateTime objects to MongoDB\BSON\UTCDateTime and added a verification for DateTime objects in $where['values'] array to ensure that all DateTime values will be properly converted to MongoDB\BSON\UTCDateTime.
