### PR TITLE
Fix attribute read for values nested on multiple levels

### DIFF
--- a/src/Jenssegers/Mongodb/Eloquent/Model.php
+++ b/src/Jenssegers/Mongodb/Eloquent/Model.php
@@ -237,16 +237,7 @@ abstract class Model extends BaseModel
      */
     protected function getAttributeFromArray($key)
     {
-        // Support keys in dot notation.
-        if (str_contains($key, '.')) {
-            $attributes = array_dot($this->attributes);
-
-            if (array_key_exists($key, $attributes)) {
-                return $attributes[$key];
-            }
-        }
-
-        return parent::getAttributeFromArray($key);
+        return array_get($this->attributes, $key);
     }
 
     /**

--- a/src/Jenssegers/Mongodb/Eloquent/Model.php
+++ b/src/Jenssegers/Mongodb/Eloquent/Model.php
@@ -237,7 +237,12 @@ abstract class Model extends BaseModel
      */
     protected function getAttributeFromArray($key)
     {
-        return array_get($this->attributes, $key);
+        // Support keys in dot notation.
+        if (str_contains($key, '.')) {
+            return array_get($this->attributes, $key);
+        }
+
+        return parent::getAttributeFromArray($key);
     }
 
     /**

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -495,6 +495,22 @@ class ModelTest extends TestCase
         $this->assertEquals('Strasbourg', $user['address.city']);
     }
 
+    public function testMultipleLevelDotNotation()
+    {
+        $book = Book::create([
+            'title' => 'A Game of Thrones',
+            'chapters' => [
+                'one' => [
+                    'title' => 'The first chapter',
+                ],
+            ],
+        ]);
+
+        $this->assertEquals(['one' => ['title' => 'The first chapter']], $book->chapters);
+        $this->assertEquals(['title' => 'The first chapter'], $book['chapters.one']);
+        $this->assertEquals('The first chapter', $book['chapters.one.title']);
+    }
+
     public function testGetDirtyDates()
     {
         $user = new User();


### PR DESCRIPTION
There is a bug in the retrieval of intermediary nested values
Let's assume the following structure of data:
`$foo['a.b.c'] = 1;`

```php
>>> $foo['a'];
=> [
     "b" => [
       "c" => 1,
     ],
   ]

>>> $foo['a.b'];
=> null // <-- this is wrong as it should return this:

>>> $foo['a']['b'];
=> [
     "c" => 1,
   ]

>>> $foo['a.b.c'];  // this works fine
=> 1
```