### PR TITLE
Fix dropIndex for compound indexes with sorting order

### DIFF
--- a/src/Jenssegers/Mongodb/Schema/Blueprint.php
+++ b/src/Jenssegers/Mongodb/Schema/Blueprint.php
@@ -129,8 +129,18 @@ class Blueprint extends \Illuminate\Database\Schema\Blueprint
             // Transform the columns to the index name.
             $transform = [];
 
-            foreach ($indexOrColumns as $column) {
-                $transform[$column] = $column . '_1';
+            foreach ($indexOrColumns as $key => $value) {
+                if (is_int($key)) {
+                    // There is no sorting order, use the default.
+                    $column = $value;
+                    $sorting = '1';
+                } else {
+                    // This is a column with sorting order e.g 'my_column' => -1.
+                    $column = $key;
+                    $sorting = $value;
+                }
+
+                $transform[$column] = $column . "_" . $sorting;
             }
 
             $indexOrColumns = implode('_', $transform);

--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -133,6 +133,20 @@ class SchemaTest extends TestCase
         $this->assertFalse($index);
 
         Schema::collection('newcollection', function ($collection) {
+            $collection->index(['field_a' => -1, 'field_b' => 1]);
+        });
+
+        $index = $this->getIndex('newcollection', 'field_a_-1_field_b_1');
+        $this->assertNotNull($index);
+
+        Schema::collection('newcollection', function ($collection) {
+            $collection->dropIndex(['field_a' => -1, 'field_b' => 1]);
+        });
+
+        $index = $this->getIndex('newcollection', 'field_a_-1_field_b_1');
+        $this->assertFalse($index);
+
+        Schema::collection('newcollection', function ($collection) {
             $collection->index(['field_a', 'field_b'], 'custom_index_name');
         });
 


### PR DESCRIPTION
It's not possible to drop an index with a descending sorting order, because the library assumes an ascending order. If no order is given to the field, the default order is used.
