### PR TITLE
Convert ALL DateTime values to UTCDateTime in Query\Builder::compileWheres

### DIFF
--- a/src/Jenssegers/Mongodb/Query/Builder.php
+++ b/src/Jenssegers/Mongodb/Query/Builder.php
@@ -920,6 +920,13 @@ class Builder extends BaseBuilder
             }
 
             // Convert DateTime values to UTCDateTime.
+            if (isset($where['values'])) {
+                array_walk_recursive($where['values'], function (&$item, $key) {
+                    if ($item instanceof DateTime) {
+                        $item = new UTCDateTime($item->getTimestamp() * 1000);
+                    }
+                });
+            }
             if (isset($where['value'])) {
                 if (is_array($where['value'])) {
                     array_walk_recursive($where['value'], function (&$item, $key) {


### PR DESCRIPTION
```
$builder->where('timestamp', '>=', $carbonDateObject1)->where('timestamp', '<=', $carbonDateObject2)
```
was working, but
```
$builder->whereBetween('timestamp', [$carbonDateObject1, $carbonDateObject2])
```
wasn't.

This was because in the `compileWheres` function only converted `$where['value']` to `UTCDateTime`, but not `$where['values']`, where the former was filled in easy queries and the latter one in between queries. MongoDB then couldn't handle the given [Carbon](http://carbon.nesbot.com/) objects (possibly autoconverted to strings)