### PR TITLE
Fixed 32-bit integer overflow by allowing UTCDateTime() to get it's own current time

### DIFF
--- a/src/Jenssegers/Mongodb/Auth/DatabaseTokenRepository.php
+++ b/src/Jenssegers/Mongodb/Auth/DatabaseTokenRepository.php
@@ -12,7 +12,7 @@ class DatabaseTokenRepository extends BaseDatabaseTokenRepository
      */
     protected function getPayload($email, $token)
     {
-        return ['email' => $email, 'token' => $token, 'created_at' => new UTCDateTime(round(microtime(true) * 1000))];
+        return ['email' => $email, 'token' => $token, 'created_at' => new UTCDateTime(null)];
     }
 
     /**

--- a/src/Jenssegers/Mongodb/Eloquent/Model.php
+++ b/src/Jenssegers/Mongodb/Eloquent/Model.php
@@ -108,7 +108,7 @@ abstract class Model extends BaseModel
      */
     public function freshTimestamp()
     {
-        return new UTCDateTime((int) round(microtime(true) * 1000));
+        return new UTCDateTime(null);
     }
 
     /**


### PR DESCRIPTION
@jenssegers This fixes the issue over on https://github.com/jenssegers/laravel-mongodb/pull/1115