### PR TITLE
Refactoring tests

### DIFF
--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -44,7 +44,7 @@ class ConnectionTest extends TestCase
     // public function testDynamic()
     // {
     //     $dbs = DB::connection('mongodb')->listCollections();
-    //     $this->assertTrue(is_array($dbs));
+    //     $this->assertInternalType('array', $dbs);
     // }
 
     // public function testMultipleConnections()
@@ -59,29 +59,29 @@ class ConnectionTest extends TestCase
     //     $mongoclient = $connection->getMongoClient();
 
     //     $hosts = $mongoclient->getHosts();
-    //     $this->assertEquals(1, count($hosts));
+    //     $this->assertCount(1, $hosts);
     // }
 
     public function testQueryLog()
     {
         DB::enableQueryLog();
 
-        $this->assertEquals(0, count(DB::getQueryLog()));
+        $this->assertCount(0, DB::getQueryLog());
 
         DB::collection('items')->get();
-        $this->assertEquals(1, count(DB::getQueryLog()));
+        $this->assertCount(1, DB::getQueryLog());
 
         DB::collection('items')->insert(['name' => 'test']);
-        $this->assertEquals(2, count(DB::getQueryLog()));
+        $this->assertCount(2, DB::getQueryLog());
 
         DB::collection('items')->count();
-        $this->assertEquals(3, count(DB::getQueryLog()));
+        $this->assertCount(3, DB::getQueryLog());
 
         DB::collection('items')->where('name', 'test')->update(['name' => 'test']);
-        $this->assertEquals(4, count(DB::getQueryLog()));
+        $this->assertCount(4, DB::getQueryLog());
 
         DB::collection('items')->where('name', 'test')->delete();
-        $this->assertEquals(5, count(DB::getQueryLog()));
+        $this->assertCount(5, DB::getQueryLog());
     }
 
     public function testSchemaBuilder()

--- a/tests/EmbeddedRelationsTest.php
+++ b/tests/EmbeddedRelationsTest.php
@@ -36,7 +36,7 @@ class EmbeddedRelationsTest extends TestCase
         $this->assertInstanceOf('DateTime', $address->created_at);
         $this->assertInstanceOf('DateTime', $address->updated_at);
         $this->assertNotNull($address->_id);
-        $this->assertTrue(is_string($address->_id));
+        $this->assertInternalType('string', $address->_id);
 
         $raw = $address->getAttributes();
         $this->assertInstanceOf('MongoDB\BSON\ObjectID', $raw['_id']);
@@ -57,8 +57,8 @@ class EmbeddedRelationsTest extends TestCase
         $user->addresses()->save($address);
         $address->unsetEventDispatcher();
 
-        $this->assertEquals(2, count($user->addresses));
-        $this->assertEquals(2, count($user->addresses()->get()));
+        $this->assertCount(2, $user->addresses);
+        $this->assertCount(2, $user->addresses()->get());
         $this->assertEquals(2, $user->addresses->count());
         $this->assertEquals(2, $user->addresses()->count());
         $this->assertEquals(['London', 'New York'], $user->addresses->pluck('city')->all());
@@ -115,8 +115,8 @@ class EmbeddedRelationsTest extends TestCase
         $user->addresses()->saveMany([new Address(['city' => 'London']), new Address(['city' => 'Bristol'])]);
 
         $array = $user->toArray();
-        $this->assertFalse(array_key_exists('_addresses', $array));
-        $this->assertTrue(array_key_exists('addresses', $array));
+        $this->assertArrayNotHasKey('_addresses', $array);
+        $this->assertArrayHasKey('addresses', $array);
     }
 
     public function testEmbedsManyAssociate()
@@ -176,7 +176,7 @@ class EmbeddedRelationsTest extends TestCase
         $user = User::create([]);
         $address = $user->addresses()->create(['city' => 'Bruxelles']);
         $this->assertInstanceOf('Address', $address);
-        $this->assertTrue(is_string($address->_id));
+        $this->assertInternalType('string', $address->_id);
         $this->assertEquals(['Bruxelles'], $user->addresses->pluck('city')->all());
 
         $raw = $address->getAttributes();
@@ -187,7 +187,7 @@ class EmbeddedRelationsTest extends TestCase
 
         $user = User::create([]);
         $address = $user->addresses()->create(['_id' => '', 'city' => 'Bruxelles']);
-        $this->assertTrue(is_string($address->_id));
+        $this->assertInternalType('string', $address->_id);
 
         $raw = $address->getAttributes();
         $this->assertInstanceOf('MongoDB\BSON\ObjectID', $raw['_id']);
@@ -385,16 +385,16 @@ class EmbeddedRelationsTest extends TestCase
 
         $user = User::find($user1->id);
         $relations = $user->getRelations();
-        $this->assertFalse(array_key_exists('addresses', $relations));
+        $this->assertArrayNotHasKey('addresses', $relations);
         $this->assertArrayHasKey('addresses', $user->toArray());
-        $this->assertTrue(is_array($user->toArray()['addresses']));
+        $this->assertInternalType('array', $user->toArray()['addresses']);
 
         $user = User::with('addresses')->get()->first();
         $relations = $user->getRelations();
-        $this->assertTrue(array_key_exists('addresses', $relations));
+        $this->assertArrayHasKey('addresses', $relations);
         $this->assertEquals(2, $relations['addresses']->count());
         $this->assertArrayHasKey('addresses', $user->toArray());
-        $this->assertTrue(is_array($user->toArray()['addresses']));
+        $this->assertInternalType('array', $user->toArray()['addresses']);
     }
 
     public function testEmbedsManyDeleteAll()
@@ -466,7 +466,7 @@ class EmbeddedRelationsTest extends TestCase
         $this->assertInstanceOf('DateTime', $father->created_at);
         $this->assertInstanceOf('DateTime', $father->updated_at);
         $this->assertNotNull($father->_id);
-        $this->assertTrue(is_string($father->_id));
+        $this->assertInternalType('string', $father->_id);
 
         $raw = $father->getAttributes();
         $this->assertInstanceOf('MongoDB\BSON\ObjectID', $raw['_id']);
