### PR TITLE
hotfix/increment-attempts

### DIFF
--- a/src/Jenssegers/Mongodb/Queue/MongoQueue.php
+++ b/src/Jenssegers/Mongodb/Queue/MongoQueue.php
@@ -101,8 +101,8 @@ class MongoQueue extends DatabaseQueue
 
         $reserved = $this->database->collection($this->table)
             ->where('queue', $this->getQueue($queue))
-            ->whereNotNull('reserved_at');
-            ->where('reserved_at', '<=', $expiration);
+            ->whereNotNull('reserved_at')
+            ->where('reserved_at', '<=', $expiration)
             ->get();
 
         foreach ($reserved as $job) {

--- a/src/Jenssegers/Mongodb/Queue/MongoQueue.php
+++ b/src/Jenssegers/Mongodb/Queue/MongoQueue.php
@@ -97,7 +97,6 @@ class MongoQueue extends DatabaseQueue
     protected function releaseJobsThatHaveBeenReservedTooLong($queue)
     {
         $expiration = Carbon::now()->subSeconds($this->retryAfter)->getTimestamp();
-        $now = time();
 
         $reserved = $this->database->collection($this->table)
             ->where('queue', $this->getQueue($queue))

--- a/tests/QueueTest.php
+++ b/tests/QueueTest.php
@@ -69,7 +69,7 @@ class QueueTest extends TestCase
         Queue::push('test1', ['action' => 'QueueJobExpired'], 'test');
         Queue::push('test2', ['action' => 'QueueJobExpired'], 'test');
 
-        $job = Queue::pop('test');
+        Queue::pop('test');
 
         $jobs = Queue::getDatabase()
             ->table(Config::get('queue.connections.database.table'))

--- a/tests/QueueTest.php
+++ b/tests/QueueTest.php
@@ -63,4 +63,20 @@ class QueueTest extends TestCase
 
         $this->assertNull($provider->find(1));
     }
+
+    public function testIncrementAttempts(): void
+    {
+        Queue::push('test1', ['action' => 'QueueJobExpired'], 'test');
+        Queue::push('test2', ['action' => 'QueueJobExpired'], 'test');
+
+        $job = Queue::pop('test');
+
+        $jobs = Queue::getDatabase()
+            ->table(Config::get('queue.connections.database.table'))
+            ->get();
+
+        $this->assertEquals(1, $jobs[0]['attempts']);
+        $this->assertEquals(1, $jobs[0]['reserved']);
+        $this->assertEquals(0, $jobs[1]['attempts']);
+    }
 }

--- a/tests/QueueTest.php
+++ b/tests/QueueTest.php
@@ -67,7 +67,7 @@ class QueueTest extends TestCase
     public function testIncrementAttempts(): void
     {
         $job_id = Queue::push('test1', ['action' => 'QueueJobExpired'], 'test');
-        $this->assertNotNull($id);
+        $this->assertNotNull($job_id);
         $id = Queue::push('test2', ['action' => 'QueueJobExpired'], 'test');
         $this->assertNotNull($id);
 

--- a/tests/QueueTest.php
+++ b/tests/QueueTest.php
@@ -66,17 +66,20 @@ class QueueTest extends TestCase
 
     public function testIncrementAttempts(): void
     {
-        Queue::push('test1', ['action' => 'QueueJobExpired'], 'test');
-        Queue::push('test2', ['action' => 'QueueJobExpired'], 'test');
+        $id = Queue::push('test1', ['action' => 'QueueJobExpired'], 'test');
+        $this->assertNotNull($id);
+        $id = Queue::push('test2', ['action' => 'QueueJobExpired'], 'test');
+        $this->assertNotNull($id);
 
-        Queue::pop('test');
+        $job = Queue::pop('test');
+        $this->assertEquals(1, $job->attempts());
+        $job->delete();
 
-        $jobs = Queue::getDatabase()
+        $others_jobs = Queue::getDatabase()
             ->table(Config::get('queue.connections.database.table'))
             ->get();
 
-        $this->assertEquals(1, $jobs[0]['attempts']);
-        $this->assertEquals(1, $jobs[0]['reserved']);
-        $this->assertEquals(0, $jobs[1]['attempts']);
+        $this->assertCount(1, $others_jobs);
+        $this->assertEquals(0, $others_jobs[0]['attempts']);
     }
 }

--- a/tests/QueueTest.php
+++ b/tests/QueueTest.php
@@ -66,7 +66,7 @@ class QueueTest extends TestCase
 
     public function testIncrementAttempts(): void
     {
-        $id = Queue::push('test1', ['action' => 'QueueJobExpired'], 'test');
+        $job_id = Queue::push('test1', ['action' => 'QueueJobExpired'], 'test');
         $this->assertNotNull($id);
         $id = Queue::push('test2', ['action' => 'QueueJobExpired'], 'test');
         $this->assertNotNull($id);

--- a/tests/QueueTest.php
+++ b/tests/QueueTest.php
@@ -69,7 +69,7 @@ class QueueTest extends TestCase
         $job_id = Queue::push('test1', ['action' => 'QueueJobExpired'], 'test');
         $this->assertNotNull($job_id);
         $job_id = Queue::push('test2', ['action' => 'QueueJobExpired'], 'test');
-        $this->assertNotNull($id);
+        $this->assertNotNull($job_id);
 
         $job = Queue::pop('test');
         $this->assertEquals(1, $job->attempts());

--- a/tests/QueueTest.php
+++ b/tests/QueueTest.php
@@ -68,7 +68,7 @@ class QueueTest extends TestCase
     {
         $job_id = Queue::push('test1', ['action' => 'QueueJobExpired'], 'test');
         $this->assertNotNull($job_id);
-        $id = Queue::push('test2', ['action' => 'QueueJobExpired'], 'test');
+        $job_id = Queue::push('test2', ['action' => 'QueueJobExpired'], 'test');
         $this->assertNotNull($id);
 
         $job = Queue::pop('test');


### PR DESCRIPTION
- increment attempts only when taken from list.

solves problems of "has been attempted too many times or run too long. The job may have previously timed out." even when there are no job errors.

many issues report the problem.