### PR TITLE
fix for returning incorrect builder in hybrid relations

### DIFF
--- a/src/Jenssegers/Mongodb/Eloquent/HybridRelations.php
+++ b/src/Jenssegers/Mongodb/Eloquent/HybridRelations.php
@@ -5,6 +5,7 @@ namespace Jenssegers\Mongodb\Eloquent;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Support\Str;
+use Jenssegers\Mongodb\Eloquent\Builder;
 use Jenssegers\Mongodb\Helpers\EloquentBuilder;
 use Jenssegers\Mongodb\Relations\BelongsTo;
 use Jenssegers\Mongodb\Relations\BelongsToMany;
@@ -300,6 +301,10 @@ trait HybridRelations
      */
     public function newEloquentBuilder($query)
     {
-        return new EloquentBuilder($query);
+        if (is_subclass_of($this, \Jenssegers\Mongodb\Eloquent\Model::class)) {
+            return new Builder($query);
+        } else {
+            return new EloquentBuilder($query);
+        }
     }
 }

--- a/src/Jenssegers/Mongodb/Eloquent/HybridRelations.php
+++ b/src/Jenssegers/Mongodb/Eloquent/HybridRelations.php
@@ -5,7 +5,6 @@ namespace Jenssegers\Mongodb\Eloquent;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Support\Str;
-use Jenssegers\Mongodb\Eloquent\Builder;
 use Jenssegers\Mongodb\Helpers\EloquentBuilder;
 use Jenssegers\Mongodb\Relations\BelongsTo;
 use Jenssegers\Mongodb\Relations\BelongsToMany;

--- a/tests/models/User.php
+++ b/tests/models/User.php
@@ -9,8 +9,7 @@ use Illuminate\Contracts\Auth\CanResetPassword as CanResetPasswordContract;
 
 class User extends Eloquent implements AuthenticatableContract, CanResetPasswordContract
 {
-    use Authenticatable, CanResetPassword;
-    use HybridRelations;
+    use Authenticatable, CanResetPassword, HybridRelations;
 
     protected $connection = 'mongodb';
     protected $dates = ['birthday', 'entry.date'];

--- a/tests/models/User.php
+++ b/tests/models/User.php
@@ -1,6 +1,7 @@
 <?php
 
 use Jenssegers\Mongodb\Eloquent\Model as Eloquent;
+use Jenssegers\Mongodb\Eloquent\HybridRelations;
 use Illuminate\Auth\Authenticatable;
 use Illuminate\Auth\Passwords\CanResetPassword;
 use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
@@ -9,6 +10,7 @@ use Illuminate\Contracts\Auth\CanResetPassword as CanResetPasswordContract;
 class User extends Eloquent implements AuthenticatableContract, CanResetPasswordContract
 {
     use Authenticatable, CanResetPassword;
+    use HybridRelations;
 
     protected $connection = 'mongodb';
     protected $dates = ['birthday', 'entry.date'];


### PR DESCRIPTION
@jenssegers @Tucker-Eric 

Commit 266305caeed70cf8ee787bcd0140c9fca2f0bcd6 introduced a bug when using HybridRelations in combination with e.g. raw methods. The `newEloquentBuilder` method always returned a `Illuminate\Database\Eloquent\Builder` but for `Jenssegers\Mongodb\Eloquent\Model` models it should return a `Jenssegers\Mongodb\Eloquent\Builder`.