### PR TITLE
Return proper value instead of _id on QueryBuilder

### DIFF
--- a/src/Jenssegers/Mongodb/Query/Builder.php
+++ b/src/Jenssegers/Mongodb/Query/Builder.php
@@ -206,6 +206,16 @@ class Builder extends BaseBuilder
     /**
      * @inheritdoc
      */
+    public function value($column)
+    {
+        $result = (array) $this->first([$column]);
+
+        return Arr::get($result, $column);
+    }
+
+    /**
+     * @inheritdoc
+     */
     public function get($columns = [])
     {
         return $this->getFresh($columns);

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -701,4 +701,16 @@ class QueryBuilderTest extends TestCase
             $this->assertEquals(1, count($result['tags']));
         }
     }
+
+    public function testValue()
+    {
+        DB::collection('books')->insert([
+            ['title' => 'Moby-Dick', 'author' => ['first_name' => 'Herman', 'last_name' => 'Melville']]
+        ]);
+
+        $this->assertEquals('Moby-Dick', DB::collection('books')->value('title'));
+        $this->assertEquals(['first_name' => 'Herman', 'last_name' => 'Melville'], DB::collection('books')->value('author'));
+        $this->assertEquals('Herman', DB::collection('books')->value('author.first_name'));
+        $this->assertEquals('Melville', DB::collection('books')->value('author.last_name'));
+    }
 }


### PR DESCRIPTION
The default implementation for `QueryBuilder::value` doesn't work with mongo, due to the fact that when using a projection, mongo always returns the `_id`.

This change accommodates for that, and also allows using dot notation to get a nested value.

Fixes #1741