### PR TITLE
fix for Argument 2 passed to Illuminate\Auth\Passwords\DatabaseTokenR…

### DIFF
--- a/src/Jenssegers/Mongodb/Auth/DatabaseTokenRepository.php
+++ b/src/Jenssegers/Mongodb/Auth/DatabaseTokenRepository.php
@@ -1,6 +1,5 @@
 <?php namespace Jenssegers\Mongodb\Auth;
 
-use DateTime;
 use DateTimeZone;
 use Illuminate\Auth\Passwords\DatabaseTokenRepository as BaseDatabaseTokenRepository;
 use MongoDB\BSON\UTCDateTime;

--- a/src/Jenssegers/Mongodb/Auth/DatabaseTokenRepository.php
+++ b/src/Jenssegers/Mongodb/Auth/DatabaseTokenRepository.php
@@ -12,7 +12,7 @@ class DatabaseTokenRepository extends BaseDatabaseTokenRepository
      */
     protected function getPayload($email, $token)
     {
-        return ['email' => $email, 'token' => $token, 'created_at' => new UTCDateTime(time() * 1000)];
+        return ['email' => $email, 'token' => $this->hasher->make($token), 'created_at' => new UTCDateTime(time() * 1000)];
     }
 
     /**
@@ -21,14 +21,10 @@ class DatabaseTokenRepository extends BaseDatabaseTokenRepository
     protected function tokenExpired($token)
     {
         // Convert UTCDateTime to a date string.
-        if ($token['created_at'] instanceof UTCDateTime) {
-            $date = $token['created_at']->toDateTime();
+        if ($token instanceof UTCDateTime) {
+            $date = $token->toDateTime();
             $date->setTimezone(new DateTimeZone(date_default_timezone_get()));
-            $token['created_at'] = $date->format('Y-m-d H:i:s');
-        } elseif (is_array($token['created_at']) and isset($token['created_at']['date'])) {
-            $date = new DateTime($token['created_at']['date'], new DateTimeZone(isset($token['created_at']['timezone']) ? $token['created_at']['timezone'] : 'UTC'));
-            $date->setTimezone(new DateTimeZone(date_default_timezone_get()));
-            $token['created_at'] = $date->format('Y-m-d H:i:s');
+            $token = $date->format('Y-m-d H:i:s');
         }
 
         return parent::tokenExpired($token);

--- a/src/Jenssegers/Mongodb/Auth/PasswordBrokerManager.php
+++ b/src/Jenssegers/Mongodb/Auth/PasswordBrokerManager.php
@@ -1,6 +1,7 @@
 <?php namespace Jenssegers\Mongodb\Auth;
 
 use Illuminate\Auth\Passwords\PasswordBrokerManager as BasePasswordBrokerManager;
+use Illuminate\Hashing\BcryptHasher as Hasher;
 
 class PasswordBrokerManager extends BasePasswordBrokerManager
 {
@@ -11,6 +12,7 @@ class PasswordBrokerManager extends BasePasswordBrokerManager
     {
         return new DatabaseTokenRepository(
             $this->app['db']->connection(),
+            new Hasher(),
             $config['table'],
             $this->app['config']['app.key'],
             $config['expire']


### PR DESCRIPTION
fixes #1164 

This worked for me (along with @McMazalf comment) in `laravel/framework v5.4.20`.

Kinda proof of concept, but works as it fills in missing argument for `__construct()` method in `laravel/framework/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php`:
```php
__construct(ConnectionInterface $connection, HasherContract $hasher,
                                $table, $hashKey, $expires = 60
```

Change of `__construct` signature was introduced in laravel/framework@c454c87f75c179043a956071a8572af538c926a9

Change in `src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php` (introduced in laravel/framework@9d674b053145968ff9060b930a644ddd7851d66f) caused update in second file, because now only date is passed to `tokenExpired()` instead of full token: 
```php
$this->tokenExpired($record['created_at'])

// instead of
$this->tokenExpired($record)
```
so it will be never an array.

Also: now tokens kept in DB have to be encrypted by `Hasher`.