### PR TITLE
Fix for QueryExecuted events firing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,9 @@
         "illuminate/container": "^5.6",
         "illuminate/database": "^5.6",
         "illuminate/events": "^5.6",
-        "mongodb/mongodb": "^1.0.0"
+        "mongodb/mongodb": "^1.0.0",
+        "ext-json": "*",
+        "ext-mongodb": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0|^7.0",

--- a/src/Jenssegers/Mongodb/Collection.php
+++ b/src/Jenssegers/Mongodb/Collection.php
@@ -55,7 +55,7 @@ class Collection
         // Convert the query parameters to a json string.
         array_walk_recursive($parameters, function (&$item, $key) {
             if ($item instanceof ObjectID) {
-                $item = (string)$item;
+                $item = (string) $item;
             }
         });
 
@@ -70,9 +70,9 @@ class Collection
 
         $implodeQuery = implode(',', $query);
 
-        $collection   = $this->collection->getCollectionName();
+        $collection = $this->collection->getCollectionName();
 
-        $queryString  = "{$collection}.{$method}({$implodeQuery})";
+        $queryString = "{$collection}.{$method}({$implodeQuery})";
 
         $this->connection->logQuery($queryString, [], $time);
 


### PR DESCRIPTION
QueryExecuted events wasnt firing w/o DB::connection('mongodb')->enableQueryLogging().
This PR removes conditional, so events will fire.