### PR TITLE
Fix inserted _id on association of child to parent in EmbedsMany

### DIFF
--- a/src/Jenssegers/Mongodb/Relations/EmbedsMany.php
+++ b/src/Jenssegers/Mongodb/Relations/EmbedsMany.php
@@ -235,8 +235,8 @@ class EmbedsMany extends EmbedsOneOrMany
      */
     protected function associateNew($model)
     {
-        // Create a new key if needed.
-        if (!$model->getAttribute('_id')) {
+        // Create _id if needed.
+        if (!$model->getKey() && $model->getKeyName() === '_id') {
             $model->setAttribute('_id', new ObjectID);
         }
 


### PR DESCRIPTION
When an object is associated to parent in `associateNew`, a Mongo ID is created and added to the model regardless of the key set on the model. This commit changes the behaviour to only add the _id in instances where the primary key is set to be `_id`. This _may_ be a breaking change if code is depending on this behaviour; but the existing behaviour is undocumented.

Fixes #1310