### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,6 +546,11 @@ Selects documents where values match a specified regular expression.
 ```php
 User::where('name', 'regex', new \MongoDB\BSON\Regex("/.*doe/i"))->get();
 ```
+Is the same as
+
+```php
+User::where('name', 'regex', new \MongoDB\BSON\Regex(".*doe",'i'))->get();
+```
 
 **NOTE:** you can also use the Laravel regexp operations. These are a bit more flexible and will automatically convert your regular expression string to a MongoDB\BSON\Regex object.
 


### PR DESCRIPTION
Add other regex demo code 

Because this code is not working in MongoDB extension version => 1.5.5
User::where('name', 'regexp', '/.*doe/i')->get();