### PR TITLE
Overwrite whereIn function in MorphMany relation.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "illuminate/container": "^5.8",
         "illuminate/database": "^5.8",
         "illuminate/events": "^5.8",
-        "mongodb/mongodb": "^1.4"
+        "mongodb/mongodb": "1.4.*"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0|^7.0",

--- a/src/Jenssegers/Mongodb/Eloquent/HybridRelations.php
+++ b/src/Jenssegers/Mongodb/Eloquent/HybridRelations.php
@@ -2,7 +2,6 @@
 
 namespace Jenssegers\Mongodb\Eloquent;
 
-use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Support\Str;
 use Jenssegers\Mongodb\Helpers\EloquentBuilder;
@@ -10,6 +9,7 @@ use Jenssegers\Mongodb\Relations\BelongsTo;
 use Jenssegers\Mongodb\Relations\BelongsToMany;
 use Jenssegers\Mongodb\Relations\HasMany;
 use Jenssegers\Mongodb\Relations\HasOne;
+use Jenssegers\Mongodb\Relations\MorphMany;
 use Jenssegers\Mongodb\Relations\MorphTo;
 
 trait HybridRelations

--- a/src/Jenssegers/Mongodb/Relations/MorphMany.php
+++ b/src/Jenssegers/Mongodb/Relations/MorphMany.php
@@ -15,7 +15,7 @@ class MorphMany extends EloquentMorphMany
      *
      * @return string
      */
-    protected function whereInMethod( EloquentModel $model, $key )
+    protected function whereInMethod(EloquentModel $model, string $key )
     {
         return 'whereIn';
     }

--- a/src/Jenssegers/Mongodb/Relations/MorphMany.php
+++ b/src/Jenssegers/Mongodb/Relations/MorphMany.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Jenssegers\Mongodb\Relations;
+
+use Illuminate\Database\Eloquent\Model as EloquentModel;
+use Illuminate\Database\Eloquent\Relations\MorphMany as EloquentMorphMany;
+
+class MorphMany extends EloquentMorphMany
+{
+    /**
+     * Get the name of the "where in" method for eager loading.
+     *
+     * @param \Illuminate\Database\Eloquent\Model $model
+     * @param string $key
+     *
+     * @return string
+     */
+    protected function whereInMethod( EloquentModel $model, $key )
+    {
+        return 'whereIn';
+    }
+}

--- a/src/Jenssegers/Mongodb/Relations/MorphMany.php
+++ b/src/Jenssegers/Mongodb/Relations/MorphMany.php
@@ -15,7 +15,7 @@ class MorphMany extends EloquentMorphMany
      *
      * @return string
      */
-    protected function whereInMethod(EloquentModel $model, string $key )
+    protected function whereInMethod(EloquentModel $model, $key)
     {
         return 'whereIn';
     }


### PR DESCRIPTION
When we using `MorphMany` relation, this Exception occurred: 
`Call to undefined method Jenssegers\Mongodb\Query\Builder::compileWhereInRaw()`

This PR overwrite `whereInMethod` function to return `whereIn` instade of the default (`whereInRaw`).