### PR TITLE
Change Carbon include to fix SerializeUsing & jsonSerialize incosistency

### DIFF
--- a/src/Jenssegers/Mongodb/Eloquent/Model.php
+++ b/src/Jenssegers/Mongodb/Eloquent/Model.php
@@ -2,7 +2,7 @@
 
 namespace Jenssegers\Mongodb\Eloquent;
 
-use Carbon\Carbon;
+use Illuminate\Support\Carbon;
 use DateTime;
 use Illuminate\Database\Eloquent\Model as BaseModel;
 use Illuminate\Database\Eloquent\Relations\Relation;


### PR DESCRIPTION
Changed the Carbon include to use the extended version of Laravel.

`use Carbon\Carbon  => use Illuminate\Support\Carbon`

This way we can use the `jsonSerialize()` and  `serializeUsing()`. methods

For example in the new ApiResources in Laravel 5.5 we can specify a global serialization for Carbon dates: 
```
   
Carbon::serializeUsing(function ($carbon) {
            return $carbon->format('U');
        });
```

https://laravel.com/docs/5.5/eloquent-serialization#date-serialization