### PR TITLE
Passport support

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ This service provider will slightly modify the internal DatabaseReminderReposito
 
 ### Passport
 
-Passport models are strictly `Illuminate\Database\Eloquent\Model` class. One way is to take ownership of the models, or simply include this service provider:
+Laravel Passport models are strictly using the `Illuminate\Database\Eloquent\Model` class. One way to make the package work is to take ownership of the models, or simply include this service provider:
 
 ```php
 'Jenssegers\Mongodb\Auth\PassportServiceProvider',

--- a/README.md
+++ b/README.md
@@ -296,6 +296,16 @@ If you want to use Laravel's native Auth functionality, register this included s
 
 This service provider will slightly modify the internal DatabaseReminderRepository to add support for MongoDB based password reminders. If you don't use password reminders, you don't have to register this service provider and everything else should work just fine.
 
+### Passport
+
+Passport models are strictly `Illuminate\Database\Eloquent\Model` class. One way is to take ownership of the models, or simply include this service provider:
+
+```php
+'Jenssegers\Mongodb\Auth\PassportServiceProvider',
+```
+
+The service provider will give instance of `Jenssegers\Mongodb\Eloquent\Model` whenever a `Model` class is invoked by any of the Passport models.
+
 ### Queues
 
 If you want to use MongoDB as your database backend, change the the driver in `config/queue.php`:

--- a/src/Jenssegers/Mongodb/Auth/PassportServiceProvider.php
+++ b/src/Jenssegers/Mongodb/Auth/PassportServiceProvider.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Jenssegers\Mongodb\Auth;
+
+use Illuminate\Support\ServiceProvider;
+
+class PassportServiceProvider extends ServiceProvider
+{
+    /**
+     * Bootstrap any application services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        // Passport models
+        $models = [
+            \Laravel\Passport\Token::class,
+            \Laravel\Passport\Client::class,
+            \Laravel\Passport\AuthCode::class,
+            \Laravel\Passport\PersonalAccessClient::class,
+        ];
+
+        foreach ($models as $model) {
+            $this->app->when($model)
+                ->needs(\Illuminate\Database\Eloquent\Model::class)
+                ->give(\Jenssegers\Mongodb\Eloquent\Model::class);
+        }
+    }
+}


### PR DESCRIPTION
Passport package has embedded models, which are tightly coupled to the Illuminate's Eloquent. One way of making Passport work is taking ownership of all the models, but this way you are limited if Passport package updates those models.

A service provider could take responsibility for mapping Illuminate models to Jenssegers' models.