### PR TITLE
->toSql() no longer throws exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Table of contents
 * [Eloquent](#eloquent)
 * [Optional: Alias](#optional-alias)
 * [Query Builder](#query-builder)
+* [`toSql()`](#to-sql)
 * [Schema](#schema)
 * [Extensions](#extensions)
 * [Troubleshooting](#troubleshooting)
@@ -240,6 +241,18 @@ $user = DB::connection('mongodb')->collection('users')->get();
 ```
 
 Read more about the query builder on http://laravel.com/docs/queries
+
+`->toSql()`
+-------------
+Hence we are in a NoSQL driver, it is counter-intuitive to use `toSql()` to output the string that will be executed.
+
+However, if you still need the string that looks like the sql for some inspection, you can use the `toSql()` method:
+```php
+User::where('some_field', '>', 300)->whereRaw(['age' => ['$gt' => 30, '$lt' => 40]])->toSql();
+
+// output
+"select * from "users" where "some_field" > ? and {"age":{"$gt":30,"$lt":40}}"
+```
 
 Schema
 ------
@@ -602,15 +615,15 @@ $users = User::where('location', 'geoWithin', [
             [
                 -0.1450383,
                 51.5069158,
-            ],       
+            ],
             [
                 -0.1367563,
                 51.5100913,
-            ],       
+            ],
             [
                 -0.1270247,
                 51.5013233,
-            ],  
+            ],
             [
                 -0.1450383,
                 51.5069158,
@@ -1058,13 +1071,8 @@ $user->unset('note');
 
 ### Query Caching
 
-You may easily cache the results of a query using the remember method:
-
-```php
-$users = User::remember(10)->get();
-```
-
-*From: http://laravel.com/docs/queries#caching-queries*
+The MongoDB driver comes integrated with [rennokki/laravel-eloquent-query-cache](https://github.com/rennokki/laravel-eloquent-query-cache). Check the documentation
+to find out how to cache your MongoDB queries.
 
 ### Query Logging
 

--- a/README.md
+++ b/README.md
@@ -1069,11 +1069,6 @@ $user = User::where('name', 'John')->first();
 $user->unset('note');
 ```
 
-### Query Caching
-
-The MongoDB driver comes integrated with [rennokki/laravel-eloquent-query-cache](https://github.com/rennokki/laravel-eloquent-query-cache). Check the documentation
-to find out how to cache your MongoDB queries.
-
 ### Query Logging
 
 By default, Laravel keeps a log in memory of all queries that have been run for the current request. However, in some cases, such as when inserting a large number of rows, this can cause the application to use excess memory. To disable the log, you may use the `disableQueryLog` method:

--- a/src/Jenssegers/Mongodb/Query/Grammar.php
+++ b/src/Jenssegers/Mongodb/Query/Grammar.php
@@ -6,4 +6,19 @@ use Illuminate\Database\Query\Grammars\Grammar as BaseGrammar;
 
 class Grammar extends BaseGrammar
 {
+    /**
+     * {@inheritdoc}
+     */
+    protected function compileWheresToArray($query)
+    {
+        return collect($query->wheres)->map(function ($where) use ($query) {
+            $baseWhere = $this->{"where{$where['type']}"}($query, $where);
+
+            if (isset($where['sql']) && is_array($where['sql'])) {
+                $baseWhere = json_encode($baseWhere);
+            }
+
+            return $where['boolean'].' '.$baseWhere;
+        })->all();
+    }
 }


### PR DESCRIPTION
First of all, I know that `toSql()` is counter-intuitive. I came across this issue when i had to cache my MongoDB queries and stumbled on this issue.
I think that grammar class now finally has a meaning.

This adds support for "raw" queries to output `toSql()` properly.

Let's take the following query:
```php
User::where('some_field', '>', 300)
    ->whereRaw(['age' => ['$gt' => 30, '$lt' => 40]])
    ->toSql();
```

Without this PR, the output would be:
```
PHP Notice:  Array to string conversion in /path-to-vendor/laravel/framework/src/Illuminate/Database/Query/Grammars/Grammar.php on line 215
```

That's because the two wheres are looking like this when they are compiled in the `compileWheresToArray()`:
```php
// this is the ->where('some_field', '>', 300)
array:5 [
  "type" => "Basic"
  "column" => "some_field"
  "operator" => ">"
  "value" => "300"
  "boolean" => "and"
]

// this is the ->whereRaw(['age' => ['$gt' => 30, '$lt' => 40]])
array:3 [
  "type" => "raw"
  "sql" => array:1 [
    "age" => array:2 [
      "$gt" => 30
      "$lt" => 40
    ]
  ]
  "boolean" => "and"
]
```

The default Laravel compiler does not support the second one.
So, instead, I had to add the `compileWheresToArray` to the `Grammar` class and
intercept and treat the array by encoding it in JSON to look kinda fine.

The output for the `toSql` would be this one:
```
"select * from "users" where "some_field" > ? and {"age":{"$gt":30,"$lt":40}}"
```

I also have updated the readme.
 