### PR TITLE
Support Laravel 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,11 +11,12 @@
     ],
     "license" : "MIT",
     "require": {
-        "illuminate/support": "^5.1",
-        "illuminate/container": "^5.1",
-        "illuminate/database": "^5.1",
-        "illuminate/events": "^5.1",
-        "mongodb/mongodb": "^1.0.0"
+        "illuminate/support": "^5.5",
+        "illuminate/container": "^5.5",
+        "illuminate/database": "^5.5",
+        "illuminate/events": "^5.5",
+        "mongodb/mongodb": "^1.0.0",
+        "doctrine/dbal": "^2.5"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.0|^6.0",

--- a/src/Jenssegers/Mongodb/Eloquent/Builder.php
+++ b/src/Jenssegers/Mongodb/Eloquent/Builder.php
@@ -29,6 +29,7 @@ class Builder extends EloquentBuilder
         'exists',
         'push',
         'pull',
+        'getConnection',
     ];
 
     /**

--- a/src/Jenssegers/Mongodb/Eloquent/HybridRelations.php
+++ b/src/Jenssegers/Mongodb/Eloquent/HybridRelations.php
@@ -217,7 +217,7 @@ trait HybridRelations
      * @param  string $relation
      * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
      */
-    public function belongsToMany($related, $collection = null, $foreignKey = null, $otherKey = null, $relation = null)
+    public function belongsToMany($related, $collection = null, $foreignKey = null, $otherKey = null, $parentKey = null, $relatedKey = null, $relation = null)
     {
         // If no relationship name was passed, we will pull backtraces to get the
         // name of the calling function. We will use that function name as the
@@ -228,7 +228,7 @@ trait HybridRelations
 
         // Check if it is a relation with an original model.
         if (!is_subclass_of($related, \Jenssegers\Mongodb\Eloquent\Model::class)) {
-            return parent::belongsToMany($related, $collection, $foreignKey, $otherKey, $relation);
+            return parent::belongsToMany($related, $collection, $foreignKey, $otherKey, $parentKey, $relatedKey, $relation);
         }
 
         // First, we'll need to determine the foreign key and "other key" for the
@@ -252,7 +252,7 @@ trait HybridRelations
         // appropriate query constraint and entirely manages the hydrations.
         $query = $instance->newQuery();
 
-        return new BelongsToMany($query, $this, $collection, $foreignKey, $otherKey, $relation);
+        return new BelongsToMany($query, $this, $collection, $foreignKey, $otherKey, $parentKey, $relatedKey, $relation);
     }
 
     /**

--- a/src/Jenssegers/Mongodb/Eloquent/HybridRelations.php
+++ b/src/Jenssegers/Mongodb/Eloquent/HybridRelations.php
@@ -240,6 +240,11 @@ trait HybridRelations
 
         $otherKey = $otherKey ?: $instance->getForeignKey() . 's';
 
+        // We need to feed the primary key to the relationship
+        $parentKey = $this->getKeyName();
+
+        $relatedKey = $otherKey;
+
         // If no table name was provided, we can guess it by concatenating the two
         // models using underscores in alphabetical order. The two model names
         // are transformed to snake case from their default CamelCase also.

--- a/src/Jenssegers/Mongodb/Relations/BelongsToMany.php
+++ b/src/Jenssegers/Mongodb/Relations/BelongsToMany.php
@@ -184,7 +184,7 @@ class BelongsToMany extends EloquentBelongsToMany
             $id = $model->getKey();
 
             // Attach the new parent id to the related model.
-            $model->push($this->foreignKey, $this->parent->getKey(), true);
+            $model->push($this->foreignPivotKey, $this->parent->getKey(), true);
         } else {
             if ($id instanceof Collection) {
                 $id = $id->modelKeys();
@@ -195,7 +195,7 @@ class BelongsToMany extends EloquentBelongsToMany
             $query->whereIn($this->related->getKeyName(), (array) $id);
 
             // Attach the new parent id to the related model.
-            $query->push($this->foreignKey, $this->parent->getKey(), true);
+            $query->push($this->foreignPivotKey, $this->parent->getKey(), true);
         }
 
         // Attach the new ids to the parent model.
@@ -231,7 +231,7 @@ class BelongsToMany extends EloquentBelongsToMany
         }
 
         // Remove the relation to the parent.
-        $query->pull($this->foreignKey, $this->parent->getKey());
+        $query->pull($this->foreignPivotKey, $this->parent->getKey());
 
         if ($touch) {
             $this->touchIfTouching();
@@ -245,7 +245,7 @@ class BelongsToMany extends EloquentBelongsToMany
      */
     protected function buildDictionary(Collection $results)
     {
-        $foreign = $this->foreignKey;
+        $foreign = $this->foreignPivotKey;
 
         // First we will build a dictionary of child models keyed by the foreign key
         // of the relation so that we will easily and quickly match them to their
@@ -286,7 +286,7 @@ class BelongsToMany extends EloquentBelongsToMany
      */
     public function getForeignKey()
     {
-        return $this->foreignKey;
+        return $this->foreignPivotKey;
     }
 
     /**
@@ -294,7 +294,7 @@ class BelongsToMany extends EloquentBelongsToMany
      */
     public function getQualifiedForeignKeyName()
     {
-        return $this->foreignKey;
+        return $this->foreignPivotKey;
     }
 
     /**
@@ -324,6 +324,6 @@ class BelongsToMany extends EloquentBelongsToMany
      */
     public function getRelatedKey()
     {
-        return property_exists($this, 'relatedKey') ? $this->relatedKey : $this->otherKey;
+        return property_exists($this, 'relatedPivotKey') ? $this->relatedPivotKey : $this->relatedKey;
     }
 }

