### PR TITLE
Add default attribute to `EmbedsOneOrMany::create` method

### DIFF
--- a/src/Jenssegers/Mongodb/Relations/EmbedsOneOrMany.php
+++ b/src/Jenssegers/Mongodb/Relations/EmbedsOneOrMany.php
@@ -143,7 +143,7 @@ abstract class EmbedsOneOrMany extends Relation
      * @param  array $attributes
      * @return Model
      */
-    public function create(array $attributes)
+    public function create(array $attributes = [])
     {
         // Here we will set the raw attributes to avoid hitting the "fill" method so
         // that we do not have to worry about a mass accessor rules blocking sets


### PR DESCRIPTION
This brings it inline with the base Eloquent `create` method, and allows us to call this method without providing any attributes.