### PR TITLE
Feat/support laravel 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,15 +11,15 @@
     ],
     "license" : "MIT",
     "require": {
-        "illuminate/support": "^5.8",
-        "illuminate/container": "^5.8",
-        "illuminate/database": "^5.8",
-        "illuminate/events": "^5.8",
+        "illuminate/support": "^6.0",
+        "illuminate/container": "^6.0",
+        "illuminate/database": "^6.0",
+        "illuminate/events": "^6.0",
         "mongodb/mongodb": "^1.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.0|^7.0",
-        "orchestra/testbench": "^3.1",
+        "phpunit/phpunit": "^8.0",
+        "orchestra/testbench": "^4.0",
         "mockery/mockery": "^1.0",
         "satooshi/php-coveralls": "^2.0",
         "doctrine/dbal": "^2.5"

--- a/src/Jenssegers/Mongodb/Connection.php
+++ b/src/Jenssegers/Mongodb/Connection.php
@@ -67,9 +67,11 @@ class Connection extends BaseConnection
      * Begin a fluent query against a database collection.
      *
      * @param  string $table
+     * @param  string|null  $as
+     * @param  string|null  $connection
      * @return Query\Builder
      */
-    public function table($table)
+    public function table($table, $as = null, $connection = null)
     {
         return $this->collection($table);
     }

--- a/src/Jenssegers/Mongodb/Query/Builder.php
+++ b/src/Jenssegers/Mongodb/Query/Builder.php
@@ -690,7 +690,7 @@ class Builder extends BaseBuilder
     /**
      * @inheritdoc
      */
-    public function from($collection)
+    public function from($collection, $as = null)
     {
         if ($collection) {
             $this->collection = $this->connection->getCollection($collection);

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -44,7 +44,7 @@ class ConnectionTest extends TestCase
     // public function testDynamic()
     // {
     //     $dbs = DB::connection('mongodb')->listCollections();
-    //     $this->assertInternalType('array', $dbs);
+    //     $this->assertIsArray($dbs);
     // }
 
     // public function testMultipleConnections()

--- a/tests/EmbeddedRelationsTest.php
+++ b/tests/EmbeddedRelationsTest.php
@@ -36,7 +36,7 @@ class EmbeddedRelationsTest extends TestCase
         $this->assertInstanceOf('DateTime', $address->created_at);
         $this->assertInstanceOf('DateTime', $address->updated_at);
         $this->assertNotNull($address->_id);
-        $this->assertInternalType('string', $address->_id);
+        $this->assertIsString($address->_id);
 
         $raw = $address->getAttributes();
         $this->assertInstanceOf('MongoDB\BSON\ObjectID', $raw['_id']);
@@ -176,7 +176,7 @@ class EmbeddedRelationsTest extends TestCase
         $user = User::create([]);
         $address = $user->addresses()->create(['city' => 'Bruxelles']);
         $this->assertInstanceOf('Address', $address);
-        $this->assertInternalType('string', $address->_id);
+        $this->assertIsString($address->_id);
         $this->assertEquals(['Bruxelles'], $user->addresses->pluck('city')->all());
 
         $raw = $address->getAttributes();
@@ -187,7 +187,7 @@ class EmbeddedRelationsTest extends TestCase
 
         $user = User::create([]);
         $address = $user->addresses()->create(['_id' => '', 'city' => 'Bruxelles']);
-        $this->assertInternalType('string', $address->_id);
+        $this->assertIsString($address->_id);
 
         $raw = $address->getAttributes();
         $this->assertInstanceOf('MongoDB\BSON\ObjectID', $raw['_id']);
@@ -387,14 +387,14 @@ class EmbeddedRelationsTest extends TestCase
         $relations = $user->getRelations();
         $this->assertArrayNotHasKey('addresses', $relations);
         $this->assertArrayHasKey('addresses', $user->toArray());
-        $this->assertInternalType('array', $user->toArray()['addresses']);
+        $this->assertIsArray($user->toArray()['addresses']);
 
         $user = User::with('addresses')->get()->first();
         $relations = $user->getRelations();
         $this->assertArrayHasKey('addresses', $relations);
         $this->assertEquals(2, $relations['addresses']->count());
         $this->assertArrayHasKey('addresses', $user->toArray());
-        $this->assertInternalType('array', $user->toArray()['addresses']);
+        $this->assertIsArray($user->toArray()['addresses']);
     }
 
     public function testEmbedsManyDeleteAll()
@@ -466,7 +466,7 @@ class EmbeddedRelationsTest extends TestCase
         $this->assertInstanceOf('DateTime', $father->created_at);
         $this->assertInstanceOf('DateTime', $father->updated_at);
         $this->assertNotNull($father->_id);
-        $this->assertInternalType('string', $father->_id);
+        $this->assertIsString($father->_id);
 
         $raw = $father->getAttributes();
         $this->assertInstanceOf('MongoDB\BSON\ObjectID', $raw['_id']);
@@ -541,7 +541,7 @@ class EmbeddedRelationsTest extends TestCase
 
         $array = $user->toArray();
         $this->assertArrayHasKey('addresses', $array);
-        $this->assertInternalType('array', $array['addresses']);
+        $this->assertIsArray($array['addresses']);
     }
 
     public function testEmbeddedSave()

--- a/tests/HybridRelationsTest.php
+++ b/tests/HybridRelationsTest.php
@@ -27,7 +27,7 @@ class HybridRelationsTest extends TestCase
         // Mysql User
         $user->name = "John Doe";
         $user->save();
-        $this->assertInternalType('int', $user->id);
+        $this->assertIsInt($user->id);
 
         // SQL has many
         $book = new Book(['title' => 'Game of Thrones']);
@@ -93,8 +93,8 @@ class HybridRelationsTest extends TestCase
         $otherUser->id = 3;
         $otherUser->save();
         // Make sure they are created
-        $this->assertInternalType('int', $user->id);
-        $this->assertInternalType('int', $otherUser->id);
+        $this->assertIsInt($user->id);
+        $this->assertIsInt($otherUser->id);
         // Clear to start
         $user->books()->truncate();
         $otherUser->books()->truncate();
@@ -147,8 +147,8 @@ class HybridRelationsTest extends TestCase
         $otherUser->id = 3;
         $otherUser->save();
         // Make sure they are created
-        $this->assertInternalType('int', $user->id);
-        $this->assertInternalType('int', $otherUser->id);
+        $this->assertIsInt($user->id);
+        $this->assertIsInt($otherUser->id);
         // Clear to start
         Book::truncate();
         MysqlBook::truncate();

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -39,7 +39,7 @@ class ModelTest extends TestCase
         $this->assertEquals(1, User::count());
 
         $this->assertTrue(isset($user->_id));
-        $this->assertInternalType('string', $user->_id);
+        $this->assertIsString($user->_id);
         $this->assertNotEquals('', (string) $user->_id);
         $this->assertNotEquals(0, strlen((string) $user->_id));
         $this->assertInstanceOf(Carbon::class, $user->created_at);
@@ -110,7 +110,7 @@ class ModelTest extends TestCase
         $this->assertEquals('customId', $user->_id);
 
         $raw = $user->getAttributes();
-        $this->assertInternalType('string', $raw['_id']);
+        $this->assertIsString($raw['_id']);
     }
 
     public function testManualIntId()
