### PR TITLE
Laravel Auth Password Reset Exception

### DIFF
--- a/src/Jenssegers/Mongodb/Auth/PasswordBrokerManager.php
+++ b/src/Jenssegers/Mongodb/Auth/PasswordBrokerManager.php
@@ -11,6 +11,7 @@ class PasswordBrokerManager extends BasePasswordBrokerManager
     {
         return new DatabaseTokenRepository(
             $this->app['db']->connection(),
+            new \Illuminate\Hashing\BcryptHasher,
             $config['table'],
             $this->app['config']['app.key'],
             $config['expire']


### PR DESCRIPTION
This fixes:

```
(1/1) ErrorException
Argument 2 passed to Illuminate\Auth\Passwords\DatabaseTokenRepository::__construct() must implement interface Illuminate\Contracts\Hashing\Hasher, string given, called in C:\laragon\www\pinpacker2\vendor\jenssegers\mongodb\src\Jenssegers\Mongodb\Auth\PasswordBrokerManager.php on line 17 and defined
in DatabaseTokenRepository.php (line 58)
at HandleExceptions->handleError(4096, 'Argument 2 passed to Illuminate\\Auth\\Passwords\\DatabaseTokenRepository::__construct() must implement interface Illuminate\\Contracts\\Hashing\\Hasher, string given, called in C:\\laragon\\www\\pinpacker2\\vendor\\jenssegers\\mongodb\\src\\Jenssegers\\Mongodb\\Auth\\PasswordBrokerManager.php on line 17 and defined', 'C:\\laragon\\www\\pinpacker2\\vendor\\laravel\\framework\\src\\Illuminate\\Auth\\Passwords\\DatabaseTokenRepository.php', 58, array('connection' => object(Connection)))
in DatabaseTokenRepository.php (line 58)

```
exception when using laravel 5.4 + mongodb auth password reset form.