### PR TITLE
Get the Other/Owner Key name based on different version of Illuminate/Database

### DIFF
--- a/src/Jenssegers/Mongodb/Relations/BelongsTo.php
+++ b/src/Jenssegers/Mongodb/Relations/BelongsTo.php
@@ -11,7 +11,7 @@ class BelongsTo extends \Illuminate\Database\Eloquent\Relations\BelongsTo
             // For belongs to relationships, which are essentially the inverse of has one
             // or has many relationships, we need to actually query on the primary key
             // of the related models matching on the foreign key that's on a parent.
-            $this->query->where($this->getOtherKeyPropertyName(), '=', $this->parent->{$this->foreignKey});
+            $this->query->where($this->getOwnerKey(), '=', $this->parent->{$this->foreignKey});
         }
     }
 
@@ -25,7 +25,7 @@ class BelongsTo extends \Illuminate\Database\Eloquent\Relations\BelongsTo
         // We'll grab the primary key name of the related models since it could be set to
         // a non-standard name and not "id". We will then construct the constraint for
         // our eagerly loading query so it returns the proper models from execution.
-        $key = $this->getOtherKeyPropertyName();
+        $key = $this->getOwnerKey();
 
         $this->query->whereIn($key, $this->getEagerModelKeys($models));
     }
@@ -35,7 +35,7 @@ class BelongsTo extends \Illuminate\Database\Eloquent\Relations\BelongsTo
      * see commit https://github.com/illuminate/database/commit/6a35698d72e276f435324b7e29b3cd37ef7d5d9c
      * @return string
      */
-    public function getOtherKeyPropertyName()
+    public function getOwnerKey()
     {
         return property_exists($this, "ownerKey") ? $this->ownerKey : $this->otherKey;
     }

--- a/src/Jenssegers/Mongodb/Relations/BelongsTo.php
+++ b/src/Jenssegers/Mongodb/Relations/BelongsTo.php
@@ -11,7 +11,7 @@ class BelongsTo extends \Illuminate\Database\Eloquent\Relations\BelongsTo
             // For belongs to relationships, which are essentially the inverse of has one
             // or has many relationships, we need to actually query on the primary key
             // of the related models matching on the foreign key that's on a parent.
-            $this->query->where($this->otherKey, '=', $this->parent->{$this->foreignKey});
+            $this->query->where($this->getOtherKeyPropertyName(), '=', $this->parent->{$this->foreignKey});
         }
     }
 
@@ -25,8 +25,18 @@ class BelongsTo extends \Illuminate\Database\Eloquent\Relations\BelongsTo
         // We'll grab the primary key name of the related models since it could be set to
         // a non-standard name and not "id". We will then construct the constraint for
         // our eagerly loading query so it returns the proper models from execution.
-        $key = $this->otherKey;
+        $key = $this->getOtherKeyPropertyName();
 
         $this->query->whereIn($key, $this->getEagerModelKeys($models));
+    }
+
+    /**
+     * get the Other/Owner Key name based on different version of Illuminate/Database
+     * see commit https://github.com/illuminate/database/commit/6a35698d72e276f435324b7e29b3cd37ef7d5d9c
+     * @return string
+     */
+    public function getOtherKeyPropertyName()
+    {
+        return property_exists($this, "ownerKey") ? $this->ownerKey : $this->otherKey;
     }
 }

--- a/src/Jenssegers/Mongodb/Relations/BelongsToMany.php
+++ b/src/Jenssegers/Mongodb/Relations/BelongsToMany.php
@@ -110,7 +110,7 @@ class BelongsToMany extends EloquentBelongsToMany
         // First we need to attach any of the associated models that are not currently
         // in this joining table. We'll spin through the given IDs, checking to see
         // if they exist in the array of current ones, and if not we will insert.
-        $current = $this->parent->{$this->otherKey} ?: [];
+        $current = $this->parent->{$this->getOtherKeyPropertyName()} ?: [];
 
         // See issue #256.
         if ($current instanceof Collection) {
@@ -192,7 +192,7 @@ class BelongsToMany extends EloquentBelongsToMany
         }
 
         // Attach the new ids to the parent model.
-        $this->parent->push($this->otherKey, (array) $id, true);
+        $this->parent->push($this->getOtherKeyPropertyName(), (array) $id, true);
 
         if ($touch) {
             $this->touchIfTouching();
@@ -220,7 +220,7 @@ class BelongsToMany extends EloquentBelongsToMany
         $ids = (array) $ids;
 
         // Detach all ids from the parent model.
-        $this->parent->pull($this->otherKey, $ids);
+        $this->parent->pull($this->getOtherKeyPropertyName(), $ids);
 
         // Prepare the query to select all related objects.
         if (count($ids) > 0) {
@@ -309,5 +309,15 @@ class BelongsToMany extends EloquentBelongsToMany
             $results[$id] = $attributes;
         }
         return $results;
+    }
+
+    /**
+     * get the Other/Owner Key name based on different version of Illuminate/Database
+     * see commit https://github.com/illuminate/database/commit/6a35698d72e276f435324b7e29b3cd37ef7d5d9c
+     * @return string
+     */
+    public function getOtherKeyPropertyName()
+    {
+        return property_exists($this, "ownerKey") ? $this->ownerKey : $this->otherKey;
     }
 }

