### PR TITLE
fix filtering with operator not like issue

### DIFF
--- a/src/Jenssegers/Mongodb/Query/Builder.php
+++ b/src/Jenssegers/Mongodb/Query/Builder.php
@@ -980,7 +980,7 @@ class Builder extends BaseBuilder
 
         // Replace like or not like with a Regex instance.
         if (in_array($operator, ['like', 'not like'])) {
-            if (Str::startsWith($operator, 'not')) {
+            if ($operator === 'not like') {
                 $operator = 'not';
             } else {
                 $operator = '=';

--- a/src/Jenssegers/Mongodb/Query/Builder.php
+++ b/src/Jenssegers/Mongodb/Query/Builder.php
@@ -978,9 +978,13 @@ class Builder extends BaseBuilder
     {
         extract($where);
 
-        // Replace like with a Regex instance.
-        if ($operator == 'like') {
-            $operator = '=';
+        // Replace like or not like with a Regex instance.
+        if (in_array($operator, ['like', 'not like'])) {
+            if (Str::startsWith($operator, 'not')) {
+                $operator = 'not';
+            } else {
+                $operator = '=';
+            }
 
             // Convert to regular expression.
             $regex = preg_replace('#(^|[^\\\])%#', '$1.*', preg_quote($value));

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -71,6 +71,21 @@ class QueryTest extends TestCase
         $this->assertCount(1, $users);
     }
 
+    public function testNotLike(): void
+    {
+        $users = User::where('name', 'not like', '%doe')->get();
+        $this->assertCount(7, $users);
+
+        $users = User::where('name', 'not like', '%y%')->get();
+        $this->assertCount(6, $users);
+
+        $users = User::where('name', 'not LIKE', '%y%')->get();
+        $this->assertCount(6, $users);
+
+        $users = User::where('name', 'not like', 't%')->get();
+        $this->assertCount(8, $users);
+    }
+
     public function testSelect(): void
     {
         $user = User::where('name', 'John Doe')->select('name')->first();


### PR DESCRIPTION
when filtering data with not like operator like the following example

`User::where('name', 'not like', 'ahmed')`

the following exception has been thrown
**unknown operator: $not like**

this PR fixes this issue and treated it as regex same as the like operator.