### PR TITLE
Add default property to getIdAttribute

### DIFF
--- a/src/Jenssegers/Mongodb/Eloquent/Model.php
+++ b/src/Jenssegers/Mongodb/Eloquent/Model.php
@@ -41,7 +41,7 @@ abstract class Model extends BaseModel
      * @param  mixed  $value
      * @return mixed
      */
-    public function getIdAttribute($value)
+    public function getIdAttribute($value = null)
     {
         // If we don't have a value for 'id', we will use the Mongo '_id' value.
         // This allows us to work with models in a more sql-like way.


### PR DESCRIPTION
Since the function has a check for `! $value` and assigns the MongoDB default of ‘_id’ we should be able to omit the property.