### PR TITLE
add lists method to eloquent builder.

### DIFF
--- a/src/Jenssegers/Mongodb/Eloquent/Builder.php
+++ b/src/Jenssegers/Mongodb/Eloquent/Builder.php
@@ -232,4 +232,22 @@ class Builder extends EloquentBuilder
 
         return $results;
     }
+
+    /**
+     * Override lists method
+     *
+     * @param string $column
+     * @param string $key
+     * 
+     * @return \Illuminate\Support\Collection
+     **/
+    public function lists($column, $key = null)
+    {
+        if ($key === "_id") {
+        
+            return parent::get([$column, $key])->lists($column, $key);
+        }
+
+        return parent::lists($column, $key);
+    }
 }

--- a/src/Jenssegers/Mongodb/Eloquent/Builder.php
+++ b/src/Jenssegers/Mongodb/Eloquent/Builder.php
@@ -238,13 +238,11 @@ class Builder extends EloquentBuilder
      *
      * @param string $column
      * @param string $key
-     * 
      * @return \Illuminate\Support\Collection
      **/
     public function lists($column, $key = null)
     {
         if ($key === "_id") {
-        
             return parent::get([$column, $key])->lists($column, $key);
         }
 


### PR DESCRIPTION
[Illuminate\Database\Eloquent\Builder](https://github.com/laravel/framework/blob/5.2/src/Illuminate/Database/Eloquent/Builder.php#L467) has lists method

so it's will never call [Jenssegers\Mongodb\Query\Builder](https://github.com/jenssegers/laravel-mongodb/blob/2.3/src/Jenssegers/Mongodb/Query/Builder.php#L622)'s lists method