### PR TITLE
Support for _id of binary type (to use UUIDs as _id)

### DIFF
--- a/src/Jenssegers/Mongodb/Eloquent/Model.php
+++ b/src/Jenssegers/Mongodb/Eloquent/Model.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Jenssegers\Mongodb\Query\Builder as QueryBuilder;
+use MongoDB\BSON\Binary;
 use MongoDB\BSON\ObjectID;
 use MongoDB\BSON\UTCDateTime;
 use Illuminate\Contracts\Queue\QueueableEntity;
@@ -56,6 +57,8 @@ abstract class Model extends BaseModel
         // Convert ObjectID to string.
         if ($value instanceof ObjectID) {
             return (string) $value;
+        } elseif ($value instanceof Binary) {
+            return (string) $value->getData();
         }
 
         return $value;
@@ -165,7 +168,7 @@ abstract class Model extends BaseModel
     public function setAttribute($key, $value)
     {
         // Convert _id to ObjectID.
-        if ($key == '_id' && is_string($value)) {
+        if (($key == '_id' || Str::endsWith($key, '_id')) && is_string($value)) {
             $builder = $this->newBaseQueryBuilder();
 
             $value = $builder->convertKey($value);
@@ -197,6 +200,8 @@ abstract class Model extends BaseModel
         foreach ($attributes as $key => &$value) {
             if ($value instanceof ObjectID) {
                 $value = (string) $value;
+            } elseif ($value instanceof Binary) {
+                $value = (string) $value->getData();
             }
         }
 

--- a/src/Jenssegers/Mongodb/Query/Builder.php
+++ b/src/Jenssegers/Mongodb/Query/Builder.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Jenssegers\Mongodb\Connection;
 use MongoCollection;
+use MongoDB\BSON\Binary;
 use MongoDB\BSON\ObjectID;
 use MongoDB\BSON\Regex;
 use MongoDB\BSON\UTCDateTime;
@@ -849,6 +850,8 @@ class Builder extends BaseBuilder
     {
         if (is_string($id) && strlen($id) === 24 && ctype_xdigit($id)) {
             return new ObjectID($id);
+        } elseif (strlen($id) === 16 && preg_match('~[^\x20-\x7E\t\r\n]~', $id) > 0) {
+            return new Binary($id, Binary::TYPE_UUID);
         }
 
         return $id;
@@ -909,7 +912,7 @@ class Builder extends BaseBuilder
             }
 
             // Convert id's.
-            if (isset($where['column']) && ($where['column'] == '_id' || Str::endsWith($where['column'], '._id'))) {
+            if (isset($where['column']) && ($where['column'] == '_id' || Str::endsWith($where['column'], '_id'))) {
                 // Multiple values.
                 if (isset($where['values'])) {
                     foreach ($where['values'] as &$value) {


### PR DESCRIPTION
While using the ObjectID type is the default implementation in MongoDB, it's technically possible to use anything for the primary key as long as you use a unique value. Some implementations (including mine) use a UUID as the primary key. UUIDs are stored in MongoDB as Binary types. The provider in its current state doesn't work in that situation.

These PR are the changes I've made to make it work. The only thing not included is a trait that automatically generates the UUID on the "creating", for example:
```
<?php

namespace App;

use MongoDB\BSON\Binary;
use Ramsey\Uuid\Uuid;

trait MongodbBinaryUuid
{
    /**
     * Boot the trait.
     *
     * @return void
     */
    protected static function bootMongodbBinaryUuid()
    {
        static::creating(function (Model $model) {
            if ($model->{$model->getKeyName()}) {
                return;
            }

            $model->{$model->getKeyName()} = new Binary(static::encodeUuid(Uuid::uuid1()), Binary::TYPE_UUID);
        });
    }
}
```
Note that my actual trait is actually more complete, with scopes and such.

I'm not sure this is the best way but it works for my use case and I'm curious to hear feedback. Surely I can be the only one with a need to use UUIDs as _id right? ;)