@@ -541,7 +541,7 @@ class EmbeddedRelationsTest extends TestCase
 
         $array = $user->toArray();
         $this->assertArrayHasKey('addresses', $array);
-        $this->assertTrue(is_array($array['addresses']));
+        $this->assertInternalType('array', $array['addresses']);
     }
 
     public function testEmbeddedSave()

--- a/tests/HybridRelationsTest.php
+++ b/tests/HybridRelationsTest.php
@@ -27,13 +27,13 @@ class HybridRelationsTest extends TestCase
         // Mysql User
         $user->name = "John Doe";
         $user->save();
-        $this->assertTrue(is_int($user->id));
+        $this->assertInternalType('int', $user->id);
 
         // SQL has many
         $book = new Book(['title' => 'Game of Thrones']);
         $user->books()->save($book);
         $user = MysqlUser::find($user->id); // refetch
-        $this->assertEquals(1, count($user->books));
+        $this->assertCount(1, $user->books);
 
         // MongoDB belongs to
         $book = $user->books()->first(); // refetch
@@ -58,7 +58,7 @@ class HybridRelationsTest extends TestCase
         $book = new MysqlBook(['title' => 'Game of Thrones']);
         $user->mysqlBooks()->save($book);
         $user = User::find($user->_id); // refetch
-        $this->assertEquals(1, count($user->mysqlBooks));
+        $this->assertCount(1, $user->mysqlBooks);
 
         // SQL belongs to
         $book = $user->mysqlBooks()->first(); // refetch
@@ -93,8 +93,8 @@ class HybridRelationsTest extends TestCase
         $otherUser->id = 3;
         $otherUser->save();
         // Make sure they are created
-        $this->assertTrue(is_int($user->id));
-        $this->assertTrue(is_int($otherUser->id));
+        $this->assertInternalType('int', $user->id);
+        $this->assertInternalType('int', $otherUser->id);
         // Clear to start
         $user->books()->truncate();
         $otherUser->books()->truncate();
@@ -147,8 +147,8 @@ class HybridRelationsTest extends TestCase
         $otherUser->id = 3;
         $otherUser->save();
         // Make sure they are created
-        $this->assertTrue(is_int($user->id));
-        $this->assertTrue(is_int($otherUser->id));
+        $this->assertInternalType('int', $user->id);
+        $this->assertInternalType('int', $otherUser->id);
         // Clear to start
         Book::truncate();
         MysqlBook::truncate();

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -21,7 +21,7 @@ class ModelTest extends TestCase
         $user = new User;
         $this->assertInstanceOf(Model::class, $user);
         $this->assertInstanceOf('Jenssegers\Mongodb\Connection', $user->getConnection());
-        $this->assertEquals(false, $user->exists);
+        $this->assertFalse($user->exists);
         $this->assertEquals('users', $user->getTable());
         $this->assertEquals('_id', $user->getKeyName());
     }
@@ -35,11 +35,11 @@ class ModelTest extends TestCase
 
         $user->save();
 
-        $this->assertEquals(true, $user->exists);
+        $this->assertTrue($user->exists);
         $this->assertEquals(1, User::count());
 
         $this->assertTrue(isset($user->_id));
-        $this->assertTrue(is_string($user->_id));
+        $this->assertInternalType('string', $user->_id);
         $this->assertNotEquals('', (string) $user->_id);
         $this->assertNotEquals(0, strlen((string) $user->_id));
         $this->assertInstanceOf(Carbon::class, $user->created_at);
@@ -67,7 +67,7 @@ class ModelTest extends TestCase
         $check->age = 36;
         $check->save();
 
-        $this->assertEquals(true, $check->exists);
+        $this->assertTrue($check->exists);
         $this->assertInstanceOf(Carbon::class, $check->created_at);
         $this->assertInstanceOf(Carbon::class, $check->updated_at);
         $this->assertEquals(1, User::count());
@@ -93,7 +93,7 @@ class ModelTest extends TestCase
         $user->age = 35;
         $user->save();
 
-        $this->assertEquals(true, $user->exists);
+        $this->assertTrue($user->exists);
         $this->assertEquals('4af9f23d8ead0e1d32000000', $user->_id);
 
         $raw = $user->getAttributes();
@@ -106,7 +106,7 @@ class ModelTest extends TestCase
         $user->age = 35;
         $user->save();
 
-        $this->assertEquals(true, $user->exists);
+        $this->assertTrue($user->exists);
         $this->assertEquals('customId', $user->_id);
 
         $raw = $user->getAttributes();
@@ -122,7 +122,7 @@ class ModelTest extends TestCase
         $user->age = 35;
         $user->save();
 
-        $this->assertEquals(true, $user->exists);
+        $this->assertTrue($user->exists);
         $this->assertEquals(1, $user->_id);
 
         $raw = $user->getAttributes();
@@ -137,7 +137,7 @@ class ModelTest extends TestCase
         $user->age = 35;
         $user->save();
 
-        $this->assertEquals(true, $user->exists);
+        $this->assertTrue($user->exists);
         $this->assertEquals(1, User::count());
 
         $user->delete();
@@ -161,7 +161,7 @@ class ModelTest extends TestCase
 
         $all = User::all();
 
-        $this->assertEquals(2, count($all));
+        $this->assertCount(2, $all);
         $this->assertContains('John Doe', $all->pluck('name'));
         $this->assertContains('Jane Doe', $all->pluck('name'));
     }
@@ -177,7 +177,7 @@ class ModelTest extends TestCase
         $check = User::find($user->_id);
 
         $this->assertInstanceOf(Model::class, $check);
-        $this->assertEquals(true, $check->exists);
+        $this->assertTrue($check->exists);
         $this->assertEquals($user->_id, $check->_id);
 
         $this->assertEquals('John Doe', $check->name);
@@ -192,7 +192,7 @@ class ModelTest extends TestCase
         ]);
 
         $users = User::get();
