### PR TITLE
 Fix #1293: Exception: BelongsToMany Is Not supported for hybrid query constraints! #1324 

### DIFF
--- a/src/Jenssegers/Mongodb/Helpers/QueriesRelationships.php
+++ b/src/Jenssegers/Mongodb/Helpers/QueriesRelationships.php
@@ -4,6 +4,7 @@ namespace Jenssegers\Mongodb\Helpers;
 
 use Closure;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasOneOrMany;
 use Jenssegers\Mongodb\Eloquent\Model;
 

--- a/src/Jenssegers/Mongodb/Helpers/QueriesRelationships.php
+++ b/src/Jenssegers/Mongodb/Helpers/QueriesRelationships.php
@@ -112,7 +112,11 @@ trait QueriesRelationships
             return $relation->getForeignKey();
         }
 
-        throw new \Exception(class_basename($relation) . ' Is Not supported for hybrid query constraints!');
+        if ($relation instanceof BelongsToMany && ! $this->isAcrossConnections($relation)) {
+            return $this->model->getKeyName();
+        }
+
+        throw new \Exception(class_basename($relation) . ' is not supported for hybrid query constraints.');
     }
 
     /**


### PR DESCRIPTION
This fixes issue #1293 where non-hybrid BelongsToMany relations were throwing the described exception.

I previously submitted this change as PR #1324 but closed it as I developed the original fix on a previous build. I've made sure this change is compatible with the latest version, and am resubmitting this.

(Sorry that I can't reopen the original PR, but I had to recreate the branch on my account)