### PR TITLE
Improve pagination execution time 

### DIFF
--- a/src/Jenssegers/Mongodb/Query/Builder.php
+++ b/src/Jenssegers/Mongodb/Query/Builder.php
@@ -272,7 +272,7 @@ class Builder extends BaseBuilder
 
                     // Null coalense only > 7.2
 
-                    $aggregations = blank($this->aggregate['collumns']) ? [] : $this->aggregate['collumns'];
+                    $aggregations = blank($this->aggregate['columns']) ? [] : $this->aggregate['columns'];
 
                     if (in_array('*', $aggregations) && $function == 'count') {
                         // When ORM is paginating, count doesnt need a aggregation, just a cursor operation
@@ -284,8 +284,8 @@ class Builder extends BaseBuilder
                         // Preserving format expected by framework
                         $results = [
                             [
-                                "_id"       => null,
-                                "aggregate" => $totalResults
+                                '_id'       => null,
+                                'aggregate' => $totalResults
                             ]
                         ];
                         return $this->useCollections ? new Collection($results) : $results;

--- a/src/Jenssegers/Mongodb/Query/Builder.php
+++ b/src/Jenssegers/Mongodb/Query/Builder.php
@@ -289,7 +289,6 @@ class Builder extends BaseBuilder
                     } elseif ($function == 'count') {
                         // Translate count into sum.
                         $group['aggregate'] = ['$sum' => 1];
-
                     } else {
                         $group['aggregate'] = ['$' . $function => '$' . $column];
                     }

--- a/src/Jenssegers/Mongodb/Query/Builder.php
+++ b/src/Jenssegers/Mongodb/Query/Builder.php
@@ -235,7 +235,7 @@ class Builder extends BaseBuilder
         $wheres = $this->compileWheres();
 
         // Use MongoDB's aggregation framework when using grouping or aggregation functions.
-        if ($this->groups || $this->aggregate || $this->paginating) {
+        if ($this->groups || $this->aggregate) {
             $group = [];
             $unwinds = [];
 
@@ -279,15 +279,7 @@ class Builder extends BaseBuilder
                     }
                 }
             }
-
-            // When using pagination, we limit the number of returned columns
-            // by adding a projection.
-            if ($this->paginating) {
-                foreach ($this->columns as $column) {
-                    $this->projections[$column] = 1;
-                }
-            }
-
+            
             // The _id field is mandatory when using grouping.
             if ($group && empty($group['_id'])) {
                 $group['_id'] = null;


### PR DESCRIPTION
In order to improve pagination, cursor operations instead aggregations pipelines take a better performance.

### Using
https://docs.mongodb.com/manual/reference/method/cursor.count/
### Instead
https://docs.mongodb.com/manual/reference/operator/aggregation/sum/

### Using
https://docs.mongodb.com/manual/reference/method/cursor.skip/
### Instead
https://docs.mongodb.com/manual/reference/operator/aggregation/skip/

### Using
https://docs.mongodb.com/manual/reference/method/cursor.limit/
### Instead
https://docs.mongodb.com/manual/reference/operator/aggregation/limit/



