### PR TITLE
Changes in travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ php:
 services:
   - docker
 
+before_script:
+  - docker pull composer
+  - docker run --rm -v $(pwd):/app composer install --prefer-source --no-interaction
 install:
   - docker version
   - sudo pip install docker-compose

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,8 @@ install:
   - docker version
   - sudo pip install docker-compose
   - docker-compose version
-  - sed -i -e "s/php:cli/php:${TRAVIS_PHP_VERSION}-cli/g" Dockerfile
   - cat Dockerfile
-  - docker-compose build
+  - docker-compose build --build-arg PHP_VERSION="${TRAVIS_PHP_VERSION}"
 
 script:
   - docker-compose up --exit-code-from php

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
   - sudo pip install docker-compose
   - docker-compose version
   - cat Dockerfile
-  - docker-compose build --build-arg PHP_VERSION="${TRAVIS_PHP_VERSION}"
+  - docker-compose build --build-arg PHP_VERSION=${TRAVIS_PHP_VERSION}
 
 script:
   - docker-compose up --exit-code-from php

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,6 @@ php:
 services:
   - docker
 
-before_script:
-  - docker pull composer
-  - docker run --rm -v $(pwd):/app composer install --prefer-source --no-interaction
 install:
   - docker version
   - sudo pip install docker-compose

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM php:cli
+ARG PHP_VERSION
+
+FROM php:${PHP_VERSION}-cli
 
 RUN pecl install xdebug
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,9 @@ FROM php:${PHP_VERSION}-cli
 RUN pecl install xdebug
 
 RUN apt-get update && \
-    apt-get install -y autoconf pkg-config libssl-dev git && \
-    pecl install mongodb git zlib1g-dev && docker-php-ext-enable mongodb && \
+    apt-get install -y autoconf pkg-config libssl-dev git zlib1g-dev
+
+RUN pecl install mongodb && docker-php-ext-enable mongodb && \
     docker-php-ext-install -j$(nproc) pdo pdo_mysql zip && docker-php-ext-enable xdebug
 
 RUN curl -sS https://getcomposer.org/installer | php \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ services:
         volumes:
             - .:/code
         working_dir: /code
+        environment:
+          PHP_VERSION: ${TRAVIS_PHP_VERSION}
         command: bash -c "composer install --prefer-source --no-interaction && php ./vendor/bin/phpunit"
         depends_on:
           - mysql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
         working_dir: /code
         environment:
           PHP_VERSION: ${PHP_VERSION}
-        command: bash -c "composer install --prefer-source --no-interaction && php ./vendor/bin/phpunit"
+        command: bash -c "php ./vendor/bin/phpunit"
         depends_on:
           - mysql
           - mongodb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
 version: '3'
 
 services:
-
     php:
         container_name: php
         build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
         working_dir: /code
         environment:
           PHP_VERSION: ${PHP_VERSION}
-        command: bash -c "php ./vendor/bin/phpunit"
+        command: bash -c "composer install --prefer-source --no-interaction && php ./vendor/bin/phpunit"
         depends_on:
           - mysql
           - mongodb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
             - .:/code
         working_dir: /code
         environment:
-          PHP_VERSION: ${PHP_VERSION}
+          PHP_VERSION: 7.1
         command: bash -c "composer install --prefer-source --no-interaction && php ./vendor/bin/phpunit"
         depends_on:
           - mysql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
             - .:/code
         working_dir: /code
         environment:
-          PHP_VERSION: ${TRAVIS_PHP_VERSION}
+          PHP_VERSION: ${PHP_VERSION}
         command: bash -c "composer install --prefer-source --no-interaction && php ./vendor/bin/phpunit"
         depends_on:
           - mysql


### PR DESCRIPTION
On my opinion we don't need execute sed command in `.travis.yml` because Docker engine has arguments in Dockerfile and we can use it 
- Add arg PHP_VERSION in `Dockerfile`
- Set arg PHP_VERSION in `.travis.yml` from env variable `TRAVIS_PHP_VERSION`
- Package `zlib1g-dev` replaced from `pecl install` to `apt-get install`