### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,18 @@ If you want to use this library with [Sentry](https://cartalyst.com/manual/sentr
 
 The MongoDB session driver is available in a separate package, check out https://github.com/jenssegers/Laravel-MongoDB-Session
 
+Database Testing
+-------
+
+#### Resetting The Database After Each Test
+```php
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+```
+And inside each test classes.
+```php
+use DatabaseMigrations;
+```
+
 Examples
 --------
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Table of contents
 * [Schema](#schema)
 * [Extensions](#extensions)
 * [Troubleshooting](#troubleshooting)
+* [Database Testing](#database-testing)
 * [Examples](#examples)
 
 Installation


### PR DESCRIPTION
Add Database Testing to index.
`use DatabaseMigrations;` instead of `use RefreshDatabase;` for laravel 5.6 compatibility issue (#1475)