### PR TITLE
Update originalIsEquivalent to work with Laravel 5.8

### DIFF
--- a/src/Jenssegers/Mongodb/Eloquent/Model.php
+++ b/src/Jenssegers/Mongodb/Eloquent/Model.php
@@ -228,7 +228,7 @@ abstract class Model extends BaseModel
     /**
      * @inheritdoc
      */
-    protected function originalIsEquivalent($key, $current)
+    public function originalIsEquivalent($key, $current)
     {
         if (!array_key_exists($key, $this->original)) {
             return false;


### PR DESCRIPTION
The originalIsEquivalent method of the  Illuminate\Database\Eloquent\Concerns\HasAttributes trait has been changed from  protected to public.

All that we need to do to make this work with Laravel 5.8 si to change this method to public, all the rest of the functionality seems to work.