### PR TITLE
Fix issue using query builder first() method (in case with usage outside the Laravel)

### DIFF
--- a/src/Jenssegers/Mongodb/Query/Builder.php
+++ b/src/Jenssegers/Mongodb/Query/Builder.php
@@ -152,6 +152,8 @@ class Builder extends BaseBuilder
             $version = filter_var(explode(')', $version)[0], FILTER_SANITIZE_NUMBER_FLOAT, FILTER_FLAG_ALLOW_FRACTION); // lumen
             return version_compare($version, '5.3', '>=');
         }
+
+        return true;
     }
 
     /**


### PR DESCRIPTION
In my case when i using the query builder outside the Laravel app i catching error

`Fatal error: Uncaught Error: Call to a member function first() on array in /application/vendor/illuminate/database/Concerns/BuildsQueries.php on line 77` 

In the new versions of illuminate/database  `BuildsQueries`  first() method  looks like

```
public function first($columns = ['*'])
    {
        return $this->take(1)->get($columns)->first();
    }
```
So it means that get() method must return collection not the array. I made the simple change that would fix this issue. 