### PR TITLE
EmbedsMany respect primaryKey on association

### DIFF
--- a/src/Jenssegers/Mongodb/Relations/EmbedsMany.php
+++ b/src/Jenssegers/Mongodb/Relations/EmbedsMany.php
@@ -236,7 +236,7 @@ class EmbedsMany extends EmbedsOneOrMany
     protected function associateNew($model)
     {
         // Create a new key if needed.
-        if (!$model->getAttribute('_id')) {
+        if ($model->getKeyName() == '_id' && !$model->getAttribute('_id')) {
             $model->setAttribute('_id', new ObjectID);
         }
 


### PR DESCRIPTION
I have a situation where I don't want my EmbedsMany objects to have an _id attribute. Normally I can just set the $primaryKey = null on my object. But EmbedsMany is not respecting this on new associations. This change fixes that.