### PR TITLE
Aggregation shouldn't mutate querybuilder

### DIFF
--- a/src/Jenssegers/Mongodb/Query/Builder.php
+++ b/src/Jenssegers/Mongodb/Query/Builder.php
@@ -422,18 +422,28 @@ class Builder extends BaseBuilder
     public function aggregate($function, $columns = [])
     {
         $this->aggregate = compact('function', 'columns');
-
+        
+        $previousColumns = $this->columns;
+        
+        // We will also back up the select bindings since the select clause will be
+        // removed when performing the aggregate function. Once the query is run
+        // we will add the bindings back onto this query so they can get used.
+        $previousSelectBindings = $this->bindings['select'];
+        
+        $this->bindings['select'] = [];
+        
         $results = $this->get($columns);
-
+        
         // Once we have executed the query, we will reset the aggregate property so
         // that more select queries can be executed against the database without
         // the aggregate value getting in the way when the grammar builds it.
-        $this->columns = null;
         $this->aggregate = null;
-
+        $this->columns = $previousColumns;
+        $this->bindings['select'] = $previousSelectBindings;
+        
         if (isset($results[0])) {
             $result = (array) $results[0];
-
+            
             return $result['aggregate'];
         }
     }


### PR DESCRIPTION
Aggregations (like $query->count() ) modifies the internal state of the queryBuilder object, therefore the $query looses eg. the projection.

Eloquent solves this in the following way:
https://github.com/laravel/framework/blob/5.3/src/Illuminate/Database/Query/Builder.php#L2036