### PR TITLE
Fixes eager loads for hasMany relations

### DIFF
--- a/src/Jenssegers/Mongodb/Eloquent/Model.php
+++ b/src/Jenssegers/Mongodb/Eloquent/Model.php
@@ -26,6 +26,13 @@ abstract class Model extends BaseModel
     protected $collection;
 
     /**
+     * Indicates if the IDs are auto-incrementing.
+     *
+     * @var bool
+     */
+    public $incrementing = false;
+    
+    /**
      * The primary key for the model.
      *
      * @var string


### PR DESCRIPTION
Illuminate\Database\Eloquent\Relations\Relation.php@whereInMethod uses model's $incrementing property to determine which method to use for eager loading of relations. If it's incrementing == true, then it uses whereIntegerInRaw which is wrong.