### PR TITLE
use env values from phpunit.xml, update database.php and queue.php

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -42,4 +42,13 @@
             <directory>tests/ValidationTest.php</directory>
         </testsuite>
     </testsuites>
+    <php>
+        <env name="MONGO_HOST" value="mongodb"/>
+        <env name="MONGO_DATABASE" value="unittest"/>
+        <env name="MONGO_PORT" value="27017"/>
+        <env name="MYSQL_HOST" value="mysql"/>
+        <env name="MYSQL_DATABASE" value="unittest"/>
+        <env name="MYSQL_USERNAME" value="root"/>
+        <env name="QUEUE_CONNECTION" value="database"/>
+    </php>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -15,31 +15,31 @@
             <directory>tests/</directory>
         </testsuite>
         <testsuite name="schema">
-            <directory>tests/SchemaTest.php</directory>
+            <file>tests/SchemaTest.php</file>
         </testsuite>
         <testsuite name="seeder">
-            <directory>tests/SeederTest.php</directory>
+            <file>tests/SeederTest.php</file>
         </testsuite>
         <testsuite name="cache">
-            <directory>tests/CacheTest.php</directory>
+            <file>tests/CacheTest.php</file>
         </testsuite>
         <testsuite name="builder">
-            <directory>tests/QueryBuilderTest.php</directory>
-            <directory>tests/QueryTest.php</directory>
+            <file>tests/QueryBuilderTest.php</file>
+            <file>tests/QueryTest.php</file>
         </testsuite>
         <testsuite name="model">
-            <directory>tests/ModelTest.php</directory>
-            <directory>tests/RelationsTest.php</directory>
+            <file>tests/ModelTest.php</file>
+            <file>tests/RelationsTest.php</file>
         </testsuite>
         <testsuite name="relations">
-            <directory>tests/RelationsTest.php</directory>
-            <directory>tests/EmbeddedRelationsTest.php</directory>
+            <file>tests/RelationsTest.php</file>
+            <file>tests/EmbeddedRelationsTest.php</file>
         </testsuite>
         <testsuite name="mysqlrelations">
-            <directory>tests/RelationsTest.php</directory>
+            <file>tests/RelationsTest.php</file>
         </testsuite>
         <testsuite name="validation">
-            <directory>tests/ValidationTest.php</directory>
+            <file>tests/ValidationTest.php</file>
         </testsuite>
     </testsuites>
     <php>

--- a/tests/QueueTest.php
+++ b/tests/QueueTest.php
@@ -24,6 +24,7 @@ class QueueTest extends TestCase
             'displayName' => 'test',
             'job' => 'test',
             'maxTries' => null,
+            'delay' => null,
             'timeout' => null,
             'data' => ['action' => 'QueueJobLifeCycle'],
         ]), $job->getRawBody());

--- a/tests/config/database.php
+++ b/tests/config/database.php
@@ -1,7 +1,7 @@
 <?php
 
 $mongoHost = env('MONGO_HOST', 'mongodb');
-$mongoPort = env('MONGO_PORT') ? intval(env('MONGO_PORT')) : 27017;
+$mongoPort = env('MONGO_PORT') ? (int) env('MONGO_PORT') : 27017;
 
 return [
 

--- a/tests/config/database.php
+++ b/tests/config/database.php
@@ -1,5 +1,8 @@
 <?php
 
+$mongoHost = env('MONGO_HOST', 'mongodb');
+$mongoPort = env('MONGO_PORT') ? intval(env('MONGO_PORT')) : 27017;
+
 return [
 
     'connections' => [
@@ -7,21 +10,21 @@ return [
         'mongodb' => [
             'name'       => 'mongodb',
             'driver'     => 'mongodb',
-            'host'       => 'mongodb',
-            'database'   => 'unittest',
+            'host'       => $mongoHost,
+            'database'   => env('MONGO_DATABASE', 'unittest'),
         ],
 
         'dsn_mongodb' => [
             'driver'    => 'mongodb',
-            'dsn'       => 'mongodb://mongodb:27017',
-            'database'  => 'unittest',
+            'dsn'       => "mongodb://$mongoHost:$mongoPort",
+            'database'  => env('MONGO_DATABASE', 'unittest'),
         ],
 
         'mysql' => [
             'driver'    => 'mysql',
-            'host'      => 'mysql',
-            'database'  => 'unittest',
-            'username'  => 'root',
+            'host'      => env('MYSQL_HOST', 'mysql'),
+            'database'  => env('MYSQL_DATABASE', 'unittest'),
+            'username'  => env('MYSQL_USERNAME', 'root'),
             'password'  => '',
             'charset'   => 'utf8',
             'collation' => 'utf8_unicode_ci',

--- a/tests/config/queue.php
+++ b/tests/config/queue.php
@@ -2,7 +2,7 @@
 
 return [
 
-    'default' => 'database',
+    'default' => env('QUEUE_CONNECTION'),
 
     'connections' => [
 
@@ -16,7 +16,7 @@ return [
     ],
 
     'failed' => [
-        'database' => 'mongodb',
+        'database' => env('MONGO_DATABASE'),
         'table'    => 'failed_jobs',
     ],
 


### PR DESCRIPTION
- Add values for env variables to phpunit.xml
- Use env values instead hardcode values

It is can usefull if one of variables (`MONGO_HOST` for example) is different from default hardcode value 