### PR TITLE
Fix drop index

### DIFF
--- a/src/Jenssegers/Mongodb/Schema/Blueprint.php
+++ b/src/Jenssegers/Mongodb/Schema/Blueprint.php
@@ -76,25 +76,22 @@ class Blueprint extends \Illuminate\Database\Schema\Blueprint
     /**
      * @inheritdoc
      */
-    public function dropIndex($columns = null)
+    public function dropIndex($indexOrColumns = null)
     {
-        $columns = $this->fluent($columns);
+        if (is_array($indexOrColumns)) {
+            $indexOrColumns = $this->fluent($indexOrColumns);
 
-        // Columns are passed as a default array.
-        if (is_array($columns) && is_int(key($columns))) {
-            // Transform the columns to the required array format.
+            // Transform the columns to the index name.
             $transform = [];
 
-            foreach ($columns as $column) {
+            foreach ($indexOrColumns as $column) {
                 $transform[$column] = $column . '_1';
             }
 
-            $columns = $transform;
+            $indexOrColumns = join('_', $transform);
         }
 
-        foreach ($columns as $column) {
-            $this->collection->dropIndex($column);
-        }
+        $this->collection->dropIndex($indexOrColumns);
 
         return $this;
     }

--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -93,7 +93,7 @@ class SchemaTest extends TestCase
     {
         Schema::collection('newcollection', function ($collection) {
             $collection->unique('uniquekey');
-            $collection->dropIndex('uniquekey');
+            $collection->dropIndex('uniquekey_1');
         });
 
         $index = $this->getIndex('newcollection', 'uniquekey');
@@ -106,6 +106,34 @@ class SchemaTest extends TestCase
 
         $index = $this->getIndex('newcollection', 'uniquekey');
         $this->assertEquals(null, $index);
+
+        Schema::collection('newcollection', function ($collection) {
+            $collection->index(['field_a', 'field_b']);
+        });
+
+        $index = $this->getIndex('newcollection', 'field_a_1_field_b_1');
+        $this->assertNotNull($index);
+
+        Schema::collection('newcollection', function ($collection) {
+            $collection->dropIndex(['field_a', 'field_b']);
+        });
+
+        $index = $this->getIndex('newcollection', 'field_a_1_field_b_1');
+        $this->assertFalse($index);
+
+        Schema::collection('newcollection', function ($collection) {
+            $collection->index(['field_a', 'field_b'], 'custom_index_name');
+        });
+
+        $index = $this->getIndex('newcollection', 'custom_index_name');
+        $this->assertNotNull($index);
+
+        Schema::collection('newcollection', function ($collection) {
+            $collection->dropIndex('custom_index_name');
+        });
+
+        $index = $this->getIndex('newcollection', 'custom_index_name');
+        $this->assertFalse($index);
     }
 
     public function testBackground()


### PR DESCRIPTION
Fixes bug that prevents dropping compound indexes with multiple fields.
Indexes can now be dropped by name or column list, adhering to the Illuminate Blueprint interface.

Closes #1036 #1478

Alternative to #1459