--- a/src/Jenssegers/Mongodb/Relations/BelongsToMany.php
+++ b/src/Jenssegers/Mongodb/Relations/BelongsToMany.php
@@ -93,7 +93,7 @@ class BelongsToMany extends EloquentBelongsToMany
     /**
      * @inheritdoc
      */
-    public function create(array $attributes, array $joining = [], $touch = true)
+    public function create(array $attributes = [], array $joining = [], $touch = true)
     {
         $instance = $this->related->newInstance($attributes);
 

--- a/src/Jenssegers/Mongodb/Relations/BelongsToMany.php
+++ b/src/Jenssegers/Mongodb/Relations/BelongsToMany.php
@@ -298,6 +298,14 @@ class BelongsToMany extends EloquentBelongsToMany
     }
 
     /**
+     * @inheritdoc
+     */
+    public function getQualifiedForeignPivotKeyName()
+    {
+        return $this->foreignPivotKey;
+    }
+
+    /**
      * Format the sync list so that it is keyed by ID. (Legacy Support)
      * The original function has been renamed to formatRecordsList since Laravel 5.3
      *

--- a/src/Jenssegers/Mongodb/Relations/EmbedsOneOrMany.php
+++ b/src/Jenssegers/Mongodb/Relations/EmbedsOneOrMany.php
@@ -96,7 +96,7 @@ abstract class EmbedsOneOrMany extends Relation
      *
      * @return Collection
      */
-    public function get()
+    public function get($columns = [])
     {
         return $this->getResults();
     }
@@ -120,7 +120,7 @@ abstract class EmbedsOneOrMany extends Relation
     public function save(Model $model)
     {
         $model->setParentRelation($this);
-
+        
         return $model->save() ? $model : false;
     }
 

--- a/tests/EmbeddedRelationsTest.php
+++ b/tests/EmbeddedRelationsTest.php
@@ -217,6 +217,7 @@ class EmbeddedRelationsTest extends TestCase
         $address->setEventDispatcher($events = Mockery::mock('Illuminate\Events\Dispatcher'));
         $events->shouldReceive('until')->once()->with('eloquent.deleting: ' . get_class($address), Mockery::type('Address'))->andReturn(true);
         $events->shouldReceive('fire')->once()->with('eloquent.deleted: ' . get_class($address), Mockery::type('Address'));
