### PR TITLE
Fix ambiguous column for "where conditions" in hybrid relations with a "join"

### DIFF
--- a/src/Jenssegers/Mongodb/Helpers/QueriesRelationships.php
+++ b/src/Jenssegers/Mongodb/Helpers/QueriesRelationships.php
@@ -153,16 +153,21 @@ trait QueriesRelationships
      */
     protected function getRelatedConstraintKey($relation)
     {
-        if ($relation instanceof HasOneOrMany) {
-            return $this->model->getKeyName();
+        $prefix = ! $this->model instanceof Model ? $this->model->getTable().'.' : '';
+
+        if ($relation instanceof HasOneOrMany)
+        {
+            return $prefix.$this->model->getKeyName();
         }
 
-        if ($relation instanceof BelongsTo) {
-            return $relation->getForeignKeyName();
+        if ($relation instanceof BelongsTo)
+        {
+            return $prefix.$relation->getForeignKeyName();
         }
 
-        if ($relation instanceof BelongsToMany && !$this->isAcrossConnections($relation)) {
-            return $this->model->getKeyName();
+        if ($relation instanceof BelongsToMany && ! $this->isAcrossConnections($relation))
+        {
+            return $prefix.$this->model->getKeyName();
         }
 
         throw new Exception(class_basename($relation) . ' is not supported for hybrid query constraints.');

--- a/src/Jenssegers/Mongodb/Helpers/QueriesRelationships.php
+++ b/src/Jenssegers/Mongodb/Helpers/QueriesRelationships.php
@@ -153,7 +153,7 @@ trait QueriesRelationships
      */
     protected function getRelatedConstraintKey($relation)
     {
-        $prefix = ! $this->model instanceof Model ? $this->model->getTable().'.' : '';
+        $prefix = $this->model instanceof Model ? '' : $this->model->getTable().'.';
 
         if ($relation instanceof HasOneOrMany)
         {

--- a/src/Jenssegers/Mongodb/Helpers/QueriesRelationships.php
+++ b/src/Jenssegers/Mongodb/Helpers/QueriesRelationships.php
@@ -163,7 +163,7 @@ trait QueriesRelationships
             return $prefix.$relation->getForeignKeyName();
         }
 
-        if ($relation instanceof BelongsToMany && ! $this->isAcrossConnections($relation)) {
+        if ($relation instanceof BelongsToMany && !$this->isAcrossConnections($relation)) {
             return $prefix.$this->model->getKeyName();
         }
 

--- a/src/Jenssegers/Mongodb/Helpers/QueriesRelationships.php
+++ b/src/Jenssegers/Mongodb/Helpers/QueriesRelationships.php
@@ -155,18 +155,15 @@ trait QueriesRelationships
     {
         $prefix = $this->model instanceof Model ? '' : $this->model->getTable().'.';
 
-        if ($relation instanceof HasOneOrMany)
-        {
+        if ($relation instanceof HasOneOrMany) {
             return $prefix.$this->model->getKeyName();
         }
 
-        if ($relation instanceof BelongsTo)
-        {
+        if ($relation instanceof BelongsTo) {
             return $prefix.$relation->getForeignKeyName();
         }
 
-        if ($relation instanceof BelongsToMany && ! $this->isAcrossConnections($relation))
-        {
+        if ($relation instanceof BelongsToMany && ! $this->isAcrossConnections($relation)) {
             return $prefix.$this->model->getKeyName();
         }
 


### PR DESCRIPTION
## Description
Resolve keyname with a prefix of the table name for models which are not of `Jenssegers\Mongodb\Eloquent\Model`.

Fix #1876