### PR TITLE
fix serialize embedded relationships

### DIFF
--- a/src/Jenssegers/Mongodb/Relations/EmbedsOneOrMany.php
+++ b/src/Jenssegers/Mongodb/Relations/EmbedsOneOrMany.php
@@ -393,4 +393,14 @@ abstract class EmbedsOneOrMany extends Relation
 
         return $results;
     }
+
+    /**
+     * Get the foreign key for the relationship.
+     *
+     * @return string
+     */
+    public function getQualifiedForeignKeyName()
+    {
+        return $this->foreignKey;
+    }
 }

--- a/tests/EmbeddedRelationsTest.php
+++ b/tests/EmbeddedRelationsTest.php
@@ -765,4 +765,23 @@ class EmbeddedRelationsTest extends TestCase
         $this->assertEquals(2, $results->count());
         $this->assertEquals(3, $results->total());
     }
+
+    public function testGetQueueableRelationsEmbedsMany()
+    {
+        $user = User::create(['name' => 'John Doe']);
+        $user->addresses()->save(new Address(['city' => 'New York']));
+        $user->addresses()->save(new Address(['city' => 'Paris']));
+
+        $this->assertEquals(['addresses'], $user->getQueueableRelations());
+        $this->assertEquals([], $user->addresses->getQueueableRelations());
+    }
+
+    public function testGetQueueableRelationsEmbedsOne()
+    {
+        $user = User::create(['name' => 'John Doe']);
+        $user->father()->save(new User(['name' => 'Mark Doe']));
+
+        $this->assertEquals(['father'], $user->getQueueableRelations());
+        $this->assertEquals([], $user->father->getQueueableRelations());
+    }
 }


### PR DESCRIPTION
Currently, when you serialize a model (usually to place on a queue) with an embedded relationship, a loop occurs when all nested relationships are sent to the queue (https://github.com/laravel/framework/pull/21229). This is due to the parent relationship, which is duplicated in the embedded model. Pull Request removes the parent relationship from the model's embedded.