-        $this->assertEquals(2, count($users));
+        $this->assertCount(2, $users);
         $this->assertInstanceOf(Collection::class, $users);
         $this->assertInstanceOf(Model::class, $users[0]);
     }
@@ -216,10 +216,10 @@ class ModelTest extends TestCase
         $this->assertEquals(0, $items->count());
 
         $item = Item::where('name', 'nothing')->first();
-        $this->assertEquals(null, $item);
+        $this->assertNull($item);
 
         $item = Item::find('51c33d8981fec6813e00000a');
-        $this->assertEquals(null, $item);
+        $this->assertNull($item);
     }
 
     public function testFindOrfail()
@@ -233,7 +233,7 @@ class ModelTest extends TestCase
         $user = User::create(['name' => 'Jane Poe']);
 
         $this->assertInstanceOf(Model::class, $user);
-        $this->assertEquals(true, $user->exists);
+        $this->assertTrue($user->exists);
         $this->assertEquals('Jane Poe', $user->name);
 
         $check = User::where('name', 'Jane Poe')->first();
@@ -278,12 +278,12 @@ class ModelTest extends TestCase
         $this->assertEquals(2, Soft::count());
 
         $user = Soft::where('name', 'John Doe')->first();
-        $this->assertEquals(true, $user->exists);
-        $this->assertEquals(false, $user->trashed());
+        $this->assertTrue($user->exists);
+        $this->assertFalse($user->trashed());
         $this->assertNull($user->deleted_at);
 
         $user->delete();
-        $this->assertEquals(true, $user->trashed());
+        $this->assertTrue($user->trashed());
         $this->assertNotNull($user->deleted_at);
 
         $user = Soft::where('name', 'John Doe')->first();
@@ -295,7 +295,7 @@ class ModelTest extends TestCase
         $user = Soft::withTrashed()->where('name', 'John Doe')->first();
         $this->assertNotNull($user);
         $this->assertInstanceOf(Carbon::class, $user->deleted_at);
-        $this->assertEquals(true, $user->trashed());
+        $this->assertTrue($user->trashed());
 
         $user->restore();
         $this->assertEquals(2, Soft::count());
@@ -340,9 +340,9 @@ class ModelTest extends TestCase
         $keys = array_keys($array);
         sort($keys);
         $this->assertEquals(['_id', 'created_at', 'name', 'type', 'updated_at'], $keys);
-        $this->assertTrue(is_string($array['created_at']));
-        $this->assertTrue(is_string($array['updated_at']));
-        $this->assertTrue(is_string($array['_id']));
+        $this->assertInternalType('string', $array['created_at']);
+        $this->assertInternalType('string', $array['updated_at']);
+        $this->assertInternalType('string', $array['_id']);
     }
 
     public function testUnset()
@@ -352,7 +352,7 @@ class ModelTest extends TestCase
 
         $user1->unset('note1');
 
-        $this->assertFalse(isset($user1->note1));
+        $this->assertObjectNotHasAttribute('note1', $user1);
         $this->assertTrue(isset($user1->note2));
         $this->assertTrue(isset($user2->note1));
         $this->assertTrue(isset($user2->note2));
@@ -361,15 +361,15 @@ class ModelTest extends TestCase
         $user1 = User::find($user1->_id);
         $user2 = User::find($user2->_id);
 
-        $this->assertFalse(isset($user1->note1));
+        $this->assertObjectNotHasAttribute('note1', $user1);
         $this->assertTrue(isset($user1->note2));
         $this->assertTrue(isset($user2->note1));
         $this->assertTrue(isset($user2->note2));
 
         $user2->unset(['note1', 'note2']);
 
-        $this->assertFalse(isset($user2->note1));
-        $this->assertFalse(isset($user2->note2));
+        $this->assertObjectNotHasAttribute('note1', $user2);
+        $this->assertObjectNotHasAttribute('note2', $user2);
     }
 
     public function testDates()
@@ -396,7 +396,7 @@ class ModelTest extends TestCase
         $this->assertEquals($item->getOriginal('created_at')
             ->toDateTime()
             ->getTimestamp(), $item->created_at->getTimestamp());
-        $this->assertTrue(abs(time() - $item->created_at->getTimestamp()) < 2);
+        $this->assertLessThan(2, abs(time() - $item->created_at->getTimestamp()));
 
         // test default date format for json output
         $item = Item::create(['name' => 'sword']);

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -53,12 +53,12 @@ class QueryBuilderTest extends TestCase
     public function testGet()
     {
         $users = DB::collection('users')->get();
-        $this->assertEquals(0, count($users));
+        $this->assertCount(0, $users);
 
         DB::collection('users')->insert(['name' => 'John Doe']);
 
         $users = DB::collection('users')->get();
-        $this->assertEquals(1, count($users));
+        $this->assertCount(1, $users);
     }
 
     public function testNoDocument()
@@ -67,10 +67,10 @@ class QueryBuilderTest extends TestCase
         $this->assertEquals([], $items);
 
         $item = DB::collection('items')->where('name', 'nothing')->first();
-        $this->assertEquals(null, $item);
+        $this->assertNull($item);
 
         $item = DB::collection('items')->where('_id', '51c33d8981fec6813e00000a')->first();
-        $this->assertEquals(null, $item);
+        $this->assertNull($item);
     }
 
     public function testInsert()
@@ -81,11 +81,11 @@ class QueryBuilderTest extends TestCase
         ]);
 
         $users = DB::collection('users')->get();
-        $this->assertEquals(1, count($users));
+        $this->assertCount(1, $users);
 
         $user = $users[0];
         $this->assertEquals('John Doe', $user['name']);
-        $this->assertTrue(is_array($user['tags']));
+        $this->assertInternalType('array', $user['tags']);
     }
 
     public function testInsertGetId()
@@ -108,8 +108,8 @@ class QueryBuilderTest extends TestCase
         ]);
 
         $users = DB::collection('users')->get();
-        $this->assertEquals(2, count($users));
-        $this->assertTrue(is_array($users[0]['tags']));
+        $this->assertCount(2, $users);
+        $this->assertInternalType('array', $users[0]['tags']);
     }
 
     public function testFind()
