### PR TITLE
Fix: Missing return statement

### DIFF
--- a/src/Jenssegers/Mongodb/Eloquent/Model.php
+++ b/src/Jenssegers/Mongodb/Eloquent/Model.php
@@ -175,7 +175,7 @@ abstract class Model extends BaseModel
             return;
         }
 
-        parent::setAttribute($key, $value);
+        return parent::setAttribute($key, $value);
     }
 
     /**


### PR DESCRIPTION
The parent setter returns $this which is not returned in the current method.