### PR TITLE
Allow setting hint option on QueryBuilder

### DIFF
--- a/src/Jenssegers/Mongodb/Query/Builder.php
+++ b/src/Jenssegers/Mongodb/Query/Builder.php
@@ -375,10 +375,12 @@ class Builder extends BaseBuilder
             if ($this->limit) {
                 $options['limit'] = $this->limit;
             }
+            if ($this->hint) {
+                $options['hint'] = $this->hint;
+            }
             if ($columns) {
                 $options['projection'] = $columns;
             }
-            // if ($this->hint)    $cursor->hint($this->hint);
 
             // Fix for legacy support, converts the results to arrays instead of objects.
             $options['typeMap'] = ['root' => 'array', 'document' => 'array'];

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -701,4 +701,25 @@ class QueryBuilderTest extends TestCase
             $this->assertEquals(1, count($result['tags']));
         }
     }
+
+    public function testHintOptions()
+    {
+        DB::collection('items')->insert([
+            ['name' => 'fork',  'tags' => ['sharp', 'pointy']],
+            ['name' => 'spork', 'tags' => ['sharp', 'pointy', 'round', 'bowl']],
+            ['name' => 'spoon', 'tags' => ['round', 'bowl']],
+        ]);
+
+        $results = DB::collection('items')->hint(['$natural' => -1])->get();
+
+        $this->assertArraySubset(['name' => 'spoon'], $results[0]);
+        $this->assertArraySubset(['name' => 'spork'], $results[1]);
+        $this->assertArraySubset(['name' => 'fork'], $results[2]);
+
+        $results = DB::collection('items')->hint(['$natural' => 1])->get();
+
+        $this->assertArraySubset(['name' => 'spoon'], $results[2]);
+        $this->assertArraySubset(['name' => 'spork'], $results[1]);
+        $this->assertArraySubset(['name' => 'fork'], $results[0]);
+    }
 }


### PR DESCRIPTION
The hint option allows us to use the $natural ordering meta operator. 

I've added tests that validate that hint options are rather sent.

Thanks !