### PR TITLE
fix for non string id

### DIFF
--- a/src/Jenssegers/Mongodb/Query/Builder.php
+++ b/src/Jenssegers/Mongodb/Query/Builder.php
@@ -854,7 +854,7 @@ class Builder extends BaseBuilder
     {
         if (is_string($id) && strlen($id) === 24 && ctype_xdigit($id)) {
             return new ObjectID($id);
-        } elseif (strlen($id) === 16 && preg_match('~[^\x20-\x7E\t\r\n]~', $id) > 0) {
+        } elseif (is_string($id) && strlen($id) === 16 && preg_match('~[^\x20-\x7E\t\r\n]~', $id) > 0) {
             return new Binary($id, Binary::TYPE_UUID);
         }
 


### PR DESCRIPTION
#1611 breaks the following query:
```php
$query->where('_id', 'mod', [2, 1]);
```
With the exception:
```strlen() expects parameter 1 to be string, array given```.

To fix it we have to check if $id is string before call to strlen().
