### PR TITLE
fix dsn config when not unix socket

### DIFF
--- a/src/Jenssegers/Mongodb/Connection.php
+++ b/src/Jenssegers/Mongodb/Connection.php
@@ -4,7 +4,6 @@ namespace Jenssegers\Mongodb;
 
 use Illuminate\Database\Connection as BaseConnection;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Str;
 use MongoDB\Client;
 
 class Connection extends BaseConnection
@@ -151,7 +150,7 @@ class Connection extends BaseConnection
     }
 
     /**
-     * Determine if the given configuration array has a UNIX socket value.
+     * Determine if the given configuration array has a dsn string.
      *
      * @param  array  $config
      * @return bool
@@ -162,22 +161,14 @@ class Connection extends BaseConnection
     }
 
     /**
-     * Get the DSN string for a socket configuration.
+     * Get the DSN string form configuration.
      *
      * @param  array  $config
      * @return string
      */
     protected function getDsnString(array $config)
     {
-        $dsn_string = $config['dsn'];
-
-        if (Str::contains($dsn_string, 'mongodb://')) {
-            $dsn_string = Str::replaceFirst('mongodb://', '', $dsn_string);
-        }
-
-        $dsn_string = rawurlencode($dsn_string);
-
-        return "mongodb://{$dsn_string}";
+        return $config['dsn'];
     }
 
     /**

--- a/tests/DsnTest.php
+++ b/tests/DsnTest.php
@@ -1,0 +1,14 @@
+<?php
+
+class DsnTest extends TestCase
+{
+    public function test_dsn_works()
+    {
+        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Collection::class, DsnAddress::all());
+    }
+}
+
+class DsnAddress extends Address
+{
+    protected $connection = 'dsn_mongodb';
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -51,6 +51,7 @@ class TestCase extends Orchestra\Testbench\TestCase
         $app['config']->set('database.default', 'mongodb');
         $app['config']->set('database.connections.mysql', $config['connections']['mysql']);
         $app['config']->set('database.connections.mongodb', $config['connections']['mongodb']);
+        $app['config']->set('database.connections.dsn_mongodb', $config['connections']['dsn_mongodb']);
 
         $app['config']->set('auth.model', 'User');
         $app['config']->set('auth.providers.users.model', 'User');

--- a/tests/config/database.php
+++ b/tests/config/database.php
@@ -11,6 +11,12 @@ return [
             'database'   => 'unittest',
         ],
 
+        'dsn_mongodb' => [
+            'driver'    => 'mongodb',
+            'dsn'       => 'mongodb://mongodb:27017',
+            'database'  => 'unittest',
+        ],
+
         'mysql' => [
             'driver'    => 'mysql',
             'host'      => 'mysql',


### PR DESCRIPTION
It is assumed in #1397 that dsn is only for unix sockets. But the assumption is wrong, causing issues #1456 and #1449 

IMO, a better approach would be having a separate `unix_socket` config to be encoded via `rawurlencode()` in this package or just let the users call `rawurlencode()` themselves when providing such URIs in 'dsn'.