### PR TITLE
Update mongodb/mongodb to support all options and added hint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "illuminate/container": "^5.5",
         "illuminate/database": "^5.5",
         "illuminate/events": "^5.5",
-        "mongodb/mongodb": "^1.0.0"
+        "mongodb/mongodb": "^1.2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0",

--- a/src/Jenssegers/Mongodb/Query/Builder.php
+++ b/src/Jenssegers/Mongodb/Query/Builder.php
@@ -378,7 +378,10 @@ class Builder extends BaseBuilder
             if ($columns) {
                 $options['projection'] = $columns;
             }
-            // if ($this->hint)    $cursor->hint($this->hint);
+
+            if ($this->hint) {
+                $options['hint'] = $this->hint;
+            }
 
             // Fix for legacy support, converts the results to arrays instead of objects.
             $options['typeMap'] = ['root' => 'array', 'document' => 'array'];


### PR DESCRIPTION
Updating to mongodb/mongodb 1.2.0 uses this fix:
https://jira.mongodb.org/browse/PHPLIB-264

Also added hint to options.

Warning: requires driver ext-mongodb ^1.3.0