### PR TITLE
add connection name config for Password Reset in Laravel 5.3

### DIFF
--- a/src/Jenssegers/Mongodb/Auth/PasswordBrokerManager.php
+++ b/src/Jenssegers/Mongodb/Auth/PasswordBrokerManager.php
@@ -12,8 +12,10 @@ class PasswordBrokerManager extends BasePasswordBrokerManager
      */
     protected function createTokenRepository(array $config)
     {
+        $connection = isset($config['connection']) ? $config['connection'] : null;
+
         return new DatabaseTokenRepository(
-            $this->app['db']->connection(),
+            $this->app['db']->connection($connection),
             $config['table'],
             $this->app['config']['app.key'],
             $config['expire']

--- a/src/Jenssegers/Mongodb/Auth/PasswordResetServiceProvider.php
+++ b/src/Jenssegers/Mongodb/Auth/PasswordResetServiceProvider.php
@@ -4,28 +4,6 @@ use Illuminate\Auth\Passwords\PasswordResetServiceProvider as BasePasswordResetS
 
 class PasswordResetServiceProvider extends BasePasswordResetServiceProvider
 {
-    /**
-     * Register the token repository implementation.
-     *
-     * @return void
-     */
-    protected function registerTokenRepository()
-    {
-        $this->app->singleton('auth.password.tokens', function ($app) {
-            $connection = $app['db']->connection();
-
-            // The database token repository is an implementation of the token repository
-            // interface, and is responsible for the actual storing of auth tokens and
-            // their e-mail addresses. We will inject this table and hash key to it.
-            $table = $app['config']['auth.password.table'];
-
-            $key = $app['config']['app.key'];
-
-            $expire = $app['config']->get('auth.password.expire', 60);
-
-            return new DatabaseTokenRepository($connection, $table, $key, $expire);
-        });
-    }
 
     /**
      * Register the password broker instance.


### PR DESCRIPTION
when mongo db connection is not as default connection.

example: config/auth.php in Laravel 5.3
```
'passwords' => [
    'users' => [
        'provider' => 'users',
        'table' => 'password_resets',
        'connection' => 'custom_connection_name', // optional
        'expire' => 60,
    ],
],
```
