### PR TITLE
bug fix: formatting exception so it can be saved to the database.

### DIFF
--- a/src/Jenssegers/Mongodb/Queue/Failed/MongoFailedJobProvider.php
+++ b/src/Jenssegers/Mongodb/Queue/Failed/MongoFailedJobProvider.php
@@ -4,6 +4,7 @@ namespace Jenssegers\Mongodb\Queue\Failed;
 
 use Carbon\Carbon;
 use Illuminate\Queue\Failed\DatabaseFailedJobProvider;
+use Exception;
 
 class MongoFailedJobProvider extends DatabaseFailedJobProvider
 {
@@ -13,6 +14,7 @@ class MongoFailedJobProvider extends DatabaseFailedJobProvider
      * @param  string $connection
      * @param  string $queue
      * @param  string $payload
+	 * @param  Exception $exception
      *
      * @return void
      */
@@ -20,7 +22,12 @@ class MongoFailedJobProvider extends DatabaseFailedJobProvider
     {
         $failed_at = Carbon::now()->getTimestamp();
 
-        $this->getTable()->insert(compact('connection', 'queue', 'payload', 'failed_at', 'exception'));
+		$exception = [
+			'Message: ' 	=> $exception->getMessage(),
+			'Stack Trace: ' => $exception->getTrace()
+		];
+
+		$this->getTable()->insert(compact('connection', 'queue', 'payload', 'failed_at', 'exception'));
     }
 
     /**


### PR DESCRIPTION
I have encountered the problem with saving failed jobs to mongo, - the exception field is always blank. 
The problem was reproduced using amqp and mysql as queue drivers, and mongo db version 3.6.2 on ubuntu 14.04. 
I have formatted the exception field into the array with the message and stack trace as keys. 
This way exception can be saved to the mongo db database.
