### PR TITLE
Fixed error for usage outside Laravel.

### DIFF
--- a/src/Jenssegers/Mongodb/Query/Builder.php
+++ b/src/Jenssegers/Mongodb/Query/Builder.php
@@ -123,7 +123,7 @@ class Builder extends BaseBuilder
     ];
 
     /**
-     * Check if we need to return Collections instead of plain arrays (laravel >= 5.3 )
+     * Check if we need to return Collections instead of plain arrays (laravel >= 5.3 or usage outside laravel)
      *
      * @var boolean
      */
@@ -141,7 +141,7 @@ class Builder extends BaseBuilder
     }
 
     /**
-     * Returns true if Laravel or Lumen >= 5.3
+     * Returns true if Laravel or Lumen >= 5.3 or usage outside Laravel
      *
      * @return bool
      */
@@ -152,6 +152,7 @@ class Builder extends BaseBuilder
             $version = filter_var(explode(')', $version)[0], FILTER_SANITIZE_NUMBER_FLOAT, FILTER_FLAG_ALLOW_FRACTION); // lumen
             return version_compare($version, '5.3', '>=');
         }
+        return true;
     }
 
     /**


### PR DESCRIPTION
An error `Call to a member function all() on array` will encouter when calling `Model::all()` outside Laravel. #978 #1321 

I found that the problem is because the function `shouldUseCollections()` in `Jenssegers\Mongodb\Query\Builder` only checks the version of Laravel, and does not handle the usage outside Laravel.

I added a newline so that the variable `useCollections`is now `true` by default.