### PR TITLE
New way for drop index

### DIFF
--- a/src/Jenssegers/Mongodb/Schema/Blueprint.php
+++ b/src/Jenssegers/Mongodb/Schema/Blueprint.php
@@ -80,19 +80,24 @@ class Blueprint extends \Illuminate\Database\Schema\Blueprint
     {
         $columns = $this->fluent($columns);
 
-        // Columns are passed as a default array.
-        if (is_array($columns) && is_int(key($columns))) {
-            // Transform the columns to the required array format.
-            $transform = [];
-
-            foreach ($columns as $column) {
-                $transform[$column] = $column . '_1';
-            }
-
-            $columns = $transform;
+        $listOfCurrentIndexes = [];
+        foreach ($this->collection->listIndexes() as $currentIndexName) {
+            $listOfCurrentIndexes[] = $currentIndexName['name'];
         }
 
-        foreach ($columns as $column) {
+        //Filter columns with exists indexes
+        $existsIndexes = [];
+        foreach ($columns as $indexName) {
+            if(in_array($indexName, $listOfCurrentIndexes)) {
+                $existsIndexes[] = $indexName;
+            }
+            $postFixedIndexName = $indexName . '_1';
+            if(in_array($postFixedIndexName, $listOfCurrentIndexes)) {
+                $existsIndexes[] = $postFixedIndexName;
+            }
+        }
+
+        foreach ($existsIndexes as $column) {
             $this->collection->dropIndex($column);
         }
 

--- a/src/Jenssegers/Mongodb/Schema/Blueprint.php
+++ b/src/Jenssegers/Mongodb/Schema/Blueprint.php
@@ -88,11 +88,11 @@ class Blueprint extends \Illuminate\Database\Schema\Blueprint
         //Filter columns with exists indexes
         $existsIndexes = [];
         foreach ($columns as $indexName) {
-            if(in_array($indexName, $listOfCurrentIndexes)) {
+            if (in_array($indexName, $listOfCurrentIndexes)) {
                 $existsIndexes[] = $indexName;
             }
             $postFixedIndexName = $indexName . '_1';
-            if(in_array($postFixedIndexName, $listOfCurrentIndexes)) {
+            if (in_array($postFixedIndexName, $listOfCurrentIndexes)) {
                 $existsIndexes[] = $postFixedIndexName;
             }
         }

--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -106,6 +106,17 @@ class SchemaTest extends TestCase
 
         $index = $this->getIndex('newcollection', 'uniquekey');
         $this->assertEquals(null, $index);
+
+        Schema::collection('newcollection', function ($collection) {
+            $collection->index(
+                'uniquekey',
+                'uniquekey'
+            );
+            $collection->dropIndex(['uniquekey']);
+        });
+
+        $index = $this->getIndex('newcollection', 'uniquekey');
+        $this->assertEquals(null, $index);
     }
 
     public function testBackground()


### PR DESCRIPTION
Сhanged `dropIndex` method to add support for correct creation/dropping index by index name.
Added test case with index creation using `$name` argument, which failed with current implementation of `dropIndex`

Closes #1036
