### PR TITLE
Get base query before update so that scopes are applied

### DIFF
--- a/src/Jenssegers/Mongodb/Eloquent/Builder.php
+++ b/src/Jenssegers/Mongodb/Eloquent/Builder.php
@@ -44,7 +44,7 @@ class Builder extends EloquentBuilder
             return 1;
         }
 
-        return $this->query->update($this->addUpdatedAtColumn($values), $options);
+        return $this->toBase()->update($this->addUpdatedAtColumn($values), $options);
     }
 
     /**

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -21,6 +21,7 @@ class QueryTest extends TestCase
     public function tearDown(): void
     {
         User::truncate();
+        Scoped::truncate();
         parent::tearDown();
     }
 
@@ -308,5 +309,22 @@ class QueryTest extends TestCase
         $this->assertNull($results->first()->title);
         $this->assertEquals(9, $results->total());
         $this->assertEquals(1, $results->currentPage());
+    }
+
+    public function testUpdate()
+    {
+        $this->assertEquals(1, User::where(['name' => 'John Doe'])->update(['name' => 'Jim Morrison']));
+        $this->assertEquals(1, User::where(['name' => 'Jim Morrison'])->count());
+
+        Scoped::create(['favorite' => true]);
+        Scoped::create(['favorite' => false]);
+
+        $this->assertCount(1, Scoped::get());
+        $this->assertEquals(1, Scoped::query()->update(['name' => 'Johnny']));
+        $this->assertCount(1, Scoped::withoutGlobalScopes()->where(['name' => 'Johnny'])->get());
+
+        $this->assertCount(2, Scoped::withoutGlobalScopes()->get());
+        $this->assertEquals(2, Scoped::withoutGlobalScopes()->update(['name' => 'Jimmy']));
+        $this->assertCount(2, Scoped::withoutGlobalScopes()->where(['name' => 'Jimmy'])->get());
     }
 }

--- a/tests/models/Scoped.php
+++ b/tests/models/Scoped.php
@@ -1,0 +1,20 @@
+<?php
+
+use Jenssegers\Mongodb\Eloquent\Model as Eloquent;
+use Jenssegers\Mongodb\Eloquent\Builder;
+
+class Scoped extends Eloquent
+{
+    protected $connection = 'mongodb';
+    protected $collection = 'scoped';
+    protected $fillable = ['name', 'favorite'];
+
+    protected static function boot()
+    {
+        parent::boot();
+
+        static::addGlobalScope('favorite', function (Builder $builder) {
+            $builder->where('favorite', true);
+        });
+    }
+}


### PR DESCRIPTION
If we do `toBase()` on update (as `Illuminate\Database\Eloquent\Builder` does), then it applies global scopes to the query so that it updates only those models that it should.

Fixes #1798