### PR TITLE
Change access specifier on $operators property

### DIFF
--- a/src/Jenssegers/Mongodb/Query/Builder.php
+++ b/src/Jenssegers/Mongodb/Query/Builder.php
@@ -60,7 +60,7 @@ class Builder extends BaseBuilder
      *
      * @var array
      */
-    protected $operators = [
+    public $operators = [
         '=', '<', '>', '<=', '>=', '<>', '!=',
         'like', 'not like', 'between', 'ilike',
         '&', '|', '^', '<<', '>>',


### PR DESCRIPTION
This change is made to match the access specifier in Laravel's base Query Builder class. This was changed in Laravel 5.4.

Fixes #1077