### PR TITLE
fix HybridRelations::belongsToMany not compatible with Model::belongsToMany 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,10 +11,10 @@
     ],
     "license" : "MIT",
     "require": {
-        "illuminate/support": "^5.1",
-        "illuminate/container": "^5.1",
-        "illuminate/database": "^5.1",
-        "illuminate/events": "^5.1",
+        "illuminate/support": "^5.5",
+        "illuminate/container": "^5.5",
+        "illuminate/database": "^5.5",
+        "illuminate/events": "^5.5",
         "mongodb/mongodb": "^1.0.0"
     },
     "require-dev": {

--- a/src/Jenssegers/Mongodb/Eloquent/HybridRelations.php
+++ b/src/Jenssegers/Mongodb/Eloquent/HybridRelations.php
@@ -204,17 +204,20 @@ trait HybridRelations
         }
     }
 
-    /**
+    **
      * Define a many-to-many relationship.
      *
      * @param  string $related
      * @param  string $collection
-     * @param  string $foreignKey
-     * @param  string $otherKey
+     * @param  string $foreignPivotKey
+     * @param  string $relatedPivotKey
+     * @param  string $parentKey
+     * @param  string $relatedKey
      * @param  string $relation
      * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
      */
-    public function belongsToMany($related, $collection = null, $foreignKey = null, $otherKey = null, $relation = null)
+    public function belongsToMany($related, $collection = null, $foreignPivotKey = null, $relatedPivotKey = null,
+                                      $parentKey = null, $relatedKey = null, $relation = null)
     {
         // If no relationship name was passed, we will pull backtraces to get the
         // name of the calling function. We will use that function name as the
@@ -225,17 +228,18 @@ trait HybridRelations
 
         // Check if it is a relation with an original model.
         if (! is_subclass_of($related, \Jenssegers\Mongodb\Eloquent\Model::class)) {
-            return parent::belongsToMany($related, $collection, $foreignKey, $otherKey, $relation);
+            return parent::belongsToMany($related, $collection = null, $foreignPivotKey = null, $relatedPivotKey = null,
+                $parentKey = null, $relatedKey = null, $relation = null);
         }
 
         // First, we'll need to determine the foreign key and "other key" for the
         // relationship. Once we have determined the keys we'll make the query
         // instances as well as the relationship instances we need for this.
-        $foreignKey = $foreignKey ?: $this->getForeignKey().'s';
+        $foreignPivotKey = $foreignPivotKey ?: $this->getForeignKey().'s';
 
         $instance = new $related;
 
-        $otherKey = $otherKey ?: $instance->getForeignKey().'s';
+        $relatedPivotKey = $relatedPivotKey ?: $instance->getForeignKey().'s';
 
         // If no table name was provided, we can guess it by concatenating the two
         // models using underscores in alphabetical order. The two model names
@@ -249,7 +253,9 @@ trait HybridRelations
         // appropriate query constraint and entirely manages the hydrations.
         $query = $instance->newQuery();
 
-        return new BelongsToMany($query, $this, $collection, $foreignKey, $otherKey, $relation);
+        return new BelongsToMany($query, $this, $collection,
+            $foreignPivotKey, $relatedPivotKey,
+            $parentKey, $relatedKey, $relation);
     }
 
     /**

--- a/src/Jenssegers/Mongodb/Eloquent/HybridRelations.php
+++ b/src/Jenssegers/Mongodb/Eloquent/HybridRelations.php
@@ -204,7 +204,7 @@ trait HybridRelations
         }
     }
 
-    **
+    /**
      * Define a many-to-many relationship.
      *
      * @param  string $related


### PR DESCRIPTION
This should fix issue #1273 for Laravel 5.5.
This is incompatible with Laravel < 5.5 so it couldn't be used for v 3.2.*