### PR TITLE
Updating with updated_at column triggers some weird behaviour

### DIFF
--- a/src/Jenssegers/Mongodb/Query/Builder.php
+++ b/src/Jenssegers/Mongodb/Query/Builder.php
@@ -1146,7 +1146,7 @@ class Builder extends BaseBuilder
 
         return array_merge(
             [$column => $this->model->freshTimestampString()],
-            $values,
+            $values
         );
     }
 

--- a/src/Jenssegers/Mongodb/Query/Builder.php
+++ b/src/Jenssegers/Mongodb/Query/Builder.php
@@ -1134,6 +1134,23 @@ class Builder extends BaseBuilder
     }
 
     /**
+     * @inheritdoc
+     */
+    protected function addUpdatedAtColumn(array $values)
+    {
+        if (! $this->model->usesTimestamps()) {
+            return $values;
+        }
+
+        $column = $this->qualifyColumn($this->model->getUpdatedAtColumn());
+
+        return array_merge(
+            [$column => $this->model->freshTimestampString()],
+            $values,
+        );
+    }
+
+    /**
      * Set custom options for the query.
      *
      * @param  array $options

--- a/tests/AuthTest.php
+++ b/tests/AuthTest.php
@@ -5,7 +5,7 @@ use Illuminate\Foundation\Application;
 
 class AuthTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         User::truncate();
         DB::collection('password_reminders')->truncate();

--- a/tests/EmbeddedRelationsTest.php
+++ b/tests/EmbeddedRelationsTest.php
@@ -2,7 +2,7 @@
 
 class EmbeddedRelationsTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         Mockery::close();
 

--- a/tests/GeospatialTest.php
+++ b/tests/GeospatialTest.php
@@ -2,7 +2,7 @@
 
 class GeospatialTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -43,7 +43,7 @@ class GeospatialTest extends TestCase
         ]);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Schema::drop('locations');
     }

--- a/tests/HybridRelationsTest.php
+++ b/tests/HybridRelationsTest.php
@@ -2,7 +2,7 @@
 
 class HybridRelationsTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -11,7 +11,7 @@ class HybridRelationsTest extends TestCase
         MysqlRole::executeSchema();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         MysqlUser::truncate();
         MysqlBook::truncate();

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -8,7 +8,7 @@ use MongoDB\BSON\UTCDateTime;
 
 class ModelTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         User::truncate();
         Soft::truncate();

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -548,4 +548,13 @@ class ModelTest extends TestCase
 
         $this->assertEquals(3, $count);
     }
+
+    public function testUpdateWithUpdatedAt()
+    {
+        $item = Item::create(['name' => 'sword']);
+        $item->update($item->toArray());
+
+        $this->assertNull($item->items);
+        $this->assertNull(optional($item->items)->updated_at);
+    }
 }

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -5,7 +5,7 @@ use MongoDB\BSON\Regex;
 
 class QueryBuilderTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         DB::collection('users')->truncate();
         DB::collection('items')->truncate();

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -4,7 +4,7 @@ class QueryTest extends TestCase
 {
     protected static $started = false;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         User::create(['name' => 'John Doe', 'age' => 35, 'title' => 'admin']);
@@ -18,7 +18,7 @@ class QueryTest extends TestCase
         User::create(['name' => 'Error', 'age' => null, 'title' => null]);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         User::truncate();
         parent::tearDown();

--- a/tests/QueueTest.php
+++ b/tests/QueueTest.php
@@ -2,7 +2,7 @@
 
 class QueueTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/RelationsTest.php
+++ b/tests/RelationsTest.php
@@ -2,7 +2,7 @@
 
 class RelationsTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         Mockery::close();
 

--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -2,7 +2,7 @@
 
 class SchemaTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         Schema::drop('newcollection');
     }

--- a/tests/SeederTest.php
+++ b/tests/SeederTest.php
@@ -2,7 +2,7 @@
 
 class SeederTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         User::truncate();
     }

--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -2,7 +2,7 @@
 
 class ValidationTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         User::truncate();
     }


### PR DESCRIPTION
Closes #1720 

The initial PR on laravel/framework that broke things: https://github.com/laravel/framework/issues/27791

I decided to revert the changes and fix PHPUnit 7.5 `void` hints.