### PR TITLE
Fix inefficient regex in like operator

### DIFF
--- a/src/Jenssegers/Mongodb/Query/Builder.php
+++ b/src/Jenssegers/Mongodb/Query/Builder.php
@@ -995,7 +995,7 @@ class Builder extends BaseBuilder
             $operator = '=';
 
             // Convert to regular expression.
-            $regex = preg_replace('#(^|[^\\\])%#', '$1.*', preg_quote($value));
+            $regex = preg_replace('#(^|[^\\\])%#', '$1', preg_quote($value));
 
             // Convert like to regular expression.
             if (!Str::startsWith($value, '%')) {


### PR DESCRIPTION
### Current condition:
`where('table_name', 'like', '%keyword%')` is converted to `/.*keyword.*/` which is not efficient for string matching
### Improvement:
convert like operator to more efficient regex which is `/keyword/`

### Regex performance comparison:
Text : 
```
MongoDB World 2018 drew MongoDB community members from across the globe. At the event, attendees were able to meet with experts, connect with one another, and have a good time at the daily closing receptions. If you weren’t able to attend and followed the #MDBW18 hashtag, chances are you found yourself dealing with a bit of FOMO. But just because you missed out on the in-person experience doesn’t mean you have to miss out on the learning.
```
Matching keyword `MongoDB`:
- Regex `/.*MongoDB.*/` use 430 steps
- Regex `/MongoDB/` use 20 steps

I check that steps on https://regex101.com/