### PR TITLE
PHP7 Support for Laravel 4.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ composer.lock
 *.sublime-project
 *.sublime-workspace
 *.project
+/.idea

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "illuminate/support": "4.2.*",
         "illuminate/container": "4.2.*",
         "illuminate/database": "4.2.*",
-        "illuminate/events": "4.2.*"
+        "illuminate/events": "4.2.*",
+        "alcaeus/mongo-php-adapter": "^1.1.0"
     },
     "require-dev": {
         "orchestra/testbench": "2.2.*",

--- a/src/Jenssegers/Mongodb/Collection.php
+++ b/src/Jenssegers/Mongodb/Collection.php
@@ -56,7 +56,22 @@ class Collection {
 
         $start = microtime(true);
 
-        $result = call_user_func_array(array($this->collection, $method), $parameters);
+        //$result = call_user_func_array(array($this->collection, $method), $parameters);
+
+        // Fix for PHP7
+        // https://github.com/LearningLocker/learninglocker/issues/893#issue-203456708
+        // based on https://github.com/alcaeus/mongo-php-adapter/issues/107#issuecomment-219393254
+        if (PHP_VERSION_ID >= 70000 && in_array($method, array('insert', 'batchInsert', 'save'))) {
+            $saveData = array_shift($parameters);
+            $saveParams = array_shift($parameters);
+            if (NULL==$saveParams) {
+                $saveParams = array();
+            }
+            $result = call_user_func_array(array($this->collection, $method), array(&$saveData, $saveParams));
+        } else {
+            $result = call_user_func_array(array($this->collection, $method), $parameters);
+        }
+
 
         // Once we have run the query we will calculate the time that it took to run and
         // then log the query, bindings, and execution time so we will report them on


### PR DESCRIPTION
This pull request aims to bring PHP7 support for Laravel 4.2 packages, which officially support PHP7.

All credits goes to @glowdan from his comment here: https://github.com/alcaeus/mongo-php-adapter/issues/107#issuecomment-219393254 

Also, another discussion regarding this issue here: https://github.com/LearningLocker/learninglocker/issues/893

If this specific version is selected as requirement, this may break compatibility with PHP versions lower than 5.6, and since there hasn't been an update to 2.0 branch for a while, I believe, if this would be accepted, a simple note would suffice for users.

Thanks in advance,