### PR TITLE
Remove the database from the connection string.

### DIFF
--- a/src/Jenssegers/Mongodb/Connection.php
+++ b/src/Jenssegers/Mongodb/Connection.php
@@ -183,7 +183,7 @@ class Connection extends \Illuminate\Database\Connection
             }
         }
 
-        return "mongodb://" . implode(',', $hosts) . "/{$database}";
+        return "mongodb://" . implode(',', $hosts) . ($database? "/{$database}" : '');
     }
 
     /**


### PR DESCRIPTION
This PR removes the `database` from the connection string as advised here https://github.com/mongodb/mongo-php-library/issues/171.

> If you are expecting to authenticate against the "admin" database, I would suggest removing both "/database" from the URI string and the db key from the options. The driver already defaults to authenticate against the "admin" database. If you do wish to specify a different database, you can either do so via the URI string (where you're currently indicating that you want to auth against the database named "database") or the authSource option (specified as either a query string parameter in the URI string or via the options array).
> 
> I realize this does differ from the legacy driver's MongoClient constructor options, where we previously accepted a "db" option. The driver and library documentation for MongoDB\Driver\Manager and MongoDB\Client, respectively, now refer to the Connection string documentation, which I cite below.
> 
> /database: Optional. The name of the database to authenticate if the connection string includes authentication credentials in the form of username:password@. If /database is not specified and the connection string includes credentials, the driver will authenticate to the admin database.
> Source: Standard Connection String Format.
> 
> authSource: Specify the database name associated with the user’s credentials, if the users collection do not exist in the database where the client is connecting. authSource defaults to the database specified in the connection string.
> 
> MongoDB will ignore authSource values if the connection string specifies no user name.
> Source: Authentication Options.
> 
> In your case, you are specifying a username via the array options, so you need not worry about the last line of the authSource docs (if you decide to use that option).

Also potentially related to https://github.com/jenssegers/laravel-mongodb/issues/963
