### PR TITLE
Set the correct auth database in connection string

### DIFF
--- a/src/Jenssegers/Mongodb/Connection.php
+++ b/src/Jenssegers/Mongodb/Connection.php
@@ -185,7 +185,9 @@ class Connection extends \Illuminate\Database\Connection
             }
         }
 
-        return "mongodb://" . implode(',', $hosts) . ($database ? "/{$database}" : '');
+        $auth_database = isset($options) ? array_get($options, 'database', null) : null;
+
+        return "mongodb://" . implode(',', $hosts) . ($auth_database? "/{$auth_database}" : '');
     }
 
     /**


### PR DESCRIPTION
Hey,

This is related to https://github.com/jenssegers/laravel-mongodb/pull/971

I've just realised that the connection string should be using the auth database from the `options` array, rather than the main database.

This PR corrects that problem. Sorry, only just noticed after you merged my previous PR 😞 