### PR TITLE
Fix Convert UTCDateTime to a date string when reset password

### DIFF
--- a/src/Jenssegers/Mongodb/Auth/DatabaseTokenRepository.php
+++ b/src/Jenssegers/Mongodb/Auth/DatabaseTokenRepository.php
@@ -26,6 +26,23 @@ class DatabaseTokenRepository extends BaseDatabaseTokenRepository
      */
     protected function tokenExpired($createdAt)
     {
+        $createdAt = $this->convertDateTime($createdAt);
+
+        return parent::tokenExpired($createdAt);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function tokenRecentlyCreated($createdAt)
+    {
+        $createdAt = $this->convertDateTime($createdAt);
+        
+        return parent::tokenRecentlyCreated($createdAt);
+    }
+
+    private function convertDateTime($createdAt)
+    {
         // Convert UTCDateTime to a date string.
         if ($createdAt instanceof UTCDateTime) {
             $date = $createdAt->toDateTime();
@@ -37,6 +54,6 @@ class DatabaseTokenRepository extends BaseDatabaseTokenRepository
             $createdAt = $date->format('Y-m-d H:i:s');
         }
 
-        return parent::tokenExpired($createdAt);
+        return $createdAt;
     }
 }


### PR DESCRIPTION
Fix request reset password when data/token in password_resets collection exist.
If request reset password for 2nd time and so on, when users failed to reset password before (token in database still exist) it will return error "DateTime::__construct(): Failed to parse time string..." in Carbon.

So I create method tokenRecentlyCreated in DatabaseTokenRepository to convert UTCDateTime to a date string and return converted value to laravel's default method