--- a/src/Jenssegers/Mongodb/Relations/BelongsToMany.php
+++ b/src/Jenssegers/Mongodb/Relations/BelongsToMany.php
@@ -110,7 +110,7 @@ class BelongsToMany extends EloquentBelongsToMany
         // First we need to attach any of the associated models that are not currently
         // in this joining table. We'll spin through the given IDs, checking to see
         // if they exist in the array of current ones, and if not we will insert.
-        $current = $this->parent->{$this->getOtherKeyPropertyName()} ?: [];
+        $current = $this->parent->{$this->getOwnerKey()} ?: [];
 
         // See issue #256.
         if ($current instanceof Collection) {
@@ -192,7 +192,7 @@ class BelongsToMany extends EloquentBelongsToMany
         }
 
         // Attach the new ids to the parent model.
-        $this->parent->push($this->getOtherKeyPropertyName(), (array) $id, true);
+        $this->parent->push($this->getOwnerKey(), (array) $id, true);
 
         if ($touch) {
             $this->touchIfTouching();
@@ -220,7 +220,7 @@ class BelongsToMany extends EloquentBelongsToMany
         $ids = (array) $ids;
 
         // Detach all ids from the parent model.
-        $this->parent->pull($this->getOtherKeyPropertyName(), $ids);
+        $this->parent->pull($this->getOwnerKey(), $ids);
 
         // Prepare the query to select all related objects.
         if (count($ids) > 0) {
@@ -316,7 +316,7 @@ class BelongsToMany extends EloquentBelongsToMany
      * see commit https://github.com/illuminate/database/commit/6a35698d72e276f435324b7e29b3cd37ef7d5d9c
      * @return string
      */
-    public function getOtherKeyPropertyName()
+    public function getOwnerKey()
     {
         return property_exists($this, "ownerKey") ? $this->ownerKey : $this->otherKey;
     }

--- a/src/Jenssegers/Mongodb/Relations/MorphTo.php
+++ b/src/Jenssegers/Mongodb/Relations/MorphTo.php
@@ -13,7 +13,7 @@ class MorphTo extends EloquentMorphTo
             // For belongs to relationships, which are essentially the inverse of has one
             // or has many relationships, we need to actually query on the primary key
             // of the related models matching on the foreign key that's on a parent.
-            $this->query->where($this->otherKey, '=', $this->parent->{$this->foreignKey});
+            $this->query->where($this->getOtherKeyPropertyName(), '=', $this->parent->{$this->foreignKey});
         }
     }
 
@@ -32,5 +32,15 @@ class MorphTo extends EloquentMorphTo
         $query = $instance->newQuery();
 
         return $query->whereIn($key, $this->gatherKeysByType($type)->all())->get();
+    }
+
+    /**
+     * get the Other/Owner Key name based on different version of Illuminate/Database
+     * see commit https://github.com/illuminate/database/commit/6a35698d72e276f435324b7e29b3cd37ef7d5d9c
+     * @return string
+     */
+    public function getOtherKeyPropertyName()
+    {
+        return property_exists($this, "ownerKey") ? $this->ownerKey : $this->otherKey;
     }
 }

--- a/src/Jenssegers/Mongodb/Relations/MorphTo.php
+++ b/src/Jenssegers/Mongodb/Relations/MorphTo.php
@@ -13,7 +13,7 @@ class MorphTo extends EloquentMorphTo
             // For belongs to relationships, which are essentially the inverse of has one
             // or has many relationships, we need to actually query on the primary key
             // of the related models matching on the foreign key that's on a parent.
-            $this->query->where($this->getOtherKeyPropertyName(), '=', $this->parent->{$this->foreignKey});
+            $this->query->where($this->getOwnerKey(), '=', $this->parent->{$this->foreignKey});
         }
     }
 
@@ -39,7 +39,7 @@ class MorphTo extends EloquentMorphTo
      * see commit https://github.com/illuminate/database/commit/6a35698d72e276f435324b7e29b3cd37ef7d5d9c
      * @return string
      */
-    public function getOtherKeyPropertyName()
+    public function getOwnerKey()
     {
         return property_exists($this, "ownerKey") ? $this->ownerKey : $this->otherKey;
     }


### PR DESCRIPTION
Recently Taylor changed the names in relations otherKey to ownerKey
see commit [commit](https://github.com/illuminate/database/commit/6a35698d72e276f435324b7e29b3cd37ef7d5d9c)
