### PR TITLE
Updated DatabaseFailedJobProvider

### DIFF
--- a/src/Jenssegers/Mongodb/Queue/Failed/MongoFailedJobProvider.php
+++ b/src/Jenssegers/Mongodb/Queue/Failed/MongoFailedJobProvider.php
@@ -26,7 +26,7 @@ class MongoFailedJobProvider extends DatabaseFailedJobProvider
     /**
      * Get a list of all of the failed jobs.
      *
-     * @return array
+     * @return object[]
      */
     public function all()
     {
@@ -34,7 +34,7 @@ class MongoFailedJobProvider extends DatabaseFailedJobProvider
 
         $all = array_map(function ($job) {
             $job['id'] = (string) $job['_id'];
-            return $job;
+            return (object) $job;
         }, $all);
 
         return $all;
@@ -44,7 +44,7 @@ class MongoFailedJobProvider extends DatabaseFailedJobProvider
      * Get a single failed job.
      *
      * @param  mixed $id
-     * @return array
+     * @return object
      */
     public function find($id)
     {
@@ -52,7 +52,7 @@ class MongoFailedJobProvider extends DatabaseFailedJobProvider
 
         $job['id'] = (string) $job['_id'];
 
-        return $job;
+        return (object) $job;
     }
 
     /**


### PR DESCRIPTION
Updated DatabaseFailedJobProvider to return object(s) instead of arrays as defined by the FailedJobProviderInterface.
Fixes a bug that caused queue:retry to fail when using mongodb for failed jobs.

Resolves #1417 and #1373 