+        $events->shouldReceive('fire')->with('eloquent.retrieved: ' . get_class($address), anything());
 
         $user->addresses()->destroy($address->_id);
         $this->assertEquals(['Bristol', 'Bruxelles'], $user->addresses->pluck('city')->all());
@@ -255,7 +256,7 @@ class EmbeddedRelationsTest extends TestCase
         $address->setEventDispatcher($events = Mockery::mock('Illuminate\Events\Dispatcher'));
         $events->shouldReceive('until')->once()->with('eloquent.deleting: ' . get_class($address), Mockery::type('Address'))->andReturn(true);
         $events->shouldReceive('fire')->with('eloquent.deleted: ' . get_class($address), Mockery::type('Address'));
-
+        $events->shouldReceive('fire')->with('eloquent.retrieved: ' . get_class($address), anything());
 
         $address->delete();
 
@@ -347,6 +348,7 @@ class EmbeddedRelationsTest extends TestCase
 
         $address->setEventDispatcher($events = Mockery::mock('Illuminate\Events\Dispatcher'));
         $events->shouldReceive('until')->once()->with('eloquent.deleting: ' . get_class($address), Mockery::mustBe($address))->andReturn(false);
+        $events->shouldReceive('fire')->with('eloquent.retrieved: ' . get_class($address), anything());
 
         $this->assertEquals(0, $user->addresses()->destroy($address));
         $this->assertEquals(['New York'], $user->addresses->pluck('city')->all());
@@ -453,6 +455,7 @@ class EmbeddedRelationsTest extends TestCase
         $events->shouldReceive('until')->once()->with('eloquent.creating: ' . get_class($father), $father)->andReturn(true);
         $events->shouldReceive('fire')->once()->with('eloquent.created: ' . get_class($father), $father);
         $events->shouldReceive('fire')->once()->with('eloquent.saved: ' . get_class($father), $father);
+        $events->shouldReceive('fire')->once()->with('eloquent.retrieved: ' . get_class($father), anything());
 
         $father = $user->father()->save($father);
         $father->unsetEventDispatcher();
@@ -472,6 +475,7 @@ class EmbeddedRelationsTest extends TestCase
         $events->shouldReceive('until')->once()->with('eloquent.updating: ' . get_class($father), $father)->andReturn(true);
         $events->shouldReceive('fire')->once()->with('eloquent.updated: ' . get_class($father), $father);
         $events->shouldReceive('fire')->once()->with('eloquent.saved: ' . get_class($father), $father);
+        $events->shouldReceive('fire')->once()->with('eloquent.retrieved: ' . get_class($father), anything());
 
         $father->name = 'Tom Doe';
         $user->father()->save($father);
@@ -487,6 +491,7 @@ class EmbeddedRelationsTest extends TestCase
         $events->shouldReceive('until')->once()->with('eloquent.creating: ' . get_class($father), $father)->andReturn(true);
         $events->shouldReceive('fire')->once()->with('eloquent.created: ' . get_class($father), $father);
         $events->shouldReceive('fire')->once()->with('eloquent.saved: ' . get_class($father), $father);
+        $events->shouldReceive('fire')->once()->with('eloquent.retrieved: ' . get_class($father), anything());
 
         $father = $user->father()->save($father);
         $father->unsetEventDispatcher();
@@ -502,6 +507,7 @@ class EmbeddedRelationsTest extends TestCase
 
         $father->setEventDispatcher($events = Mockery::mock('Illuminate\Events\Dispatcher'));
         $events->shouldReceive('until')->times(0)->with('eloquent.saving: ' . get_class($father), $father);
+        $events->shouldReceive('fire')->with('eloquent.retrieved: ' . get_class($father), anything());
 
         $father = $user->father()->associate($father);
         $father->unsetEventDispatcher();

