### PR TITLE
When comparing new value to original, take type into account

### DIFF
--- a/src/Jenssegers/Mongodb/Eloquent/Model.php
+++ b/src/Jenssegers/Mongodb/Eloquent/Model.php
@@ -241,7 +241,7 @@ abstract class Model extends BaseModel
             $current = $current instanceof UTCDateTime ? $this->asDateTime($current) : $current;
             $original = $original instanceof UTCDateTime ? $this->asDateTime($original) : $original;
 
-            return $current == $original;
+            return $current === $original;
         }
 
         if ($this->hasCast($key)) {


### PR DESCRIPTION
This function is called from `getDirty()` to determine if a field on a model has been updated. When comparing dates, the types still need to be checked. You may be trying to replace the string “1994-04-01 00:00:00” with a date value of 1994-04-01 00:00:00, and for these two values, comparison with `==` is true while `===` is false. If we use `==`, the value in the database will remain a string instead of updating to a date as we are trying to do.