### PR TITLE
Gets database name from DSN string

### DIFF
--- a/src/Jenssegers/Mongodb/Connection.php
+++ b/src/Jenssegers/Mongodb/Connection.php
@@ -4,7 +4,6 @@ namespace Jenssegers\Mongodb;
 
 use Illuminate\Database\Connection as BaseConnection;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Str;
 use MongoDB\Client;
 
 class Connection extends BaseConnection
@@ -151,7 +150,7 @@ class Connection extends BaseConnection
     }
 
     /**
-     * Determine if the given configuration array has a UNIX socket value.
+     * Determine if the given configuration array has a dsn string.
      *
      * @param  array  $config
      * @return bool
@@ -162,22 +161,14 @@ class Connection extends BaseConnection
     }
 
     /**
-     * Get the DSN string for a socket configuration.
+     * Get the DSN string form configuration.
      *
      * @param  array  $config
      * @return string
      */
     protected function getDsnString(array $config)
     {
-        $dsn_string = $config['dsn'];
-
-        if (Str::contains($dsn_string, 'mongodb://')) {
-            $dsn_string = Str::replaceFirst('mongodb://', '', $dsn_string);
-        }
-
-        $dsn_string = rawurlencode($dsn_string);
-
-        return "mongodb://{$dsn_string}";
+        return $config['dsn'];
     }
 
     /**

--- a/src/Jenssegers/Mongodb/Connection.php
+++ b/src/Jenssegers/Mongodb/Connection.php
@@ -41,7 +41,7 @@ class Connection extends BaseConnection
         $this->connection = $this->createConnection($dsn, $config, $options);
 
         // Select database
-        $this->db = $this->connection->selectDatabase($config['database']);
+        $this->db = $this->connection->selectDatabase($this->getDatabaseDsn($dsn));
 
         $this->useDefaultPostProcessor();
 
@@ -191,8 +191,17 @@ class Connection extends BaseConnection
 
         // Check if we want to authenticate against a specific database.
         $auth_database = isset($config['options']) && !empty($config['options']['database']) ? $config['options']['database'] : null;
-
         return 'mongodb://' . implode(',', $hosts) . ($auth_database ? '/' . $auth_database : '');
+    }
+
+    /**
+     * Get database name from DSN string.
+     * @param string $dsn
+     * @return string
+     */
+    protected function getDatabaseDsn($dsn)
+    {
+        return trim(parse_url($dsn, PHP_URL_PATH), '/');
     }
 
     /**

--- a/src/Jenssegers/Mongodb/Connection.php
+++ b/src/Jenssegers/Mongodb/Connection.php
@@ -41,7 +41,7 @@ class Connection extends BaseConnection
         $this->connection = $this->createConnection($dsn, $config, $options);
 
         // Select database
-        $this->db = $this->connection->selectDatabase($this->getDatabaseDsn($dsn));
+        $this->db = $this->connection->selectDatabase($this->getDatabaseDsn($dsn, $config['database']));
 
         $this->useDefaultPostProcessor();
 
@@ -190,7 +190,7 @@ class Connection extends BaseConnection
         }
 
         // Check if we want to authenticate against a specific database.
-        $auth_database = isset($config['database']) && !empty($config['database']) ? $config['database'] : null;
+        $auth_database = isset($config['options']) && !empty($config['options']['database']) ? $config['options']['database'] : null;
         return 'mongodb://' . implode(',', $hosts) . ($auth_database ? '/' . $auth_database : '');
     }
 
@@ -199,9 +199,10 @@ class Connection extends BaseConnection
      * @param string $dsn
      * @return string
      */
-    protected function getDatabaseDsn($dsn)
+    protected function getDatabaseDsn($dsn, $database)
     {
-        return trim(parse_url($dsn, PHP_URL_PATH), '/');
+        $dsnDatabase = trim(parse_url($dsn, PHP_URL_PATH), '/');
+        return $dsnDatabase?:$database;
     }
 
     /**

--- a/src/Jenssegers/Mongodb/Connection.php
+++ b/src/Jenssegers/Mongodb/Connection.php
@@ -195,14 +195,15 @@ class Connection extends BaseConnection
     }
 
     /**
-     * Get database name from DSN string.
+     * Get database name from DSN string, if there is no database in DSN path - returns back $database argument.
      * @param string $dsn
+     * @param $database
      * @return string
      */
     protected function getDatabaseDsn($dsn, $database)
     {
         $dsnDatabase = trim(parse_url($dsn, PHP_URL_PATH), '/');
-        return $dsnDatabase?:$database;
+        return trim($dsnDatabase) ? $dsnDatabase : $database;
     }
 
     /**

--- a/src/Jenssegers/Mongodb/Connection.php
+++ b/src/Jenssegers/Mongodb/Connection.php
@@ -190,7 +190,7 @@ class Connection extends BaseConnection
         }
 
         // Check if we want to authenticate against a specific database.
-        $auth_database = isset($config['options']) && !empty($config['options']['database']) ? $config['options']['database'] : null;
+        $auth_database = isset($config['database']) && !empty($config['database']) ? $config['database'] : null;
         return 'mongodb://' . implode(',', $hosts) . ($auth_database ? '/' . $auth_database : '');
     }
 

--- a/tests/DsnTest.php
+++ b/tests/DsnTest.php
@@ -1,0 +1,14 @@
+<?php
+
+class DsnTest extends TestCase
+{
+    public function test_dsn_works()
+    {
+        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Collection::class, DsnAddress::all());
+    }
+}
+
+class DsnAddress extends Address
+{
+    protected $connection = 'dsn_mongodb';
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -51,6 +51,7 @@ class TestCase extends Orchestra\Testbench\TestCase
         $app['config']->set('database.default', 'mongodb');
         $app['config']->set('database.connections.mysql', $config['connections']['mysql']);
         $app['config']->set('database.connections.mongodb', $config['connections']['mongodb']);
+        $app['config']->set('database.connections.dsn_mongodb', $config['connections']['dsn_mongodb']);
 
         $app['config']->set('auth.model', 'User');
         $app['config']->set('auth.providers.users.model', 'User');

--- a/tests/config/database.php
+++ b/tests/config/database.php
@@ -11,6 +11,12 @@ return [
             'database'   => 'unittest',
         ],
 
+        'dsn_mongodb' => [
+            'driver'    => 'mongodb',
+            'dsn'       => 'mongodb://mongodb:27017',
+            'database'  => 'unittest',
+        ],
+
         'mysql' => [
             'driver'    => 'mysql',
             'host'      => 'mysql',


### PR DESCRIPTION
This contains PR https://github.com/jenssegers/laravel-mongodb/pull/1457
and in addition I've added an ability to use database name from DSN string, so it a developer passed DSN string its not necessary to pass database name.