### PR TITLE
Updated to Mockery 1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require-dev": {
         "phpunit/phpunit": "^6.0",
         "orchestra/testbench": "^3.1",
-        "mockery/mockery": "^0.9",
+        "mockery/mockery": "^1.0",
         "satooshi/php-coveralls": "^1.0",
         "doctrine/dbal": "^2.5"
     },


### PR DESCRIPTION
Updated `mockery/mockery` to [`^1.0`](https://github.com/mockery/mockery/releases/tag/1.0).