### PR TITLE
Fix issue with chunkById.

### DIFF
--- a/src/Jenssegers/Mongodb/Eloquent/Builder.php
+++ b/src/Jenssegers/Mongodb/Eloquent/Builder.php
@@ -146,6 +146,14 @@ class Builder extends EloquentBuilder
     /**
      * @inheritdoc
      */
+    public function chunkById($count, callable $callback, $column = '_id', $alias = null)
+    {
+        return parent::chunkById($count, $callback, $column, $alias);
+    }
+
+    /**
+     * @inheritdoc
+     */
     public function raw($expression = null)
     {
         // Get raw results from the query builder.

--- a/src/Jenssegers/Mongodb/Query/Builder.php
+++ b/src/Jenssegers/Mongodb/Query/Builder.php
@@ -603,6 +603,28 @@ class Builder extends BaseBuilder
     /**
      * @inheritdoc
      */
+    public function chunkById($count, callable $callback, $column = '_id', $alias = null)
+    {
+        return parent::chunkById($count, $callback, $column, $alias);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function forPageAfterId($perPage = 15, $lastId = 0, $column = '_id')
+    {
+        // When using ObjectIDs to paginate, we need to use a hex string as the
+        // "minimum" ID rather than the integer zero so the '$lt' query works.
+        if ($column === '_id' && $lastId === 0) {
+            $lastId = '000000000000000000000000';
+        }
+
+        return parent::forPageAfterId($perPage, $lastId, $column);
+    }
+
+    /**
+     * @inheritdoc
+     */
     public function pluck($column, $key = null)
     {
         $results = $this->get(is_null($key) ? [$column] : [$column, $key]);

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -534,4 +534,18 @@ class ModelTest extends TestCase
         $user->birthday = new DateTime('19 august 1989');
         $this->assertEmpty($user->getDirty());
     }
+
+    public function testChunkById()
+    {
+        User::create(['name' => 'fork',  'tags' => ['sharp', 'pointy']]);
+        User::create(['name' => 'spork', 'tags' => ['sharp', 'pointy', 'round', 'bowl']]);
+        User::create(['name' => 'spoon', 'tags' => ['round', 'bowl']]);
+
+        $count = 0;
+        User::chunkById(2, function ($items) use (&$count) {
+            $count += count($items);
+        });
+
+        $this->assertEquals(3, $count);
+    }
 }


### PR DESCRIPTION
The `chunkById` method doesn't work with MongoDB, because the framework [assumes that the ID will be numeric](https://github.com/laravel/framework/blob/997e67cc2001006a43b73eaedf17fa1a2555fd66/src/Illuminate/Database/Query/Builder.php#L1836) & doesn't provide an easy way for the user to override that at runtime. I was able to fix this by overriding the [`forPageAfterId`](https://github.com/laravel/framework/blob/997e67cc2001006a43b73eaedf17fa1a2555fd66/src/Illuminate/Database/Query/Builder.php#L1541-L1556) method so that it would convert Laravel's assumed "zero" ID into an equivalent "zero" ObjectId.

I've also added a test to demonstrate the bug & fix.