### PR TITLE
Handle case of array of ObjectIDs correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ composer.lock
 *.project
 .idea/
 .phpunit.result.cache
+.vscode

--- a/src/Jenssegers/Mongodb/Query/Builder.php
+++ b/src/Jenssegers/Mongodb/Query/Builder.php
@@ -842,6 +842,10 @@ class Builder extends BaseBuilder
      */
     public function convertKey($id)
     {
+        if(is_array($id)) {
+            return array_map(array($this, __FUNCTION__), $id);
+        }
+        
         if (is_string($id) && strlen($id) === 24 && ctype_xdigit($id)) {
             return new ObjectID($id);
         }

--- a/src/Jenssegers/Mongodb/Query/Builder.php
+++ b/src/Jenssegers/Mongodb/Query/Builder.php
@@ -842,7 +842,7 @@ class Builder extends BaseBuilder
      */
     public function convertKey($id)
     {
-        if(is_array($id)) {
+        if (is_array($id)) {
             return array_map(array($this, __FUNCTION__), $id);
         }
         

--- a/src/Jenssegers/Mongodb/Relations/BelongsTo.php
+++ b/src/Jenssegers/Mongodb/Relations/BelongsTo.php
@@ -25,7 +25,15 @@ class BelongsTo extends \Illuminate\Database\Eloquent\Relations\BelongsTo
             // For belongs to relationships, which are essentially the inverse of has one
             // or has many relationships, we need to actually query on the primary key
             // of the related models matching on the foreign key that's on a parent.
-            $this->query->where($this->getOwnerKey(), '=', $this->parent->{$this->foreignKey});
+            $foreign = $this->parent->{$this->foreignKey};
+            if (is_array($foreign)) {
+                // This means that it is a one-to-many relationship. Try a match using whereIn.
+                $this->query->whereIn($this->getOwnerKey(), $foreign);
+            }
+            else {
+                // It's a one-to-one relationship, just match using the classic equals operator.
+                $this->query->where($this->getOwnerKey(), '=', $foreign);
+            }
         }
     }
 

--- a/src/Jenssegers/Mongodb/Relations/BelongsTo.php
+++ b/src/Jenssegers/Mongodb/Relations/BelongsTo.php
@@ -21,20 +21,21 @@ class BelongsTo extends \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
     public function addConstraints()
     {
-        if (static::$constraints) {
-            // For belongs to relationships, which are essentially the inverse of has one
-            // or has many relationships, we need to actually query on the primary key
-            // of the related models matching on the foreign key that's on a parent.
-            $foreign = $this->parent->{$this->foreignKey};
-            if (is_array($foreign)) {
-                // This means that it is a one-to-many relationship. Try a match using whereIn.
-                $this->query->whereIn($this->getOwnerKey(), $foreign);
-            }
-            else {
-                // It's a one-to-one relationship, just match using the classic equals operator.
-                $this->query->where($this->getOwnerKey(), '=', $foreign);
-            }
+        if (!static::$constraints) {
+            return;
         }
+        // For belongs to relationships, which are essentially the inverse of has one
+        // or has many relationships, we need to actually query on the primary key
+        // of the related models matching on the foreign key that's on a parent.
+        $foreign = $this->parent->{$this->foreignKey};
+        // Check if the foreign key is an array, so we can infer the cardinality of the relationship.
+        if (is_array($foreign)) {
+            // This means that it is a one-to-many relationship. Try a match using whereIn.
+            $this->query->whereIn($this->getOwnerKey(), $foreign);
+            return;
+        }
+        // It's a one-to-one relationship, just match using the classic equals operator.
+        $this->query->where($this->getOwnerKey(), '=', $foreign);
     }
 
     /**


### PR DESCRIPTION
In case an array of ObjectId-formatted Strings enter this method, this converts them to ObjectIds so that the query succeeds. Happens when calling 'get' method for one-to-many relations.