@@ -123,7 +123,7 @@ class QueryBuilderTest extends TestCase
     public function testFindNull()
     {
         $user = DB::collection('users')->find(null);
-        $this->assertEquals(null, $user);
+        $this->assertNull($user);
     }
 
     public function testCount()
@@ -187,7 +187,7 @@ class QueryBuilderTest extends TestCase
         ]);
 
         $users = DB::collection('users')->where('address.country', 'Belgium')->get();
-        $this->assertEquals(1, count($users));
+        $this->assertCount(1, $users);
         $this->assertEquals('John Doe', $users[0]['name']);
     }
 
@@ -203,10 +203,10 @@ class QueryBuilderTest extends TestCase
         ]);
 
         $items = DB::collection('items')->where('tags', 'tag2')->get();
-        $this->assertEquals(2, count($items));
+        $this->assertCount(2, $items);
 
         $items = DB::collection('items')->where('tags', 'tag1')->get();
-        $this->assertEquals(1, count($items));
+        $this->assertCount(1, $items);
     }
 
     public function testRaw()
@@ -221,7 +221,7 @@ class QueryBuilderTest extends TestCase
         });
 
         $this->assertInstanceOf('MongoDB\Driver\Cursor', $cursor);
-        $this->assertEquals(1, count($cursor->toArray()));
+        $this->assertCount(1, $cursor->toArray());
 
         $collection = DB::collection('users')->raw();
         $this->assertInstanceOf('Jenssegers\Mongodb\Collection', $collection);
@@ -230,7 +230,7 @@ class QueryBuilderTest extends TestCase
         $this->assertInstanceOf('Jenssegers\Mongodb\Collection', $collection);
 
         $results = DB::collection('users')->whereRaw(['age' => 20])->get();
-        $this->assertEquals(1, count($results));
+        $this->assertCount(1, $results);
         $this->assertEquals('Jane Doe', $results[0]['name']);
     }
 
@@ -245,41 +245,41 @@ class QueryBuilderTest extends TestCase
         DB::collection('users')->where('_id', $id)->push('tags', 'tag1');
 
         $user = DB::collection('users')->find($id);
-        $this->assertTrue(is_array($user['tags']));
-        $this->assertEquals(1, count($user['tags']));
+        $this->assertInternalType('array', $user['tags']);
+        $this->assertCount(1, $user['tags']);
         $this->assertEquals('tag1', $user['tags'][0]);
 
         DB::collection('users')->where('_id', $id)->push('tags', 'tag2');
         $user = DB::collection('users')->find($id);
-        $this->assertEquals(2, count($user['tags']));
+        $this->assertCount(2, $user['tags']);
         $this->assertEquals('tag2', $user['tags'][1]);
 
         // Add duplicate
         DB::collection('users')->where('_id', $id)->push('tags', 'tag2');
         $user = DB::collection('users')->find($id);
-        $this->assertEquals(3, count($user['tags']));
+        $this->assertCount(3, $user['tags']);
 
         // Add unique
         DB::collection('users')->where('_id', $id)->push('tags', 'tag1', true);
         $user = DB::collection('users')->find($id);
-        $this->assertEquals(3, count($user['tags']));
+        $this->assertCount(3, $user['tags']);
 
         $message = ['from' => 'Jane', 'body' => 'Hi John'];
         DB::collection('users')->where('_id', $id)->push('messages', $message);
         $user = DB::collection('users')->find($id);
-        $this->assertTrue(is_array($user['messages']));
-        $this->assertEquals(1, count($user['messages']));
+        $this->assertInternalType('array', $user['messages']);
+        $this->assertCount(1, $user['messages']);
         $this->assertEquals($message, $user['messages'][0]);
 
         // Raw
         DB::collection('users')->where('_id', $id)->push(['tags' => 'tag3', 'messages' => ['from' => 'Mark', 'body' => 'Hi John']]);
         $user = DB::collection('users')->find($id);
-        $this->assertEquals(4, count($user['tags']));
-        $this->assertEquals(2, count($user['messages']));
+        $this->assertCount(4, $user['tags']);
+        $this->assertCount(2, $user['messages']);
 
         DB::collection('users')->where('_id', $id)->push(['messages' => ['date' => new DateTime(), 'body' => 'Hi John']]);
         $user = DB::collection('users')->find($id);
-        $this->assertEquals(3, count($user['messages']));
+        $this->assertCount(3, $user['messages']);
     }
 
     public function testPull()
@@ -296,21 +296,21 @@ class QueryBuilderTest extends TestCase
         DB::collection('users')->where('_id', $id)->pull('tags', 'tag3');
 
         $user = DB::collection('users')->find($id);
-        $this->assertTrue(is_array($user['tags']));
-        $this->assertEquals(3, count($user['tags']));
+        $this->assertInternalType('array', $user['tags']);
+        $this->assertCount(3, $user['tags']);
         $this->assertEquals('tag4', $user['tags'][2]);
 
         DB::collection('users')->where('_id', $id)->pull('messages', $message1);
 
         $user = DB::collection('users')->find($id);
-        $this->assertTrue(is_array($user['messages']));
-        $this->assertEquals(1, count($user['messages']));
+        $this->assertInternalType('array', $user['messages']);
+        $this->assertCount(1, $user['messages']);
 
         // Raw
         DB::collection('users')->where('_id', $id)->pull(['tags' => 'tag2', 'messages' => $message2]);
         $user = DB::collection('users')->find($id);
-        $this->assertEquals(2, count($user['tags']));
-        $this->assertEquals(0, count($user['messages']));
+        $this->assertCount(2, $user['tags']);
+        $this->assertCount(0, $user['messages']);
     }
 
     public function testDistinct()
@@ -324,12 +324,12 @@ class QueryBuilderTest extends TestCase
 
         $items = DB::collection('items')->distinct('name')->get()->toArray();
         sort($items);
