### PR TITLE
Replaced whereIn method retrieval for relations

### DIFF
--- a/src/Jenssegers/Mongodb/Relations/BelongsTo.php
+++ b/src/Jenssegers/Mongodb/Relations/BelongsTo.php
@@ -3,6 +3,7 @@
 namespace Jenssegers\Mongodb\Relations;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model as EloquentModel;
 
 class BelongsTo extends \Illuminate\Database\Eloquent\Relations\BelongsTo
 {
@@ -58,5 +59,17 @@ class BelongsTo extends \Illuminate\Database\Eloquent\Relations\BelongsTo
     public function getOwnerKey()
     {
         return property_exists($this, 'ownerKey') ? $this->ownerKey : $this->otherKey;
+    }
+
+    /**
+     * Get the name of the "where in" method for eager loading.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
+     * @return string
+     */
+    protected function whereInMethod(EloquentModel $model, $key)
+    {
+        return 'whereIn';
     }
 }

--- a/src/Jenssegers/Mongodb/Relations/BelongsToMany.php
+++ b/src/Jenssegers/Mongodb/Relations/BelongsToMany.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany as EloquentBelongsToMany;
 use Illuminate\Support\Arr;
+use Illuminate\Database\Eloquent\Model as EloquentModel;
 
 class BelongsToMany extends EloquentBelongsToMany
 {
@@ -336,5 +337,17 @@ class BelongsToMany extends EloquentBelongsToMany
     public function getRelatedKey()
     {
         return property_exists($this, 'relatedPivotKey') ? $this->relatedPivotKey : $this->relatedKey;
+    }
+
+    /**
+     * Get the name of the "where in" method for eager loading.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
+     * @return string
+     */
+    protected function whereInMethod(EloquentModel $model, $key)
+    {
+        return 'whereIn';
     }
 }

--- a/src/Jenssegers/Mongodb/Relations/EmbedsMany.php
+++ b/src/Jenssegers/Mongodb/Relations/EmbedsMany.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Pagination\Paginator;
 use MongoDB\BSON\ObjectID;
+use Illuminate\Database\Eloquent\Model as EloquentModel;
 
 class EmbedsMany extends EmbedsOneOrMany
 {
@@ -327,5 +328,17 @@ class EmbedsMany extends EmbedsOneOrMany
         }
 
         return parent::__call($method, $parameters);
+    }
+
+    /**
+     * Get the name of the "where in" method for eager loading.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
+     * @return string
+     */
+    protected function whereInMethod(EloquentModel $model, $key)
+    {
+        return 'whereIn';
     }
 }

--- a/src/Jenssegers/Mongodb/Relations/EmbedsOne.php
+++ b/src/Jenssegers/Mongodb/Relations/EmbedsOne.php
@@ -4,6 +4,7 @@ namespace Jenssegers\Mongodb\Relations;
 
 use Illuminate\Database\Eloquent\Model;
 use MongoDB\BSON\ObjectID;
+use Illuminate\Database\Eloquent\Model as EloquentModel;
 
 class EmbedsOne extends EmbedsOneOrMany
 {
@@ -135,5 +136,17 @@ class EmbedsOne extends EmbedsOneOrMany
     public function delete()
     {
         return $this->performDelete();
+    }
+
+    /**
+     * Get the name of the "where in" method for eager loading.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
+     * @return string
+     */
+    protected function whereInMethod(EloquentModel $model, $key)
+    {
+        return 'whereIn';
     }
 }

--- a/src/Jenssegers/Mongodb/Relations/EmbedsOneOrMany.php
+++ b/src/Jenssegers/Mongodb/Relations/EmbedsOneOrMany.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Jenssegers\Mongodb\Eloquent\Model;
+use Illuminate\Database\Eloquent\Model as EloquentModel;
 
 abstract class EmbedsOneOrMany extends Relation
 {
@@ -402,5 +403,17 @@ abstract class EmbedsOneOrMany extends Relation
     public function getQualifiedForeignKeyName()
     {
         return $this->foreignKey;
+    }
+
+    /**
+     * Get the name of the "where in" method for eager loading.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
+     * @return string
+     */
+    protected function whereInMethod(EloquentModel $model, $key)
+    {
+        return 'whereIn';
     }
 }

--- a/src/Jenssegers/Mongodb/Relations/HasMany.php
+++ b/src/Jenssegers/Mongodb/Relations/HasMany.php
@@ -4,6 +4,7 @@ namespace Jenssegers\Mongodb\Relations;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\HasMany as EloquentHasMany;
+use Illuminate\Database\Eloquent\Model as EloquentModel;
 
 class HasMany extends EloquentHasMany
 {
@@ -76,5 +77,17 @@ class HasMany extends EloquentHasMany
         $key = $this->wrap($this->getQualifiedParentKeyName());
 
         return $query->where($this->getHasCompareKey(), 'exists', true);
+    }
+
+    /**
+     * Get the name of the "where in" method for eager loading.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
+     * @return string
+     */
+    protected function whereInMethod(EloquentModel $model, $key)
+    {
+        return 'whereIn';
     }
 }

--- a/src/Jenssegers/Mongodb/Relations/HasOne.php
+++ b/src/Jenssegers/Mongodb/Relations/HasOne.php
@@ -4,6 +4,7 @@ namespace Jenssegers\Mongodb\Relations;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\HasOne as EloquentHasOne;
+use Illuminate\Database\Eloquent\Model as EloquentModel;
 
 class HasOne extends EloquentHasOne
 {
@@ -76,5 +77,17 @@ class HasOne extends EloquentHasOne
         $key = $this->wrap($this->getQualifiedParentKeyName());
 
         return $query->where($this->getForeignKeyName(), 'exists', true);
+    }
+    
+    /**
+     * Get the name of the "where in" method for eager loading.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
+     * @return string
+     */
+    protected function whereInMethod(EloquentModel $model, $key)
+    {
+        return 'whereIn';
     }
 }

--- a/src/Jenssegers/Mongodb/Relations/MorphTo.php
+++ b/src/Jenssegers/Mongodb/Relations/MorphTo.php
@@ -3,6 +3,7 @@
 namespace Jenssegers\Mongodb\Relations;
 
 use Illuminate\Database\Eloquent\Relations\MorphTo as EloquentMorphTo;
+use Illuminate\Database\Eloquent\Model as EloquentModel;
 
 class MorphTo extends EloquentMorphTo
 {
@@ -41,5 +42,17 @@ class MorphTo extends EloquentMorphTo
     public function getOwnerKey()
     {
         return property_exists($this, 'ownerKey') ? $this->ownerKey : $this->otherKey;
+    }
+
+    /**
+     * Get the name of the "where in" method for eager loading.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
+     * @return string
+     */
+    protected function whereInMethod(EloquentModel $model, $key)
+    {
+        return 'whereIn';
     }
 }


### PR DESCRIPTION
Replaced whereIn method retrieval for relations, to force use standart whereIn instead of whereInRawInteger.