@@ -126,7 +126,7 @@ class ModelTest extends TestCase
         $this->assertEquals(1, $user->_id);
 
         $raw = $user->getAttributes();
-        $this->assertInternalType('integer', $raw['_id']);
+        $this->assertIsInt($raw['_id']);
     }
 
     public function testDelete()
@@ -339,9 +339,9 @@ class ModelTest extends TestCase
         $keys = array_keys($array);
         sort($keys);
         $this->assertEquals(['_id', 'created_at', 'name', 'type', 'updated_at'], $keys);
-        $this->assertInternalType('string', $array['created_at']);
-        $this->assertInternalType('string', $array['updated_at']);
-        $this->assertInternalType('string', $array['_id']);
+        $this->assertIsString($array['created_at']);
+        $this->assertIsString( $array['updated_at']);
+        $this->assertIsString($array['_id']);
     }
 
     public function testUnset()

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Str;
 use MongoDB\BSON\UTCDateTime;
 use MongoDB\BSON\Regex;
 
@@ -40,7 +41,7 @@ class QueryBuilderTest extends TestCase
 
         DB::collection('items')->where('user_id', $user_id)->delete($pid);
 
-        DB::collection('items')->where('user_id', $user_id)->delete(str_random(32));
+        DB::collection('items')->where('user_id', $user_id)->delete(Str::random(32));
 
         $this->assertEquals(2, DB::collection('items')->count());
     }