-        $this->assertEquals(3, count($items));
+        $this->assertCount(3, $items);
         $this->assertEquals(['fork', 'knife', 'spoon'], $items);
 
         $types = DB::collection('items')->distinct('type')->get()->toArray();
         sort($types);
-        $this->assertEquals(2, count($types));
+        $this->assertCount(2, $types);
         $this->assertEquals(['round', 'sharp'], $types);
     }
 
@@ -366,7 +366,7 @@ class QueryBuilderTest extends TestCase
         ]);
 
         $items = DB::collection('items')->orderBy('name')->take(2)->get();
-        $this->assertEquals(2, count($items));
+        $this->assertCount(2, $items);
         $this->assertEquals('fork', $items[0]['name']);
     }
 
@@ -380,7 +380,7 @@ class QueryBuilderTest extends TestCase
         ]);
 
         $items = DB::collection('items')->orderBy('name')->skip(2)->get();
-        $this->assertEquals(2, count($items));
+        $this->assertCount(2, $items);
         $this->assertEquals('spoon', $items[0]['name']);
     }
 
@@ -406,15 +406,15 @@ class QueryBuilderTest extends TestCase
 
         $list = DB::collection('items')->pluck('name')->toArray();
         sort($list);
-        $this->assertEquals(4, count($list));
+        $this->assertCount(4, $list);
         $this->assertEquals(['fork', 'knife', 'spoon', 'spoon'], $list);
 
         $list = DB::collection('items')->pluck('type', 'name')->toArray();
-        $this->assertEquals(3, count($list));
+        $this->assertCount(3, $list);
         $this->assertEquals(['knife' => 'sharp', 'fork' => 'sharp', 'spoon' => 'round'], $list);
 
         $list = DB::collection('items')->pluck('name', '_id')->toArray();
-        $this->assertEquals(4, count($list));
+        $this->assertCount(4, $list);
         $this->assertEquals(24, strlen(key($list)));
     }
 
@@ -498,16 +498,16 @@ class QueryBuilderTest extends TestCase
         $user1 = DB::collection('users')->find($id1);
         $user2 = DB::collection('users')->find($id2);
 
-        $this->assertFalse(isset($user1['note1']));
-        $this->assertTrue(isset($user1['note2']));
-        $this->assertTrue(isset($user2['note1']));
-        $this->assertTrue(isset($user2['note2']));
+        $this->assertArrayNotHasKey('note1', $user1);
+        $this->assertArrayHasKey('note2', $user1);
+        $this->assertArrayHasKey('note1', $user2);
+        $this->assertArrayHasKey('note2', $user2);
 
         DB::collection('users')->where('name', 'Jane Doe')->unset(['note1', 'note2']);
 
         $user2 = DB::collection('users')->find($id2);
-        $this->assertFalse(isset($user2['note1']));
-        $this->assertFalse(isset($user2['note2']));
+        $this->assertArrayNotHasKey('note1', $user2);
+        $this->assertArrayNotHasKey('note2', $user2);
     }
 
     public function testUpdateSubdocument()
@@ -539,7 +539,7 @@ class QueryBuilderTest extends TestCase
         $stop = new UTCDateTime(1000 * strtotime("1982-01-01 00:00:00"));
 
         $users = DB::collection('users')->whereBetween('birthday', [$start, $stop])->get();
-        $this->assertEquals(2, count($users));
+        $this->assertCount(2, $users);
     }
 
     public function testOperators()
@@ -551,29 +551,29 @@ class QueryBuilderTest extends TestCase
         ]);
 
         $results = DB::collection('users')->where('age', 'exists', true)->get();
-        $this->assertEquals(2, count($results));
+        $this->assertCount(2, $results);
         $resultsNames = [$results[0]['name'], $results[1]['name']];
         $this->assertContains('John Doe', $resultsNames);
         $this->assertContains('Robert Roe', $resultsNames);
 
         $results = DB::collection('users')->where('age', 'exists', false)->get();
-        $this->assertEquals(1, count($results));
+        $this->assertCount(1, $results);
         $this->assertEquals('Jane Doe', $results[0]['name']);
 
         $results = DB::collection('users')->where('age', 'type', 2)->get();
-        $this->assertEquals(1, count($results));
+        $this->assertCount(1, $results);
         $this->assertEquals('Robert Roe', $results[0]['name']);
 
         $results = DB::collection('users')->where('age', 'mod', [15, 0])->get();
-        $this->assertEquals(1, count($results));
+        $this->assertCount(1, $results);
         $this->assertEquals('John Doe', $results[0]['name']);
 
         $results = DB::collection('users')->where('age', 'mod', [29, 1])->get();
-        $this->assertEquals(1, count($results));
+        $this->assertCount(1, $results);
         $this->assertEquals('John Doe', $results[0]['name']);
 
         $results = DB::collection('users')->where('age', 'mod', [14, 0])->get();
-        $this->assertEquals(0, count($results));
+        $this->assertCount(0, $results);
 
         DB::collection('items')->insert([
             ['name' => 'fork',  'tags' => ['sharp', 'pointy']],
@@ -582,39 +582,39 @@ class QueryBuilderTest extends TestCase
         ]);
 
         $results = DB::collection('items')->where('tags', 'all', ['sharp', 'pointy'])->get();
-        $this->assertEquals(2, count($results));
+        $this->assertCount(2, $results);
 
         $results = DB::collection('items')->where('tags', 'all', ['sharp', 'round'])->get();
-        $this->assertEquals(1, count($results));
+        $this->assertCount(1, $results);
 
         $results = DB::collection('items')->where('tags', 'size', 2)->get();
-        $this->assertEquals(2, count($results));
+        $this->assertCount(2, $results);
 
         $results = DB::collection('items')->where('tags', '$size', 2)->get();
-        $this->assertEquals(2, count($results));
+        $this->assertCount(2, $results);
 
         $results = DB::collection('items')->where('tags', 'size', 3)->get();
-        $this->assertEquals(0, count($results));
+        $this->assertCount(0, $results);
 
         $results = DB::collection('items')->where('tags', 'size', 4)->get();
