### PR TITLE
Updates PasswordBroker to work with Laravel 5.4

### DIFF
--- a/src/Jenssegers/Mongodb/Auth/PasswordBrokerManager.php
+++ b/src/Jenssegers/Mongodb/Auth/PasswordBrokerManager.php
@@ -12,11 +12,26 @@ class PasswordBrokerManager extends BasePasswordBrokerManager
      */
     protected function createTokenRepository(array $config)
     {
-        return new DatabaseTokenRepository(
-            $this->app['db']->connection(),
-            $config['table'],
-            $this->app['config']['app.key'],
-            $config['expire']
-        );
+        // temp version check until new dot released for 5.4+
+        $version = explode('.', \App::version());
+
+        // Laravel 5.4+
+        if ($version[0] >= 5 && $version[1] >= 4) {
+            return new DatabaseTokenRepository(
+                $this->app['db']->connection(),
+                $this->app['hash'],
+                $config['table'],
+                $this->app['config']['app.key'],
+                $config['expire']
+            );
+        } else {
+            // Laravel < v5.4
+            return new DatabaseTokenRepository(
+                $this->app['db']->connection(),
+                $config['table'],
+                $this->app['config']['app.key'],
+                $config['expire']
+            );
+        }
     }
 }


### PR DESCRIPTION
### Bad code alert: 

This code is a shim until new dot release is available. As reset-password isn't used as often as other functions, the version check's added process should be negligible, but it still isn't the best way, obviously. 

*TODO:* Remove check for next dot release (non-compatible with Laravel < 5.4).

### PR Info:

Laravel 5.4 [implements Hasher into `DatabaseTokenRepository`](https://github.com/laravel/framework/commit/c454c87f75c179043a956071a8572af538c926a9#diff-f682f161553e5df2ef0864ef427eaa40) and therefore requires this parameter to be passed to it from `PasswordBrokerManager.php` in laravel-mongodb.

This PR adds a check to see if we're on 5.4+ and passes hasher if so, allowing it to remain compatible with prior versions of Laravel. 