@@ -85,7 +86,7 @@ class QueryBuilderTest extends TestCase
 
         $user = $users[0];
         $this->assertEquals('John Doe', $user['name']);
-        $this->assertInternalType('array', $user['tags']);
+        $this->assertIsArray($user['tags']);
     }
 
     public function testInsertGetId()
@@ -109,7 +110,7 @@ class QueryBuilderTest extends TestCase
 
         $users = DB::collection('users')->get();
         $this->assertCount(2, $users);
-        $this->assertInternalType('array', $users[0]['tags']);
+        $this->assertIsArray($users[0]['tags']);
     }
 
     public function testFind()
@@ -245,7 +246,7 @@ class QueryBuilderTest extends TestCase
         DB::collection('users')->where('_id', $id)->push('tags', 'tag1');
 
         $user = DB::collection('users')->find($id);
-        $this->assertInternalType('array', $user['tags']);
+        $this->assertIsArray($user['tags']);
         $this->assertCount(1, $user['tags']);
         $this->assertEquals('tag1', $user['tags'][0]);
 
@@ -267,7 +268,7 @@ class QueryBuilderTest extends TestCase
         $message = ['from' => 'Jane', 'body' => 'Hi John'];
         DB::collection('users')->where('_id', $id)->push('messages', $message);
         $user = DB::collection('users')->find($id);
-        $this->assertInternalType('array', $user['messages']);
+        $this->assertIsArray($user['messages']);
         $this->assertCount(1, $user['messages']);
         $this->assertEquals($message, $user['messages'][0]);
 
@@ -296,14 +297,14 @@ class QueryBuilderTest extends TestCase
         DB::collection('users')->where('_id', $id)->pull('tags', 'tag3');
 
         $user = DB::collection('users')->find($id);
-        $this->assertInternalType('array', $user['tags']);
+        $this->assertIsArray($user['tags']);
         $this->assertCount(3, $user['tags']);
         $this->assertEquals('tag4', $user['tags'][2]);
 
         DB::collection('users')->where('_id', $id)->pull('messages', $message1);
 
         $user = DB::collection('users')->find($id);
-        $this->assertInternalType('array', $user['messages']);
+        $this->assertIsArray($user['messages']);
         $this->assertCount(1, $user['messages']);
 
         // Raw

--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -227,6 +227,7 @@ class SchemaTest extends TestCase
             $collection->boolean('activated')->default(0);
             $collection->integer('user_id')->unsigned();
         });
+        $this->assertEquals('newcollection', DB::getCollection('newcollection')->getCollectionName());
     }
 
     public function testSparseUnique()


### PR DESCRIPTION
This PR would allow a version of laravel-mongodb support installs on laravel 6.0.

It could be a different release tag or branch as it seems to have been done before.

Or possibly left until laravel 6.0 is more stable and the majority of user base has adopted and migrated to an updated codebase?

for #1821

(apologies for the first brief pr message..., I pressed enter to return the line.)