### PR TITLE
[Fix] Unable to delete nested embedded models

### DIFF
--- a/src/Jenssegers/Mongodb/Relations/EmbedsMany.php
+++ b/src/Jenssegers/Mongodb/Relations/EmbedsMany.php
@@ -6,7 +6,6 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Pagination\Paginator;
-use Illuminate\Support\Arr;
 use MongoDB\BSON\ObjectID;
 
 class EmbedsMany extends EmbedsOneOrMany
@@ -79,8 +78,7 @@ class EmbedsMany extends EmbedsOneOrMany
         // Get the correct foreign key value.
         $foreignKey = $this->getForeignKeyValue($model);
 
-        // Use array dot notation for better update behavior.
-        $values = Arr::dot($model->getDirty(), $this->localKey . '.$.');
+        $values = $this->getUpdateValues($model->getDirty(), $this->localKey . '.$.');
 
         // Update document in database.
         $result = $this->getBaseQuery()->where($this->localKey . '.' . $model->getKeyName(), $foreignKey)

--- a/src/Jenssegers/Mongodb/Relations/EmbedsOne.php
+++ b/src/Jenssegers/Mongodb/Relations/EmbedsOne.php
@@ -3,7 +3,6 @@
 namespace Jenssegers\Mongodb\Relations;
 
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Arr;
 use MongoDB\BSON\ObjectID;
 
 class EmbedsOne extends EmbedsOneOrMany
@@ -71,8 +70,7 @@ class EmbedsOne extends EmbedsOneOrMany
             return $this->parent->save();
         }
 
-        // Use array dot notation for better update behavior.
-        $values = Arr::dot($model->getDirty(), $this->localKey . '.');
+        $values = $this->getUpdateValues($model->getDirty(), $this->localKey . '.');
 
         $result = $this->getBaseQuery()->update($values);
 

--- a/src/Jenssegers/Mongodb/Relations/EmbedsOneOrMany.php
+++ b/src/Jenssegers/Mongodb/Relations/EmbedsOneOrMany.php
@@ -375,4 +375,22 @@ abstract class EmbedsOneOrMany extends Relation
     {
         return $this->parent->getKey();
     }
+
+    /**
+     * Return update values
+     *
+     * @param $array
+     * @param string $prepend
+     * @return array
+     */
+    public static function getUpdateValues($array, $prepend = '')
+    {
+        $results = [];
+
+        foreach ($array as $key => $value) {
+            $results[$prepend.$key] = $value;
+        }
+
+        return $results;
+    }
 }

--- a/tests/EmbeddedRelationsTest.php
+++ b/tests/EmbeddedRelationsTest.php
@@ -653,6 +653,56 @@ class EmbeddedRelationsTest extends TestCase
         $this->assertEquals('Steve Doe', $user->father->name);
     }
 
+    public function testNestedEmbedsOneDelete()
+    {
+        $user = User::create(['name' => 'John Doe']);
+        $father = $user->father()->create(['name' => 'Mark Doe']);
+        $grandfather = $father->father()->create(['name' => 'Steve Doe']);
+        $greatgrandfather = $grandfather->father()->create(['name' => 'Tom Doe']);
+
+        $grandfather->delete();
+
+        $this->assertNull($user->father->father);
+
+        $user = User::where(['name' => 'John Doe'])->first();
+        $this->assertNull($user->father->father);
+    }
+
+    public function testNestedEmbedsManyDelete()
+    {
+        $user = User::create(['name' => 'John Doe']);
+        $country = $user->addresses()->create(['country' => 'France']);
+        $city1 = $country->addresses()->create(['city' => 'Paris']);
+        $city2 = $country->addresses()->create(['city' => 'Nice']);
+        $city3 = $country->addresses()->create(['city' => 'Lyon']);
+
+        $city2->delete();
+
+        $this->assertEquals(2, $user->addresses()->first()->addresses()->count());
+        $this->assertEquals('Lyon', $country->addresses()->last()->city);
+
+        $user = User::where('name', 'John Doe')->first();
+        $this->assertEquals(2, $user->addresses()->first()->addresses()->count());
+        $this->assertEquals('Lyon', $country->addresses()->last()->city);
+    }
+
+    public function testNestedMixedEmbedsDelete()
+    {
+        $user = User::create(['name' => 'John Doe']);
+        $father = $user->father()->create(['name' => 'Mark Doe']);
+        $country1 = $father->addresses()->create(['country' => 'France']);
+        $country2 = $father->addresses()->create(['country' => 'Belgium']);
+
+        $country1->delete();
+
+        $this->assertEquals(1, $user->father->addresses()->count());
+        $this->assertEquals('Belgium', $user->father->addresses()->last()->country);
+
+        $user = User::where('name', 'John Doe')->first();
+        $this->assertEquals(1, $user->father->addresses()->count());
+        $this->assertEquals('Belgium', $user->father->addresses()->last()->country);
+    }
+
     public function testDoubleAssociate()
     {
         $user = User::create(['name' => 'John Doe']);


### PR DESCRIPTION
The PR fixes deletion of embedded nested objects.
The current implementation uses dot notation which in combination with `$set` update operator does not actually remove objects.

@jenssegers ^