### PR TITLE
Fixed "Error parsing [float] as 64-bit integer" in Model::freshTimestamp()

### DIFF
--- a/src/Jenssegers/Mongodb/Eloquent/Model.php
+++ b/src/Jenssegers/Mongodb/Eloquent/Model.php
@@ -191,7 +191,7 @@ abstract class Model extends BaseModel
      */
     public function freshTimestamp()
     {
-        return new UTCDateTime(round(microtime(true) * 1000));
+        return new UTCDateTime((int) round(microtime(true) * 1000));
     }
 
     /**


### PR DESCRIPTION
Fixes an error when `round(microtime(true) * 1000)` works out to be a float. Running in HHVM 3.15.4

https://github.com/jenssegers/laravel-mongodb/issues/712