-        $this->assertEquals(1, count($results));
+        $this->assertCount(1, $results);
 
         $regex = new Regex(".*doe", "i");
         $results = DB::collection('users')->where('name', 'regex', $regex)->get();
-        $this->assertEquals(2, count($results));
+        $this->assertCount(2, $results);
 
         $regex = new Regex(".*doe", "i");
         $results = DB::collection('users')->where('name', 'regexp', $regex)->get();
-        $this->assertEquals(2, count($results));
+        $this->assertCount(2, $results);
 
         $results = DB::collection('users')->where('name', 'REGEX', $regex)->get();
-        $this->assertEquals(2, count($results));
+        $this->assertCount(2, $results);
 
         $results = DB::collection('users')->where('name', 'regexp', '/.*doe/i')->get();
-        $this->assertEquals(2, count($results));
+        $this->assertCount(2, $results);
 
         $results = DB::collection('users')->where('name', 'not regexp', '/.*doe/i')->get();
-        $this->assertEquals(1, count($results));
+        $this->assertCount(1, $results);
 
         DB::collection('users')->insert([
             [
@@ -634,7 +634,7 @@ class QueryBuilderTest extends TestCase
         ]);
 
         $users = DB::collection('users')->where('addresses', 'elemMatch', ['city' => 'Brussels'])->get();
-        $this->assertEquals(1, count($users));
+        $this->assertCount(1, $users);
         $this->assertEquals('Jane Doe', $users[0]['name']);
     }
 
@@ -682,7 +682,7 @@ class QueryBuilderTest extends TestCase
         $user = DB::collection('users')->where('name', 'Jane Doe')->first();
         $this->assertEquals(21, $user['age']);
         $user = DB::collection('users')->where('name', 'Robert Roe')->first();
-        $this->assertEquals(null, $user['age']);
+        $this->assertNull($user['age']);
         $user = DB::collection('users')->where('name', 'Mark Moe')->first();
         $this->assertEquals(1, $user['age']);
     }

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -27,46 +27,46 @@ class QueryTest extends TestCase
     public function testWhere()
     {
         $users = User::where('age', 35)->get();
-        $this->assertEquals(3, count($users));
+        $this->assertCount(3, $users);
 
         $users = User::where('age', '=', 35)->get();
-        $this->assertEquals(3, count($users));
+        $this->assertCount(3, $users);
 
         $users = User::where('age', '>=', 35)->get();
-        $this->assertEquals(4, count($users));
+        $this->assertCount(4, $users);
 
         $users = User::where('age', '<=', 18)->get();
-        $this->assertEquals(1, count($users));
+        $this->assertCount(1, $users);
 
         $users = User::where('age', '!=', 35)->get();
-        $this->assertEquals(6, count($users));
+        $this->assertCount(6, $users);
 
         $users = User::where('age', '<>', 35)->get();
-        $this->assertEquals(6, count($users));
+        $this->assertCount(6, $users);
     }
 
     public function testAndWhere()
     {
         $users = User::where('age', 35)->where('title', 'admin')->get();
-        $this->assertEquals(2, count($users));
+        $this->assertCount(2, $users);
 
         $users = User::where('age', '>=', 35)->where('title', 'user')->get();
-        $this->assertEquals(2, count($users));
+        $this->assertCount(2, $users);
     }
 
     public function testLike()
     {
         $users = User::where('name', 'like', '%doe')->get();
-        $this->assertEquals(2, count($users));
+        $this->assertCount(2, $users);
 
         $users = User::where('name', 'like', '%y%')->get();
-        $this->assertEquals(3, count($users));
+        $this->assertCount(3, $users);
 
         $users = User::where('name', 'LIKE', '%y%')->get();
-        $this->assertEquals(3, count($users));
+        $this->assertCount(3, $users);
 
         $users = User::where('name', 'like', 't%')->get();
-        $this->assertEquals(1, count($users));
+        $this->assertCount(1, $users);
     }
 
     public function testSelect()
@@ -74,75 +74,75 @@ class QueryTest extends TestCase
         $user = User::where('name', 'John Doe')->select('name')->first();
 
         $this->assertEquals('John Doe', $user->name);
-        $this->assertEquals(null, $user->age);
-        $this->assertEquals(null, $user->title);
+        $this->assertNull($user->age);
+        $this->assertNull($user->title);
 
         $user = User::where('name', 'John Doe')->select('name', 'title')->first();
 
         $this->assertEquals('John Doe', $user->name);
         $this->assertEquals('admin', $user->title);
-        $this->assertEquals(null, $user->age);
+        $this->assertNull($user->age);
 
         $user = User::where('name', 'John Doe')->select(['name', 'title'])->get()->first();
 
         $this->assertEquals('John Doe', $user->name);
         $this->assertEquals('admin', $user->title);
-        $this->assertEquals(null, $user->age);
+        $this->assertNull($user->age);
 
         $user = User::where('name', 'John Doe')->get(['name'])->first();
 
         $this->assertEquals('John Doe', $user->name);
-        $this->assertEquals(null, $user->age);
+        $this->assertNull($user->age);
     }
 
     public function testOrWhere()
     {
         $users = User::where('age', 13)->orWhere('title', 'admin')->get();
-        $this->assertEquals(4, count($users));
+        $this->assertCount(4, $users);
 
         $users = User::where('age', 13)->orWhere('age', 23)->get();
-        $this->assertEquals(2, count($users));
+        $this->assertCount(2, $users);
     }
 
     public function testBetween()
     {
         $users = User::whereBetween('age', [0, 25])->get();
-        $this->assertEquals(2, count($users));
+        $this->assertCount(2, $users);
 
         $users = User::whereBetween('age', [13, 23])->get();
-        $this->assertEquals(2, count($users));
+        $this->assertCount(2, $users);
 
         // testing whereNotBetween for version 4.1
         $users = User::whereBetween('age', [0, 25], 'and', true)->get();
-        $this->assertEquals(6, count($users));
+        $this->assertCount(6, $users);
     }
 
     public function testIn()
     {
         $users = User::whereIn('age', [13, 23])->get();
-        $this->assertEquals(2, count($users));
+        $this->assertCount(2, $users);
 
         $users = User::whereIn('age', [33, 35, 13])->get();
-        $this->assertEquals(6, count($users));
+        $this->assertCount(6, $users);
 
         $users = User::whereNotIn('age', [33, 35])->get();
-        $this->assertEquals(4, count($users));
+        $this->assertCount(4, $users);
 
         $users = User::whereNotNull('age')
                      ->whereNotIn('age', [33, 35])->get();
-        $this->assertEquals(3, count($users));
+        $this->assertCount(3, $users);
     }
 
     public function testWhereNull()
     {
         $users = User::whereNull('age')->get();
-        $this->assertEquals(1, count($users));
+        $this->assertCount(1, $users);
     }
 
     public function testWhereNotNull()
     {
         $users = User::whereNotNull('age')->get();
-        $this->assertEquals(8, count($users));
+        $this->assertCount(8, $users);
     }
 
     public function testOrder()
