### PR TITLE
Added `withDefault` support to EmbedsOne relation

### DIFF
--- a/src/Jenssegers/Mongodb/Relations/EmbedsOne.php
+++ b/src/Jenssegers/Mongodb/Relations/EmbedsOne.php
@@ -3,10 +3,13 @@
 namespace Jenssegers\Mongodb\Relations;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Concerns\SupportsDefaultModels;
 use MongoDB\BSON\ObjectID;
 
 class EmbedsOne extends EmbedsOneOrMany
 {
+    use SupportsDefaultModels;
+
     /**
      * @inheritdoc
      */
@@ -24,7 +27,7 @@ class EmbedsOne extends EmbedsOneOrMany
      */
     public function getResults()
     {
-        return $this->toModel($this->getEmbedded());
+        return $this->toModel($this->getEmbedded()) ?: $this->getDefaultFor($this->parent);
     }
 
     /**
@@ -135,5 +138,13 @@ class EmbedsOne extends EmbedsOneOrMany
     public function delete()
     {
         return $this->performDelete();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function newRelatedInstanceFor(Model $parent)
+    {
+        return $this->related->newInstance();
     }
 }


### PR DESCRIPTION
This pull request aims to add support for Laravel's withDefault function to the EmbedsOne relation, this function provides a way for 1 on 1 relations to define default data if no related model can be found.

Laravel documentation on this method: https://laravel.com/docs/5.6/eloquent-relationships (search for 'default models')