### PR TITLE
Don't set updated_at if using operator on collection

### DIFF
--- a/src/Jenssegers/Mongodb/Eloquent/Builder.php
+++ b/src/Jenssegers/Mongodb/Eloquent/Builder.php
@@ -35,7 +35,11 @@ class Builder extends EloquentBuilder
             return 1;
         }
 
-        return $this->query->update($this->addUpdatedAtColumn($values), $options);
+        if (! starts_with(key($values), '$')) {
+            $values = $this->addUpdatedAtColumn($values);
+        }
+
+        return $this->query->update($values, $options);
     }
 
     /**


### PR DESCRIPTION
When using an operator (key starts with $), we should not automatically
set the updated_at field as this generates an error.

Additional logic could be added to check whether a $set operator is present
and add the updated_at field to that, or create it, but for now I've simply
omitted it, as the developer probably knows what he or she is doing when using
a custom operator.