@@ -169,16 +169,16 @@ class QueryTest extends TestCase
     public function testGroupBy()
     {
         $users = User::groupBy('title')->get();
-        $this->assertEquals(3, count($users));
+        $this->assertCount(3, $users);
 
         $users = User::groupBy('age')->get();
-        $this->assertEquals(6, count($users));
+        $this->assertCount(6, $users);
 
         $users = User::groupBy('age')->skip(1)->get();
-        $this->assertEquals(5, count($users));
+        $this->assertCount(5, $users);
 
         $users = User::groupBy('age')->take(2)->get();
-        $this->assertEquals(2, count($users));
+        $this->assertCount(2, $users);
 
         $users = User::groupBy('age')->orderBy('age', 'desc')->get();
         $this->assertEquals(37, $users[0]->age);
@@ -186,13 +186,13 @@ class QueryTest extends TestCase
         $this->assertEquals(33, $users[2]->age);
 
         $users = User::groupBy('age')->skip(1)->take(2)->orderBy('age', 'desc')->get();
-        $this->assertEquals(2, count($users));
+        $this->assertCount(2, $users);
         $this->assertEquals(35, $users[0]->age);
         $this->assertEquals(33, $users[1]->age);
         $this->assertNull($users[0]->name);
 
         $users = User::select('name')->groupBy('age')->skip(1)->take(2)->orderBy('age', 'desc')->get();
-        $this->assertEquals(2, count($users));
+        $this->assertCount(2, $users);
         $this->assertNotNull($users[0]->name);
     }
 
@@ -220,7 +220,7 @@ class QueryTest extends TestCase
         })
             ->get();
 
-        $this->assertEquals(5, count($users));
+        $this->assertCount(5, $users);
 
         $users = User::where('title', 'user')->where(function ($query) {
             $query->where('age', 35)
@@ -228,7 +228,7 @@ class QueryTest extends TestCase
         })
             ->get();
 
-        $this->assertEquals(2, count($users));
+        $this->assertCount(2, $users);
 
         $users = User::where('age', 35)->orWhere(function ($query) {
             $query->where('title', 'admin')
@@ -236,7 +236,7 @@ class QueryTest extends TestCase
         })
             ->get();
 
-        $this->assertEquals(5, count($users));
+        $this->assertCount(5, $users);
 
         $users = User::whereNull('deleted_at')
                 ->where('title', 'admin')
@@ -266,13 +266,13 @@ class QueryTest extends TestCase
         $where = ['age' => ['$gt' => 30, '$lt' => 40]];
         $users = User::whereRaw($where)->get();
 
-        $this->assertEquals(6, count($users));
+        $this->assertCount(6, $users);
 
         $where1 = ['age' => ['$gt' => 30, '$lte' => 35]];
         $where2 = ['age'           => ['$gt' => 35, '$lt' => 40]];
         $users = User::whereRaw($where1)->orWhereRaw($where2)->get();
 
-        $this->assertEquals(6, count($users));
+        $this->assertCount(6, $users);
     }
 
     public function testMultipleOr()
@@ -284,7 +284,7 @@ class QueryTest extends TestCase
             $query->where('name', 'John Doe')->orWhere('name', 'Jane Doe');
         })->get();
 
-        $this->assertEquals(2, count($users));
+        $this->assertCount(2, $users);
 
         $users = User::where(function ($query) {
             $query->orWhere('age', 35)->orWhere('age', 33);
@@ -293,7 +293,7 @@ class QueryTest extends TestCase
             $query->orWhere('name', 'John Doe')->orWhere('name', 'Jane Doe');
         })->get();
 
-        $this->assertEquals(2, count($users));
+        $this->assertCount(2, $users);
     }
 
     public function testPaginate()

--- a/tests/RelationsTest.php
+++ b/tests/RelationsTest.php
@@ -24,7 +24,7 @@ class RelationsTest extends TestCase
         Book::create(['title' => 'A Clash of Kings', 'author_id' => $author->_id]);
 
         $books = $author->books;
-        $this->assertEquals(2, count($books));
+        $this->assertCount(2, $books);
 
         $user = User::create(['name' => 'John Doe']);
         Item::create(['type' => 'knife', 'user_id' => $user->_id]);
@@ -33,7 +33,7 @@ class RelationsTest extends TestCase
         Item::create(['type' => 'bag', 'user_id' => null]);
 
         $items = $user->items;
-        $this->assertEquals(3, count($items));
+        $this->assertCount(3, $items);
     }
 
     public function testBelongsTo()
@@ -52,7 +52,7 @@ class RelationsTest extends TestCase
         $this->assertEquals('John Doe', $owner->name);
 
         $book = Book::create(['title' => 'A Clash of Kings']);
-        $this->assertEquals(null, $book->author);
+        $this->assertNull($book->author);
     }
 
     public function testHasOne()
@@ -91,8 +91,8 @@ class RelationsTest extends TestCase
         $user = $items[0]->getRelation('user');
         $this->assertInstanceOf('User', $user);
         $this->assertEquals('John Doe', $user->name);
