### PR TITLE
Fix #1157 (Model::has() - ErrorException: Array to string conversion)

### DIFF
--- a/src/Jenssegers/Mongodb/Eloquent/Builder.php
+++ b/src/Jenssegers/Mongodb/Eloquent/Builder.php
@@ -150,7 +150,7 @@ class Builder extends EloquentBuilder
         $relations = $query->pluck($relation->getHasCompareKey());
         $relationCount = array_count_values(array_map(function ($id) {
             return (string) $id; // Convert Back ObjectIds to Strings
-        }, is_array($relations) ? $relations : $relations->toArray()));
+        }, is_array($relations) ? $relations : $relations->flatten()->toArray()));
 
         // Remove unwanted related objects based on the operator and count.
         $relationCount = array_filter($relationCount, function ($counted) use ($count, $operator) {


### PR DESCRIPTION
Fix #1157

With ‘BelongsToMany’ relationships calling the function `Jenssegers\Mongodb\Eloquent\Model::has` can throw an ErrorException with ‘Array to string conversion’.

By flattening the collection here we can avoid triggering the exception.