### PR TITLE
Fix Unable to set a custom collection for models

### DIFF
--- a/src/Jenssegers/Mongodb/Relations/EmbedsOneOrMany.php
+++ b/src/Jenssegers/Mongodb/Relations/EmbedsOneOrMany.php
@@ -267,7 +267,7 @@ abstract class EmbedsOneOrMany extends Relation
             $models = $this->eagerLoadRelations($models);
         }
 
-        return new Collection($models);
+        return $this->related->newCollection($models);
     }
 
     /**


### PR DESCRIPTION
Laravel allows models to define a custom collection class. However, at the moment the Collection class name is hard-coded breaking this functionality.

This PR calls the related model's newCollection method to return a collection.

See https://laravel.com/docs/5.5/eloquent-collections#custom-collections