### PR TITLE
Allow setting custom options on a query [Fixes #541]

### DIFF
--- a/src/Jenssegers/Mongodb/Query/Builder.php
+++ b/src/Jenssegers/Mongodb/Query/Builder.php
@@ -42,6 +42,13 @@ class Builder extends BaseBuilder
     public $hint;
 
     /**
+     * Custom options to add to the query.
+     *
+     * @var array
+     */
+    public $options = [];
+
+    /**
      * Indicate if we are executing a pagination query.
      *
      * @var bool
@@ -263,6 +270,11 @@ class Builder extends BaseBuilder
                 'typeMap' => ['root' => 'array', 'document' => 'array'],
             ];
 
+            // Add custom query options
+            if (count($this->options)) {
+                $options = array_merge($options, $this->options);
+            }
+
             // Execute aggregation
             $results = iterator_to_array($this->collection->aggregate($pipeline, $options));
 
@@ -320,6 +332,11 @@ class Builder extends BaseBuilder
 
             // Fix for legacy support, converts the results to arrays instead of objects.
             $options['typeMap'] = ['root' => 'array', 'document' => 'array'];
+
+            // Add custom query options
+            if (count($this->options)) {
+                $options = array_merge($options, $this->options);
+            }
 
             // Execute query and get MongoCursor
             $cursor = $this->collection->find($wheres, $options);
@@ -1017,6 +1034,19 @@ class Builder extends BaseBuilder
     protected function compileWhereRaw($where)
     {
         return $where['sql'];
+    }
+
+    /**
+     * Set custom options for the query.
+     *
+     * @param  array  $options
+     * @return $this
+     */
+    public function options(array $options)
+    {
+        $this->options = $options;
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
This adds an options method to the query builder to allow setting custom MongoDB options such as `allowDiskUse` which is required for sorting very large collections.  E.g.:
```php
$users = User::orderBy('name', 'desc')->options(['allowDiskUse' => true])->get();
```
Available options are documented here:
http://mongodb.github.io/mongo-php-library/classes/collection/#aggregate