### PR TITLE
Fix for issue #1276

### DIFF
--- a/src/Jenssegers/Mongodb/Query/Builder.php
+++ b/src/Jenssegers/Mongodb/Query/Builder.php
@@ -910,6 +910,12 @@ class Builder extends BaseBuilder
                         $where['value'] = new UTCDateTime($where['value']->getTimestamp() * 1000);
                     }
                 }
+            } elseif (isset($where['values'])) {
+                array_walk_recursive($where['values'], function (&$item, $key) {
+                    if ($item instanceof DateTime) {
+                        $item = new UTCDateTime($item->getTimestamp() * 1000);
+                    }
+                });
             }
 
             // The next item in a "chain" of wheres devices the boolean of the


### PR DESCRIPTION
This fixes the `DateTime` issue (#1276) that occurs when using methods like `whereBetween()` that sets the `values` field instead of the `value` field when compiling "wheres."