### PR TITLE
Update Builder.php

### DIFF
--- a/src/Jenssegers/Mongodb/Query/Builder.php
+++ b/src/Jenssegers/Mongodb/Query/Builder.php
@@ -144,11 +144,7 @@ class Builder extends BaseBuilder
      */
     protected function shouldUseCollections()
     {
-        if (function_exists('app')) {
-            $version = app()->version();
-            $version = filter_var(explode(')', $version)[0], FILTER_SANITIZE_NUMBER_FLOAT, FILTER_FLAG_ALLOW_FRACTION); // lumen
-            return version_compare($version, '5.3', '>=');
-        }
+        return !interface_exists("Illuminate\Database\Eloquent\ScopeInterface"));
     }
 
     /**


### PR DESCRIPTION
Do not use app function because this function is absent in other frameworks (as silex for example)
We can check if interface exists
casue from laravel code:
```<?php

namespace Illuminate\Database\Eloquent;

/**
 * @deprecated since version 5.2. Use Illuminate\Database\Eloquent\Scope.
 */
interface ScopeInterface extends Scope
{
}