### PR TITLE
reassigned getDatabaseName method

### DIFF
--- a/src/Jenssegers/Mongodb/Connection.php
+++ b/src/Jenssegers/Mongodb/Connection.php
@@ -114,6 +114,14 @@ class Connection extends BaseConnection
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function getDatabaseName()
+    {
+        return $this->getMongoDB()->getDatabaseName();
+    }
+
+    /**
      * Create a new MongoDB connection.
      *
      * @param  string $dsn


### PR DESCRIPTION
This MR for fixing [https://github.com/jenssegers/laravel-mongodb/issues/1647](url).
For example, [https://github.com/GeneaLabs/laravel-model-caching](url) uses \GeneaLabs\LaravelModelCaching\Traits\CachePrefixing::getDatabaseName() which fails with a null value returned.