### PR TITLE
fix chunkById for types other than ObjectId and laravel >= 5.6.25

### DIFF
--- a/src/Jenssegers/Mongodb/Query/Builder.php
+++ b/src/Jenssegers/Mongodb/Query/Builder.php
@@ -631,12 +631,6 @@ class Builder extends BaseBuilder
      */
     public function forPageAfterId($perPage = 15, $lastId = 0, $column = '_id')
     {
-        // When using ObjectIDs to paginate, we need to use a hex string as the
-        // "minimum" ID rather than the integer zero so the '$lt' query works.
-        if ($column === '_id' && $lastId === 0) {
-            $lastId = '000000000000000000000000';
-        }
-
         return parent::forPageAfterId($perPage, $lastId, $column);
     }
 


### PR DESCRIPTION
Fixes #1538 
This PR should be merged after laravel 5.7 release.
The removed lines used to fix an issue that is currently being handled in a better way inside laravel/framework. The lines can actually break the code if _id is not of type ObjectId.