--- a/tests/EmbeddedRelationsTest.php
+++ b/tests/EmbeddedRelationsTest.php
@@ -19,14 +19,15 @@ class EmbeddedRelationsTest extends TestCase
     {
         $user = User::create(['name' => 'John Doe']);
         $address = new Address(['city' => 'London']);
-
         $address->setEventDispatcher($events = Mockery::mock('Illuminate\Events\Dispatcher'));
+
         $events->shouldReceive('until')->once()->with('eloquent.saving: ' . get_class($address), $address)->andReturn(true);
         $events->shouldReceive('until')->once()->with('eloquent.creating: ' . get_class($address), $address)->andReturn(true);
         $events->shouldReceive('fire')->once()->with('eloquent.created: ' . get_class($address), $address);
         $events->shouldReceive('fire')->once()->with('eloquent.saved: ' . get_class($address), $address);
-
+        $events->shouldReceive('fire')->once()->with('eloquent.retrieved: ' . get_class($address), anything());
         $address = $user->addresses()->save($address);
+   
         $address->unsetEventDispatcher();
 
         $this->assertNotNull($user->addresses);
@@ -50,9 +51,12 @@ class EmbeddedRelationsTest extends TestCase
         $events->shouldReceive('until')->once()->with('eloquent.updating: ' . get_class($address), $address)->andReturn(true);
         $events->shouldReceive('fire')->once()->with('eloquent.updated: ' . get_class($address), $address);
         $events->shouldReceive('fire')->once()->with('eloquent.saved: ' . get_class($address), $address);
+        $events->shouldReceive('fire')->once()->with('eloquent.retrieved: ' . get_class($address), anything());
 
         $address->city = 'New York';
+
         $user->addresses()->save($address);
+
         $address->unsetEventDispatcher();
 
         $this->assertEquals(2, count($user->addresses));
@@ -250,7 +254,8 @@ class EmbeddedRelationsTest extends TestCase
 
         $address->setEventDispatcher($events = Mockery::mock('Illuminate\Events\Dispatcher'));
         $events->shouldReceive('until')->once()->with('eloquent.deleting: ' . get_class($address), Mockery::type('Address'))->andReturn(true);
-        $events->shouldReceive('fire')->once()->with('eloquent.deleted: ' . get_class($address), Mockery::type('Address'));
+        $events->shouldReceive('fire')->with('eloquent.deleted: ' . get_class($address), Mockery::type('Address'));
+
 
         $address->delete();
 

--- a/tests/RelationsTest.php
+++ b/tests/RelationsTest.php
@@ -155,7 +155,7 @@ class RelationsTest extends TestCase
         // Add 2 clients
         $user->clients()->save(new Client(['name' => 'Pork Pies Ltd.']));
         $user->clients()->create(['name' => 'Buffet Bar Inc.']);
-
+        
         // Refetch
         $user = User::with('clients')->find($user->_id);
         $client = Client::with('users')->first();

--- a/tests/RelationsTest.php
+++ b/tests/RelationsTest.php
@@ -169,10 +169,10 @@ class RelationsTest extends TestCase
 
         $this->assertInstanceOf('Illuminate\Database\Eloquent\Collection', $users);
         $this->assertInstanceOf('Illuminate\Database\Eloquent\Collection', $clients);
-        $this->assertInstanceOf('Client', $clients[0]);
-        $this->assertInstanceOf('User', $users[0]);
         $this->assertCount(2, $user->clients);
         $this->assertCount(1, $client->users);
+        $this->assertInstanceOf('Client', $clients[0]);
+        $this->assertInstanceOf('User', $users[0]);
 
         // Now create a new user to an existing client
         $user = $client->users()->create(['name' => 'Jane Doe']);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -64,4 +64,18 @@ class TestCase extends Orchestra\Testbench\TestCase
             'expire' => 60,
         ]);
     }
+
+    /**
+     * Enable query dumping for easier debbuging
+     * 
+     * @return void
+     */
+    protected function enableQueryDump()
+    {
+        $db = $this->app->make('db');
+        $db->connection('mongodb')->enableQueryLog();
+        $db->listen(function ($query) {
+            dump($query->sql);
+        });
+    }
 }


### PR DESCRIPTION
This is a work in progress. 

`belongsToMany` and `embedsMany` relationship are broken, probably due to some changes in Eloquent's internal behavior. 

@jenssegers : just opening this in case anyone want to contribute. of course it's not ready for merging yet. 