-        $this->assertEquals(1, count($items[0]->getRelations()));
-        $this->assertEquals(null, $items[3]->getRelation('user'));
+        $this->assertCount(1, $items[0]->getRelations());
+        $this->assertNull($items[3]->getRelation('user'));
     }
 
     public function testWithHashMany()
@@ -106,7 +106,7 @@ class RelationsTest extends TestCase
         $user = User::with('items')->find($user->_id);
 
         $items = $user->getRelation('items');
-        $this->assertEquals(3, count($items));
+        $this->assertCount(3, $items);
         $this->assertInstanceOf('Item', $items[0]);
     }
 
@@ -132,7 +132,7 @@ class RelationsTest extends TestCase
 
         $user = User::find($user->_id);
         $items = $user->items;
-        $this->assertEquals(1, count($items));
+        $this->assertCount(1, $items);
         $this->assertInstanceOf('Item', $items[0]);
         $this->assertEquals($user->_id, $items[0]->user_id);
 
@@ -161,8 +161,8 @@ class RelationsTest extends TestCase
         $client = Client::with('users')->first();
 
         // Check for relation attributes
-        $this->assertTrue(array_key_exists('user_ids', $client->getAttributes()));
-        $this->assertTrue(array_key_exists('client_ids', $user->getAttributes()));
+        $this->assertArrayHasKey('user_ids', $client->getAttributes());
+        $this->assertArrayHasKey('client_ids', $user->getAttributes());
 
         $clients = $user->getRelation('clients');
         $users = $client->getRelation('users');
@@ -190,8 +190,8 @@ class RelationsTest extends TestCase
         $this->assertInstanceOf('User', $user);
 
         // Assert they are not attached
-        $this->assertFalse(in_array($client->_id, $user->client_ids));
-        $this->assertFalse(in_array($user->_id, $client->user_ids));
+        $this->assertNotContains($client->_id, $user->client_ids);
+        $this->assertNotContains($user->_id, $client->user_ids);
         $this->assertCount(1, $user->clients);
         $this->assertCount(1, $client->users);
 
@@ -203,8 +203,8 @@ class RelationsTest extends TestCase
         $client = Client::Where('name', '=', 'Buffet Bar Inc.')->first();
 
         // Assert they are attached
-        $this->assertTrue(in_array($client->_id, $user->client_ids));
-        $this->assertTrue(in_array($user->_id, $client->user_ids));
+        $this->assertContains($client->_id, $user->client_ids);
+        $this->assertContains($user->_id, $client->user_ids);
         $this->assertCount(2, $user->clients);
         $this->assertCount(2, $client->users);
 
@@ -216,8 +216,8 @@ class RelationsTest extends TestCase
         $client = Client::Where('name', '=', 'Buffet Bar Inc.')->first();
 
         // Assert they are not attached
-        $this->assertFalse(in_array($client->_id, $user->client_ids));
-        $this->assertFalse(in_array($user->_id, $client->user_ids));
+        $this->assertNotContains($client->_id, $user->client_ids);
+        $this->assertNotContains($user->_id, $client->user_ids);
         $this->assertCount(0, $user->clients);
         $this->assertCount(1, $client->users);
     }
@@ -242,7 +242,7 @@ class RelationsTest extends TestCase
         $user = User::with('clients')->find($user->_id);
 
         // Assert non attached ID's are detached succesfully
-        $this->assertFalse(in_array('1234523', $user->client_ids));
+        $this->assertNotContains('1234523', $user->client_ids);
 
         // Assert there are two client objects in the relationship
         $this->assertCount(2, $user->clients);
@@ -330,12 +330,12 @@ class RelationsTest extends TestCase
         $group = Group::find($group->_id);
 
         // Check for custom relation attributes
-        $this->assertTrue(array_key_exists('users', $group->getAttributes()));
-        $this->assertTrue(array_key_exists('groups', $user->getAttributes()));
+        $this->assertArrayHasKey('users', $group->getAttributes());
+        $this->assertArrayHasKey('groups', $user->getAttributes());
 
         // Assert they are attached
-        $this->assertTrue(in_array($group->_id, $user->groups->pluck('_id')->toArray()));
-        $this->assertTrue(in_array($user->_id, $group->users->pluck('_id')->toArray()));
+        $this->assertContains($group->_id, $user->groups->pluck('_id')->toArray());
+        $this->assertContains($user->_id, $group->users->pluck('_id')->toArray());
         $this->assertEquals($group->_id, $user->groups()->first()->_id);
         $this->assertEquals($user->_id, $group->users()->first()->_id);
     }
@@ -370,16 +370,16 @@ class RelationsTest extends TestCase
 
         $user = User::with('photos')->find($user->_id);
         $relations = $user->getRelations();
-        $this->assertTrue(array_key_exists('photos', $relations));
+        $this->assertArrayHasKey('photos', $relations);
         $this->assertEquals(1, $relations['photos']->count());
 
         $photos = Photo::with('imageable')->get();
         $relations = $photos[0]->getRelations();
-        $this->assertTrue(array_key_exists('imageable', $relations));
+        $this->assertArrayHasKey('imageable', $relations);
         $this->assertInstanceOf('User', $photos[0]->imageable);
 
         $relations = $photos[1]->getRelations();
-        $this->assertTrue(array_key_exists('imageable', $relations));
+        $this->assertArrayHasKey('imageable', $relations);
         $this->assertInstanceOf('Client', $photos[1]->imageable);
     }
 


### PR DESCRIPTION
I've refactored several tests, using:
- `assertCount` instead of `count` function;
- `assertInternalType` instead of `is_*` functions;
- `assertArrayHasKey` and `assertArrayNotHasKey` instead of `array_key_exists` function;
- `assertTrue` instead of comparison with `true` keyword;
- `assertFalse` instead of comparison with `false` keyword;
- `assertNull` instead of comparison with `null` keyword;
- `assertContains` and `assertNotContains` instead of `in_array` function;
- `assertObjectNotHasAttribute` instead of `isset` function;
- `assertLessThan` for mathematical comparisons.