### PR TITLE
[feature] Added ->toSql() for raw wheres

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Table of contents
 * [Eloquent](#eloquent)
 * [Optional: Alias](#optional-alias)
 * [Query Builder](#query-builder)
+* [`toSql()`](#to-sql)
 * [Schema](#schema)
 * [Extensions](#extensions)
 * [Examples](#examples)
@@ -239,6 +240,20 @@ $user = DB::connection('mongodb')->collection('users')->get();
 ```
 
 Read more about the query builder on http://laravel.com/docs/queries
+
+->toSql()
+-------------
+Hence we are in a NoSQL driver, it is counter-intuitive to use `toSql()` to output the string that will be executed.
+
+However, if you still need the string that looks like the sql for some inspection, you can use the `toSql()` method:
+```php
+User::where('some_field', '>', 300)
+    ->whereRaw(['age' => ['$gt' => 30, '$lt' => 40]])
+    ->toSql();
+
+// output
+"select * from "users" where "some_field" > ? and {"age":{"$gt":30,"$lt":40}}"
+```
 
 Schema
 ------

--- a/README.md
+++ b/README.md
@@ -896,6 +896,7 @@ Query Builder
 -------------
 
 ### Basic Usage
+
 The database driver plugs right into the original query builder.
 
 When using MongoDB connections, you will be able to build fluent queries to perform database operations.

--- a/README.md
+++ b/README.md
@@ -7,33 +7,48 @@ Laravel MongoDB
 [![codecov](https://codecov.io/gh/jenssegers/laravel-mongodb/branch/master/graph/badge.svg)](https://codecov.io/gh/jenssegers/laravel-mongodb/branch/master)
 [![Donate](https://img.shields.io/badge/donate-paypal-blue.svg)](https://www.paypal.me/jenssegers)
 
-An Eloquent model and Query builder with support for MongoDB, using the original Laravel API. *This library extends the original Laravel classes, so it uses exactly the same methods.*
+This package adds functionalities to the Eloquent model and Query builder for MongoDB, using the original Laravel API. *This library extends the original Laravel classes, so it uses exactly the same methods.*
 
-Table of contents
------------------
-* [Installation](#installation)
-* [Upgrading](#upgrading)
-* [Configuration](#configuration)
-* [Eloquent](#eloquent)
-* [Optional: Alias](#optional-alias)
-* [Query Builder](#query-builder)
-* [`toSql()`](#to-sql)
-* [Schema](#schema)
-* [Extensions](#extensions)
-* [Examples](#examples)
+- [Laravel MongoDB](#laravel-mongodb)
+  - [Installation](#installation)
+    - [Laravel version Compatibility](#laravel-version-compatibility)
+    - [Laravel](#laravel)
+    - [Lumen](#lumen)
+    - [Non-Laravel projects](#non-laravel-projects)
+  - [Testing](#testing)
+  - [Configuration](#configuration)
+  - [Eloquent](#eloquent)
+    - [Extending the base model](#extending-the-base-model)
+    - [Soft Deletes](#soft-deletes)
+    - [Dates](#dates)
+    - [Basic Usage](#basic-usage)
+    - [MongoDB-specific operators](#mongodb-specific-operators)
+    - [MongoDB-specific Geo operations](#mongodb-specific-geo-operations)
+    - [Inserts, updates and deletes](#inserts-updates-and-deletes)
+    - [MongoDB specific operations](#mongodb-specific-operations)
+  - [Relationships](#relationships)
+    - [Basic Usage](#basic-usage-1)
+    - [belongsToMany and pivots](#belongstomany-and-pivots)
+    - [EmbedsMany Relationship](#embedsmany-relationship)
+    - [EmbedsOne Relationship](#embedsone-relationship)
+  - [Query Builder](#query-builder)
+    - [Basic Usage](#basic-usage-2)
+    - [Available operations](#available-operations)
+  - [Schema](#schema)
+    - [Basic Usage](#basic-usage-3)
+    - [Geospatial indexes](#geospatial-indexes)
+  - [Extending](#extending)
+    - [Cross-Database Relationships](#cross-database-relationships)
+    - [Authentication](#authentication)
+    - [Queues](#queues)
+  - [Debugging](#debugging)
+    - [->toSql()](#tosql)
+  - [Upgrading](#upgrading)
+      - [Upgrading from version 2 to 3](#upgrading-from-version-2-to-3)
 
 Installation
 ------------
-
 Make sure you have the MongoDB PHP driver installed. You can find installation instructions at http://php.net/manual/en/mongodb.installation.php
-
-**WARNING**: The old mongo PHP driver is not supported anymore in versions >= 3.0.
-
-Installation using composer:
-
-```
-composer require jenssegers/mongodb
-```
 
 ### Laravel version Compatibility
 
@@ -51,11 +66,21 @@ composer require jenssegers/mongodb
  5.8.x    | 3.5.x
  6.0.x    | 3.6.x
 
-And add the service provider in `config/app.php`:
+Install the package via Composer:
+
+```bash
+$ composer require jenssegers/mongodb
+```
+
+### Laravel
+
+In case your Laravel version does NOT autoload the packages, add the service provider to `config/app.php`:
 
 ```php
 Jenssegers\Mongodb\MongodbServiceProvider::class,
 ```
+
+### Lumen
 
 For usage with [Lumen](http://lumen.laravel.com), add the service provider in `bootstrap/app.php`. In this file, you will also need to enable Eloquent. You must however ensure that your call to `$app->withEloquent();` is **below** where you have registered the `MongodbServiceProvider`:
 
@@ -65,52 +90,20 @@ $app->register(Jenssegers\Mongodb\MongodbServiceProvider::class);
 $app->withEloquent();
 ```
 
-The service provider will register a mongodb database extension with the original database manager. There is no need to register additional facades or objects. When using mongodb connections, Laravel will automatically provide you with the corresponding mongodb objects.
+The service provider will register a MongoDB database extension with the original database manager. There is no need to register additional facades or objects.
+
+When using MongoDB connections, Laravel will automatically provide you with the corresponding MongoDB objects.
+
+### Non-Laravel projects
 
 For usage outside Laravel, check out the [Capsule manager](https://github.com/illuminate/database/blob/master/README.md) and add:
 
 ```php
-$capsule->getDatabaseManager()->extend('mongodb', function($config, $name)
-{
+$capsule->getDatabaseManager()->extend('mongodb', function($config, $name) {
     $config['name'] = $name;
 
     return new Jenssegers\Mongodb\Connection($config);
 });
-```
-
-Upgrading
----------
-
-#### Upgrading from version 2 to 3
-
-In this new major release which supports the new mongodb PHP extension, we also moved the location of the Model class and replaced the MySQL model class with a trait.
-
-Please change all `Jenssegers\Mongodb\Model` references to `Jenssegers\Mongodb\Eloquent\Model` either at the top of your model files, or your registered alias.
-
-```php
-use Jenssegers\Mongodb\Eloquent\Model as Eloquent;
-
-class User extends Eloquent {}
-```
-
-If you are using hybrid relations, your MySQL classes should now extend the original Eloquent model class `Illuminate\Database\Eloquent\Model` instead of the removed `Jenssegers\Eloquent\Model`. Instead use the new `Jenssegers\Mongodb\Eloquent\HybridRelations` trait. This should make things more clear as there is only one single model class in this package.
-
-```php
-use Jenssegers\Mongodb\Eloquent\HybridRelations;
-
-class User extends Eloquent {
-
-    use HybridRelations;
-
-    protected $connection = 'mysql';
-
-}
-```
-
-Embedded relations now return an `Illuminate\Database\Eloquent\Collection` rather than a custom Collection class. If you were using one of the special methods that were available, convert them to Collection operations.
-
-```php
-$books = $user->books()->sortBy('title');
 ```
 
 Testing
@@ -124,315 +117,238 @@ docker-compose up
 
 Configuration
 -------------
-
-Change your default database connection name in `config/database.php`:
-
-```php
-'default' => env('DB_CONNECTION', 'mongodb'),
-```
-
-And add a new mongodb connection:
+You can use MongoDB either as the main database, either as a side database. To do so, add a new `mongodb` connection to `config/database.php`:
 
 ```php
 'mongodb' => [
-    'driver'   => 'mongodb',
-    'host'     => env('DB_HOST', 'localhost'),
-    'port'     => env('DB_PORT', 27017),
-    'database' => env('DB_DATABASE'),
-    'username' => env('DB_USERNAME'),
-    'password' => env('DB_PASSWORD'),
-    'options'  => [
-        'database' => 'admin' // sets the authentication database required by mongo 3
-    ]
+    'driver' => 'mongodb',
+    'host' => env('DB_HOST', '127.0.0.1'),
+    'port' => env('DB_PORT', 27017),
+    'database' => env('DB_DATABASE', 'homestead'),
+    'username' => env('DB_USERNAME', 'homestead'),
+    'password' => env('DB_PASSWORD', 'secret'),
+    'options' => [
+        // here you can pass more settings to the Mongo Driver Manager
+        // see https://www.php.net/manual/en/mongodb-driver-manager.construct.php under "Uri Options" for a list of complete parameters that you can use
+
+        'database' => env('DB_AUTHENTICATION_DATABASE', 'admin'), // required with Mongo 3+
+    ],
 ],
 ```
 
-You can connect to multiple servers or replica sets with the following configuration:
+For multiple servers or replica set configurations, set the host to an array and specify each server host:
 
 ```php
 'mongodb' => [
-    'driver'   => 'mongodb',
-    'host'     => ['server1', 'server2'],
-    'port'     => env('DB_PORT', 27017),
-    'database' => env('DB_DATABASE'),
-    'username' => env('DB_USERNAME'),
-    'password' => env('DB_PASSWORD'),
-    'options'  => [
-        'replicaSet' => 'replicaSetName'
-    ]
+    'driver' => 'mongodb',
+    'host' => ['server1', 'server2', ...],
+    ...
+    'options' => [
+        'replicaSet' => 'rs0',
+    ],
 ],
 ```
 
-Alternatively, you can use MongoDB connection string:
+If you wish to use a connection string instead of full key-value params, you can set it so. Check the documentation on MongoDB's URI format: https://docs.mongodb.com/manual/reference/connection-string/
 
 ```php
 'mongodb' => [
-    'driver'   => 'mongodb',
+    'driver' => 'mongodb',
     'dsn' => env('DB_DSN'),
-    'database' => env('DB_DATABASE'),
+    'database' => env('DB_DATABASE', 'homestead'),
 ],
 ```
-
-Please refer to MongoDB official docs for its URI format: https://docs.mongodb.com/manual/reference/connection-string/
 
 Eloquent
 --------
 
+### Extending the base model
 This package includes a MongoDB enabled Eloquent class that you can use to define models for corresponding collections.
 
 ```php
-use Jenssegers\Mongodb\Eloquent\Model as Eloquent;
+use Jenssegers\Mongodb\Eloquent\Model;
 
-class User extends Eloquent {}
-```
-
-Note that we did not tell Eloquent which collection to use for the `User` model. Just like the original Eloquent, the lower-case, plural name of the class will be used as the collection name unless another name is explicitly specified. You may specify a custom collection (alias for table) by defining a `collection` property on your model:
-
-```php
-use Jenssegers\Mongodb\Eloquent\Model as Eloquent;
-
-class User extends Eloquent {
-
-    protected $collection = 'users_collection';
-
+class Book extends Model
+{
+    //
 }
 ```
 
-**NOTE:** Eloquent will also assume that each collection has a primary key column named id. You may define a `primaryKey` property to override this convention. Likewise, you may define a `connection` property to override the name of the database connection that should be used when utilizing the model.
+Just like a normal model, the MongoDB model class will know which collection to use based on the model name. For `Book`, the collection `books` will be used.
+
+To change the collection, pass the `$collection` property:
 
 ```php
-use Jenssegers\Mongodb\Eloquent\Model as Eloquent;
+use Jenssegers\Mongodb\Eloquent\Model;
 
-class MyModel extends Eloquent {
+class Book extends Model
+{
+    protected $collection = 'my_books_collection';
+}
+```
 
+**NOTE:** MongoDB documents are automatically stored with a unique ID that is stored in the `_id` property. If you wish to use your own ID, substitute the `$primaryKey` property and set it to your own primary key attribute name.
+
+```php
+use Jenssegers\Mongodb\Eloquent\Model;
+
+class Book extends Model
+{
+    protected $primaryKey = 'id';
+}
+
+// Mongo will also create _id, but the 'id' property will be used for primary key actions like find().
+Book::create(['id' => 1, 'title' => 'The Fault in Our Stars']);
+```
+
+Likewise, you may define a `connection` property to override the name of the database connection that should be used when utilizing the model.
+
+```php
+use Jenssegers\Mongodb\Eloquent\Model;
+
+class Book extends Model
+{
     protected $connection = 'mongodb';
-
 }
 ```
 
-Everything else (should) work just like the original Eloquent model. Read more about the Eloquent on http://laravel.com/docs/eloquent
+### Soft Deletes
 
-### Optional: Alias
+When soft deleting a model, it is not actually removed from your database. Instead, a deleted_at timestamp is set on the record.
 
-You may also register an alias for the MongoDB model by adding the following to the alias array in `config/app.php`:
-
-```php
-'Moloquent'       => Jenssegers\Mongodb\Eloquent\Model::class,
-```
-
-This will allow you to use the registered alias like:
+To enable soft deletes for a model, apply the `Jenssegers\Mongodb\Eloquent\SoftDeletes` Trait to the model:
 
 ```php
-class MyModel extends Moloquent {}
-```
+use Jenssegers\Mongodb\Eloquent\SoftDeletes;
 
-Query Builder
--------------
-
-The database driver plugs right into the original query builder. When using mongodb connections, you will be able to build fluent queries to perform database operations. For your convenience, there is a `collection` alias for `table` as well as some additional mongodb specific operators/operations.
-
-```php
-$users = DB::collection('users')->get();
-
-$user = DB::collection('users')->where('name', 'John')->first();
-```
-
-If you did not change your default database connection, you will need to specify it when querying.
-
-```php
-$user = DB::connection('mongodb')->collection('users')->get();
-```
-
-Read more about the query builder on http://laravel.com/docs/queries
-
-->toSql()
--------------
-Hence we are in a NoSQL driver, it is counter-intuitive to use `toSql()` to output the string that will be executed.
-
-However, if you still need the string that looks like the sql for some inspection, you can use the `toSql()` method:
-```php
-User::where('some_field', '>', 300)
-    ->whereRaw(['age' => ['$gt' => 30, '$lt' => 40]])
-    ->toSql();
-
-// output
-"select * from "users" where "some_field" > ? and {"age":{"$gt":30,"$lt":40}}"
-```
-
-Schema
-------
-
-The database driver also has (limited) schema builder support. You can easily manipulate collections and set indexes:
-
-```php
-Schema::create('users', function($collection)
+class User extends Model
 {
-    $collection->index('name');
+    use SoftDeletes;
 
-    $collection->unique('email');
-});
+    protected $dates = ['deleted_at'];
+}
 ```
-You can also pass all the parameters specified in the MongoDB docs [here](https://docs.mongodb.com/manual/reference/method/db.collection.createIndex/#options-for-all-index-types) in the `$options` parameter. For example:
 
-```
-Schema::create('users', function($collection)
+For more information check [Laravel Docs about Soft Deleting](http://laravel.com/docs/eloquent#soft-deleting).
+
+### Dates
+
+Eloquent allows you to work with Carbon or DateTime objects instead of MongoDate objects. Internally, these dates will be converted to MongoDate objects when saved to the database.
+
+```php
+use Jenssegers\Mongodb\Eloquent\Model;
+
+class User extends Model
 {
-    $collection->index('username',null,null,[
-                    'sparse' => true,
-                    'unique' => true,
-                    'background' => true
-    ]);
-});
+    protected $dates = ['birthday'];
+}
 ```
-Supported operations are:
 
- - create and drop
- - collection
- - hasCollection
- - index and dropIndex (compound indexes supported as well)
- - unique
- - background, sparse, expire, geospatial (MongoDB specific)
-
-All other (unsupported) operations are implemented as dummy pass-through methods, because MongoDB does not use a predefined schema. Read more about the schema builder on https://laravel.com/docs/6.0/migrations#tables
-
-### Geospatial indexes
-
-Geospatial indexes are handy for querying location-based documents. They come in two forms: `2d` and `2dsphere`. Use the schema builder to add these to a collection.
-
-To add a `2d` index:
+This allows you to execute queries like this:
 
 ```php
-Schema::create('users', function($collection)
-{
-    $collection->geospatial('name', '2d');
-});
+$users = User::where(
+    'birthday', '>',
+    new DateTime('-18 years')
+)->get();
 ```
-
-To add a `2dsphere` index:
-
-```php
-Schema::create('users', function($collection)
-{
-    $collection->geospatial('name', '2dsphere');
-});
-```
-
-Extensions
-----------
-
-### Auth
-
-If you want to use Laravel's native Auth functionality, register this included service provider:
-
-```php
-'Jenssegers\Mongodb\Auth\PasswordResetServiceProvider',
-```
-
-This service provider will slightly modify the internal DatabaseReminderRepository to add support for MongoDB based password reminders. If you don't use password reminders, you don't have to register this service provider and everything else should work just fine.
-
-### Queues
-
-If you want to use MongoDB as your database backend, change the driver in `config/queue.php`:
-
-```php
-'connections' => [
-    'database' => [
-        'driver' => 'mongodb',
-        'table'  => 'jobs',
-        'queue'  => 'default',
-        'expire' => 60,
-    ],
-]
-```
-
-If you want to use MongoDB to handle failed jobs, change the database in `config/queue.php`:
-
-```php
-'failed' => [
-    'database' => 'mongodb',
-    'table'    => 'failed_jobs',
-],
-```
-
-And add the service provider in `config/app.php`:
-
-```php
-Jenssegers\Mongodb\MongodbQueueServiceProvider::class,
-```
-
-### Sentry
-
-If you want to use this library with [Sentry](https://cartalyst.com/manual/sentry), then check out https://github.com/jenssegers/Laravel-MongoDB-Sentry
-
-### Sessions
-
-The MongoDB session driver is available in a separate package, check out https://github.com/jenssegers/Laravel-MongoDB-Session
-
-Examples
---------
 
 ### Basic Usage
 
-**Retrieving All Models**
+**Retrieving all models**
 
 ```php
 $users = User::all();
 ```
 
-**Retrieving A Record By Primary Key**
+**Retrieving a record by primary key**
 
 ```php
 $user = User::find('517c43667db388101e00000f');
 ```
 
-**Wheres**
+**Where**
 
 ```php
-$users = User::where('votes', '>', 100)->take(10)->get();
+$posts =
+    Post::where('author.name', 'John')
+        ->take(10)
+        ->get();
 ```
 
-**Or Statements**
+**OR Statements**
 
 ```php
-$users = User::where('votes', '>', 100)->orWhere('name', 'John')->get();
+$posts =
+    Post::where('votes', '>', 0)
+        ->orWhere('is_approved', true)
+        ->get();
 ```
 
-**And Statements**
+**AND statements**
 
 ```php
-$users = User::where('votes', '>', 100)->where('name', '=', 'John')->get();
+$users =
+    User::where('age', '>', 18)
+        ->where('name', '!=', 'John')
+        ->get();
 ```
 
-**Using Where In With An Array**
+**whereIn**
 
 ```php
 $users = User::whereIn('age', [16, 18, 20])->get();
 ```
 
-When using `whereNotIn` objects will be returned if the field is non existent. Combine with `whereNotNull('age')` to leave out those documents.
+When using `whereNotIn` objects will be returned if the field is non-existent. Combine with `whereNotNull('age')` to leave out those documents.
 
-**Using Where Between**
+**whereBetween**
 
 ```php
-$users = User::whereBetween('votes', [1, 100])->get();
+$posts = Post::whereBetween('votes', [1, 100])->get();
 ```
 
-**Where null**
+**whereNull**
 
 ```php
-$users = User::whereNull('updated_at')->get();
+$users = User::whereNull('age')->get();
 ```
 
-**Order By**
+**Advanced wheres**
 
 ```php
-$users = User::orderBy('name', 'desc')->get();
+$users =
+    User::where('name', 'John')
+        ->orWhere(function ($query) {
+            return $query
+                ->where('votes', '>', 100)
+                ->where('title', '<>', 'Admin');
+        })->get();
 ```
 
-**Offset & Limit**
+**orderBy**
 
 ```php
-$users = User::skip(10)->take(5)->get();
+$users = User::orderBy('age', 'desc')->get();
+```
+
+**Offset & Limit (skip & take)**
+
+```php
+$users =
+    User::skip(10)
+        ->take(5)
+        ->get();
+```
+
+**groupBy**
+
+Selected columns that are not grouped will be aggregated with the `$last` function.
+
+```php
+$users =
+    Users::groupBy('title')
+        ->get(['title', 'name']);
 ```
 
 **Distinct**
@@ -441,45 +357,36 @@ Distinct requires a field for which to return the distinct values.
 
 ```php
 $users = User::distinct()->get(['name']);
-// or
+
+// Equivalent to:
 $users = User::distinct('name')->get();
 ```
 
 Distinct can be combined with **where**:
 
 ```php
-$users = User::where('active', true)->distinct('name')->get();
+$users =
+    User::where('active', true)
+        ->distinct('name')
+        ->get();
 ```
 
-**Advanced Wheres**
+**Like**
 
 ```php
-$users = User::where('name', '=', 'John')->orWhere(function($query)
-    {
-        $query->where('votes', '>', 100)
-              ->where('title', '<>', 'Admin');
-    })
-    ->get();
-```
-
-**Group By**
-
-Selected columns that are not grouped will be aggregated with the $last function.
-
-```php
-$users = Users::groupBy('title')->get(['title', 'name']);
+$spamComments = Comment::where('body', 'like', '%spam%')->get();
 ```
 
 **Aggregation**
 
-*Aggregations are only available for MongoDB versions greater than 2.2.*
+**Aggregations are only available for MongoDB versions greater than 2.2.x**
 
 ```php
-$total = Order::count();
-$price = Order::max('price');
-$price = Order::min('price');
-$price = Order::avg('price');
-$total = Order::sum('price');
+$total = Product::count();
+$price = Product::max('price');
+$price = Product::min('price');
+$price = Product::avg('price');
+$total = Product::sum('price');
 ```
 
 Aggregations can be combined with **where**:
@@ -488,28 +395,22 @@ Aggregations can be combined with **where**:
 $sold = Orders::where('sold', true)->sum('price');
 ```
 
-Aggregations can be also used on subdocuments:
+Aggregations can be also used on sub-documents:
 
 ```php
 $total = Order::max('suborder.price');
-...
 ```
 
-**NOTE**: this aggreagtion only works with single subdocuments (like embedsOne) not subdocument arrays (like embedsMany)
+**NOTE**: This aggregation only works with single sub-documents (like `EmbedsOne`) not subdocument arrays (like `EmbedsMany`).
 
-**Like**
-
-```php
-$user = Comment::where('body', 'like', '%spam%')->get();
-```
-
-**Incrementing or decrementing a value of a column**
+**Incrementing/Decrementing the value of a column**
 
 Perform increments or decrements (default 1) on specified attributes:
 
 ```php
-User::where('name', 'John Doe')->increment('age');
-User::where('name', 'Jaques')->decrement('weight', 50);
+Cat::where('name', 'Kitty')->increment('age');
+
+Car::where('name', 'Toyota')->decrement('weight', 50);
 ```
 
 The number of updated objects is returned:
@@ -521,29 +422,14 @@ $count = User::increment('age');
 You may also specify additional columns to update:
 
 ```php
-User::where('age', '29')->increment('age', 1, ['group' => 'thirty something']);
-User::where('bmi', 30)->decrement('bmi', 1, ['category' => 'overweight']);
+Cat::where('age', 3)
+    ->increment('age', 1, ['group' => 'Kitty Club']);
+
+Car::where('weight', 300)
+    ->decrement('weight', 100, ['latest_change' => 'carbon fiber']);
 ```
 
-**Soft deleting**
-
-When soft deleting a model, it is not actually removed from your database. Instead, a deleted_at timestamp is set on the record. To enable soft deletes for a model, apply the SoftDeletingTrait to the model:
-
-```php
-use Jenssegers\Mongodb\Eloquent\SoftDeletes;
-
-class User extends Eloquent {
-
-    use SoftDeletes;
-
-    protected $dates = ['deleted_at'];
-
-}
-```
-
-For more information check http://laravel.com/docs/eloquent#soft-deleting
-
-### MongoDB specific operators
+### MongoDB-specific operators
 
 **Exists**
 
@@ -566,7 +452,7 @@ User::where('roles', 'all', ['moderator', 'author'])->get();
 Selects documents if the array field is a specified size.
 
 ```php
-User::where('tags', 'size', 3)->get();
+Post::where('tags', 'size', 3)->get();
 ```
 
 **Regex**
@@ -574,16 +460,18 @@ User::where('tags', 'size', 3)->get();
 Selects documents where values match a specified regular expression.
 
 ```php
-User::where('name', 'regex', new \MongoDB\BSON\Regex("/.*doe/i"))->get();
+use MongoDB\BSON\Regex;
+
+User::where('name', 'regex', new Regex("/.*doe/i"))->get();
 ```
 
-**NOTE:** you can also use the Laravel regexp operations. These are a bit more flexible and will automatically convert your regular expression string to a MongoDB\BSON\Regex object.
+**NOTE:** you can also use the Laravel regexp operations. These are a bit more flexible and will automatically convert your regular expression string to a `MongoDB\BSON\Regex` object.
 
 ```php
 User::where('name', 'regexp', '/.*doe/i')->get();
 ```
 
-And the inverse:
+The inverse of regexp:
 
 ```php
 User::where('name', 'not regexp', '/.*doe/i')->get();
@@ -605,245 +493,306 @@ Performs a modulo operation on the value of a field and selects documents with a
 User::where('age', 'mod', [10, 0])->get();
 ```
 
+### MongoDB-specific Geo operations
+
 **Near**
 
-**NOTE:** Specify coordinates in this order: `longitude, latitude`.
-
 ```php
-$users = User::where('location', 'near', [
-	'$geometry' => [
+$bars = Bar::where('location', 'near', [
+    '$geometry' => [
         'type' => 'Point',
-	    'coordinates' => [
-	        -0.1367563,
-            51.5100913,
+        'coordinates' => [
+            -0.1367563, // longitude
+            51.5100913, // latitude
         ],
     ],
     '$maxDistance' => 50,
-]);
+])->get();
 ```
 
 **GeoWithin**
 
 ```php
-$users = User::where('location', 'geoWithin', [
-	'$geometry' => [
+$bars = Bar::where('location', 'geoWithin', [
+    '$geometry' => [
         'type' => 'Polygon',
-	    'coordinates' => [[
+        'coordinates' => [
             [
-                -0.1450383,
-                51.5069158,
+                [-0.1450383, 51.5069158],
+                [-0.1367563, 51.5100913],
+                [-0.1270247, 51.5013233],
+                [-0.1450383, 51.5069158],
             ],
-            [
-                -0.1367563,
-                51.5100913,
-            ],
-            [
-                -0.1270247,
-                51.5013233,
-            ],
-            [
-                -0.1450383,
-                51.5069158,
-            ],
-        ]],
+        ],
     ],
-]);
+])->get();
 ```
 
 **GeoIntersects**
 
 ```php
-$locations = Location::where('location', 'geoIntersects', [
+$bars = Bar::where('location', 'geoIntersects', [
     '$geometry' => [
         'type' => 'LineString',
         'coordinates' => [
-            [
-                -0.144044,
-                51.515215,
-            ],
-            [
-                -0.129545,
-                51.507864,
-            ],
+            [-0.144044, 51.515215],
+            [-0.129545, 51.507864],
         ],
     ],
+])->get();
+```
+### Inserts, updates and deletes
+
+Inserting, updating and deleting records works just like the original Eloquent. Please check [Laravel Docs' Eloquent section](https://laravel.com/docs/6.x/eloquent).
+
+Here, only the MongoDB-specific operations are specified.
+
+### MongoDB specific operations
+
+**Raw Expressions**
+
+These expressions will be injected directly into the query.
+
+```php
+User::whereRaw([
+    'age' => ['$gt' => 30, '$lt' => 40],
+])->get();
+```
+
+You can also perform raw expressions on the internal MongoCollection object. If this is executed on the model class, it will return a collection of models.
+
+If this is executed on the query builder, it will return the original response.
+
+**Cursor timeout**
+
+To prevent `MongoCursorTimeout` exceptions, you can manually set a timeout value that will be applied to the cursor:
+
+```php
+DB::collection('users')->timeout(-1)->get();
+```
+
+**Upsert**
+
+Update or insert a document. Additional options for the update method are passed directly to the native update method.
+
+```php
+// Query Builder
+DB::collection('users')
+    ->where('name', 'John')
+    ->update($data, ['upsert' => true]);
+
+// Eloquent
+$user->update($data, ['upsert' => true]);
+```
+
+**Projections**
+
+You can apply projections to your queries using the `project` method.
+
+```php
+DB::collection('items')
+    ->project(['tags' => ['$slice' => 1]])
+    ->get();
+
+DB::collection('items')
+    ->project(['tags' => ['$slice' => [3, 7]]])
+    ->get();
+```
+
+**Projections with Pagination**
+
+```php
+$limit = 25;
+$projections = ['id', 'name'];
+
+DB::collection('items')
+    ->paginate($limit, $projections);
+```
+
+**Push**
+
+Add items to an array.
+
+```php
+DB::collection('users')
+    ->where('name', 'John')
+    ->push('items', 'boots');
+
+$user->push('items', 'boots');
+```
+
+```php
+DB::collection('users')
+    ->where('name', 'John')
+    ->push('messages', [
+        'from' => 'Jane Doe',
+        'message' => 'Hi John',
+    ]);
+
+$user->push('messages', [
+    'from' => 'Jane Doe',
+    'message' => 'Hi John',
 ]);
 ```
 
-
-**Where**
-
-Matches documents that satisfy a JavaScript expression. For more information check http://docs.mongodb.org/manual/reference/operator/query/where/#op._S_where
-
-### Inserts, updates and deletes
-
-Inserting, updating and deleting records works just like the original Eloquent.
-
-**Saving a new model**
+If you **DON'T** want duplicate items, set the third parameter to `true`:
 
 ```php
-$user = new User;
-$user->name = 'John';
-$user->save();
+DB::collection('users')
+    ->where('name', 'John')
+    ->push('items', 'boots', true);
+
+$user->push('items', 'boots', true);
 ```
 
-You may also use the create method to save a new model in a single line:
+**Pull**
+
+Remove an item from an array.
 
 ```php
-User::create(['name' => 'John']);
+DB::collection('users')
+    ->where('name', 'John')
+    ->pull('items', 'boots');
+
+$user->pull('items', 'boots');
 ```
-
-**Updating a model**
-
-To update a model, you may retrieve it, change an attribute, and use the save method.
 
 ```php
-$user = User::first();
-$user->email = 'john@foo.com';
-$user->save();
+DB::collection('users')
+    ->where('name', 'John')
+    ->pull('messages', [
+        'from' => 'Jane Doe',
+        'message' => 'Hi John',
+    ]);
+
+$user->pull('messages', [
+    'from' => 'Jane Doe',
+    'message' => 'Hi John',
+]);
 ```
 
-*There is also support for upsert operations, check https://github.com/jenssegers/laravel-mongodb#mongodb-specific-operations*
+**Unset**
 
-**Deleting a model**
-
-To delete a model, simply call the delete method on the instance:
+Remove one or more fields from a document.
 
 ```php
-$user = User::first();
-$user->delete();
+DB::collection('users')
+    ->where('name', 'John')
+    ->unset('note');
+
+$user->unset('note');
 ```
 
-Or deleting a model by its key:
+Relationships
+-------------
 
-```php
-User::destroy('517c43667db388101e00000f');
-```
+### Basic Usage
 
-For more information about model manipulation, check http://laravel.com/docs/eloquent#insert-update-delete
-
-### Dates
-
-Eloquent allows you to work with Carbon/DateTime objects instead of MongoDate objects. Internally, these dates will be converted to MongoDate objects when saved to the database. If you wish to use this functionality on non-default date fields, you will need to manually specify them as described here: https://laravel.com/docs/5.0/eloquent#date-mutators
-
-Example:
-
-```php
-use Jenssegers\Mongodb\Eloquent\Model as Eloquent;
-
-class User extends Eloquent {
-
-    protected $dates = ['birthday'];
-
-}
-```
-
-Which allows you to execute queries like:
-
-```php
-$users = User::where('birthday', '>', new DateTime('-18 years'))->get();
-```
-
-### Relations
-
-Supported relations are:
-
+The only available relationships are:
  - hasOne
  - hasMany
  - belongsTo
  - belongsToMany
+
+The MongoDB-specific relationships are:
  - embedsOne
  - embedsMany
 
-Example:
+Here is a small example:
 
 ```php
-use Jenssegers\Mongodb\Eloquent\Model as Eloquent;
+use Jenssegers\Mongodb\Eloquent\Model;
 
-class User extends Eloquent {
-
+class User extends Model
+{
     public function items()
     {
-        return $this->hasMany('Item');
+        return $this->hasMany(Item::class);
     }
-
 }
 ```
 
-And the inverse relation:
+The inverse relation of `hasMany` is `belongsTo`:
 
 ```php
-use Jenssegers\Mongodb\Eloquent\Model as Eloquent;
+use Jenssegers\Mongodb\Eloquent\Model;
 
-class Item extends Eloquent {
-
+class Item extends Model
+{
     public function user()
     {
-        return $this->belongsTo('User');
+        return $this->belongsTo(User::class);
     }
-
 }
 ```
 
-The belongsToMany relation will not use a pivot "table", but will push id's to a __related_ids__ attribute instead. This makes the second parameter for the belongsToMany method useless. If you want to define custom keys for your relation, set it to `null`:
+### belongsToMany and pivots
+
+The belongsToMany relation will not use a pivot "table" but will push id's to a __related_ids__ attribute instead. This makes the second parameter for the belongsToMany method useless.
+
+If you want to define custom keys for your relation, set it to `null`:
 
 ```php
-use Jenssegers\Mongodb\Eloquent\Model as Eloquent;
+use Jenssegers\Mongodb\Eloquent\Mode;
 
-class User extends Eloquent {
-
+class User extends Model
+{
     public function groups()
     {
-        return $this->belongsToMany('Group', null, 'user_ids', 'group_ids');
+        return $this->belongsToMany(
+            Group::class, null, 'user_ids', 'group_ids'
+        );
     }
-
 }
 ```
 
+### EmbedsMany Relationship
 
-Other relations are not yet supported, but may be added in the future. Read more about these relations on https://laravel.com/docs/master/eloquent-relationships
+If you want to embed models, rather than referencing them, you can use the `embedsMany` relation. This relation is similar to the `hasMany` relation but embeds the models inside the parent object.
 
-### EmbedsMany Relations
-
-If you want to embed models, rather than referencing them, you can use the `embedsMany` relation. This relation is similar to the `hasMany` relation, but embeds the models inside the parent object.
-
-**REMEMBER**: these relations return Eloquent collections, they don't return query builder objects!
+**REMEMBER**: These relations return Eloquent collections, they don't return query builder objects!
 
 ```php
-use Jenssegers\Mongodb\Eloquent\Model as Eloquent;
+use Jenssegers\Mongodb\Eloquent\Model;
 
-class User extends Eloquent {
-
+class User extends Model
+{
     public function books()
     {
-        return $this->embedsMany('Book');
+        return $this->embedsMany(Book::class);
     }
-
 }
 ```
 
 You can access the embedded models through the dynamic property:
 
 ```php
-$books = User::first()->books;
+$user = User::first();
+
+foreach ($user->books as $book) {
+    //
+}
 ```
 
-The inverse relation is auto*magically* available, you don't need to define this reverse relation.
+The inverse relation is auto*magically* available. You don't need to define this reverse relation.
 
 ```php
+$book = Book::first();
+
 $user = $book->user;
 ```
 
 Inserting and updating embedded models works similar to the `hasMany` relation:
 
 ```php
-$book = new Book(['title' => 'A Game of Thrones']);
+$book = $user->books()->save(
+    new Book(['title' => 'A Game of Thrones'])
+);
 
-$user = User::first();
-
-$book = $user->books()->save($book);
 // or
-$book = $user->books()->create(['title' => 'A Game of Thrones'])
+$book =
+    $user->books()
+         ->create(['title' => 'A Game of Thrones']);
 ```
 
 You can update embedded models using their `save` method (available since release 2.0.0):
@@ -852,69 +801,78 @@ You can update embedded models using their `save` method (available since releas
 $book = $user->books()->first();
 
 $book->title = 'A Game of Thrones';
-
 $book->save();
 ```
 
 You can remove an embedded model by using the `destroy` method on the relation, or the `delete` method on the model (available since release 2.0.0):
 
 ```php
-$book = $user->books()->first();
-
 $book->delete();
-// or
+
+// Similar operation
 $user->books()->destroy($book);
 ```
 
-If you want to add or remove an embedded model, without touching the database, you can use the `associate` and `dissociate` methods. To eventually write the changes to the database, save the parent object:
+If you want to add or remove an embedded model, without touching the database, you can use the `associate` and `dissociate` methods.
+
+To eventually write the changes to the database, save the parent object:
 
 ```php
 $user->books()->associate($book);
-
 $user->save();
 ```
 
 Like other relations, embedsMany assumes the local key of the relationship based on the model name. You can override the default local key by passing a second argument to the embedsMany method:
 
 ```php
-return $this->embedsMany('Book', 'local_key');
+use Jenssegers\Mongodb\Eloquent\Model;
+
+class User extends Model
+{
+    public function books()
+    {
+        return $this->embedsMany(Book::class, 'local_key');
+    }
+}
 ```
 
 Embedded relations will return a Collection of embedded items instead of a query builder. Check out the available operations here: https://laravel.com/docs/master/collections
 
-### EmbedsOne Relations
+
+### EmbedsOne Relationship
 
 The embedsOne relation is similar to the embedsMany relation, but only embeds a single model.
 
 ```php
-use Jenssegers\Mongodb\Eloquent\Model as Eloquent;
+use Jenssegers\Mongodb\Eloquent\Model;
 
-class Book extends Eloquent {
-
+class Book extends Model
+{
     public function author()
     {
-        return $this->embedsOne('Author');
+        return $this->embedsOne(Author::class);
     }
-
 }
 ```
 
 You can access the embedded models through the dynamic property:
 
 ```php
-$author = Book::first()->author;
+$book = Book::first();
+$author = $book->author;
 ```
 
 Inserting and updating embedded models works similar to the `hasOne` relation:
 
 ```php
-$author = new Author(['name' => 'John Doe']);
+$author = $book->author()->save(
+    new Author(['name' => 'John Doe'])
+);
 
-$book = Books::first();
-
-$author = $book->author()->save($author);
-// or
-$author = $book->author()->create(['name' => 'John Doe']);
+// Similar
+$author =
+    $book->author()
+         ->create(['name' => 'John Doe']);
 ```
 
 You can update the embedded model using the `save` method (available since release 2.0.0):
@@ -930,178 +888,249 @@ You can replace the embedded model with a new model like this:
 
 ```php
 $newAuthor = new Author(['name' => 'Jane Doe']);
+
 $book->author()->save($newAuthor);
 ```
 
-### MySQL Relations
+Query Builder
+-------------
 
-If you're using a hybrid MongoDB and SQL setup, you're in luck! The model will automatically return a MongoDB- or SQL-relation based on the type of the related model. Of course, if you want this functionality to work both ways, your SQL-models will need use the `Jenssegers\Mongodb\Eloquent\HybridRelations` trait. Note that this functionality only works for hasOne, hasMany and belongsTo relations.
+### Basic Usage
 
-Example SQL-based User model:
+The database driver plugs right into the original query builder.
+
+When using MongoDB connections, you will be able to build fluent queries to perform database operations.
+
+For your convenience, there is a `collection` alias for `table` as well as some additional MongoDB specific operators/operations.
+
+
+```php
+$books = DB::collection('books')->get();
+
+$hungerGames =
+    DB::collection('books')
+        ->where('name', 'Hunger Games')
+        ->first();
+```
+
+If you are familiar with [Eloquent Queries](http://laravel.com/docs/queries), there is the same functionality.
+
+### Available operations
+To see the available operations, check the [Eloquent](#eloquent) section.
+
+Schema
+------
+The database driver also has (limited) schema builder support. You can easily manipulate collections and set indexes.
+
+### Basic Usage
+
+```php
+Schema::create('users', function ($collection) {
+    $collection->index('name');
+    $collection->unique('email');
+});
+```
+
+You can also pass all the parameters specified [in the MongoDB docs](https://docs.mongodb.com/manual/reference/method/db.collection.createIndex/#options-for-all-index-types) to the `$options` parameter:
+
+```php
+Schema::create('users', function ($collection) {
+    $collection->index(
+        'username',
+        null,
+        null,
+        [
+            'sparse' => true,
+            'unique' => true,
+            'background' => true,
+        ]
+    );
+});
+```
+
+Inherited operations:
+- create and drop
+- collection
+- hasCollection
+- index and dropIndex (compound indexes supported as well)
+- unique
+
+MongoDB specific operations:
+- background
+- sparse
+- expire
+- geospatial
+
+All other (unsupported) operations are implemented as dummy pass-through methods because MongoDB does not use a predefined schema.
+
+Read more about the schema builder on [Laravel Docs](https://laravel.com/docs/6.0/migrations#tables)
+
+### Geospatial indexes
+
+Geospatial indexes are handy for querying location-based documents.
+
+They come in two forms: `2d` and `2dsphere`. Use the schema builder to add these to a collection.
+
+```php
+Schema::create('bars', function ($collection) {
+    $collection->geospatial('location', '2d');
+});
+```
+
+To add a `2dsphere` index:
+
+```php
+Schema::create('bars', function ($collection) {
+    $collection->geospatial('location', '2dsphere');
+});
+```
+
+Extending
+---------
+
+### Cross-Database Relationships
+
+If you're using a hybrid MongoDB and SQL setup, you can define relationships across them.
+
+The model will automatically return a MongoDB-related or SQL-related relation based on the type of the related model.
+
+If you want this functionality to work both ways, your SQL-models will need to use the `Jenssegers\Mongodb\Eloquent\HybridRelations` trait.
+
+**This functionality only works for `hasOne`, `hasMany` and `belongsTo`.**
+
+The MySQL model should use the `HybridRelations` trait:
 
 ```php
 use Jenssegers\Mongodb\Eloquent\HybridRelations;
 
-class User extends Eloquent {
-
+class User extends Model
+{
     use HybridRelations;
 
     protected $connection = 'mysql';
 
     public function messages()
     {
-        return $this->hasMany('Message');
+        return $this->hasMany(Message::class);
     }
-
 }
 ```
-
-And the Mongodb-based Message model:
+Within your MongoDB model, you should define the relationship:
 
 ```php
-use Jenssegers\Mongodb\Eloquent\Model as Eloquent;
+use Jenssegers\Mongodb\Eloquent\Model;
 
-class Message extends Eloquent {
-
+class Message extends Model
+{
     protected $connection = 'mongodb';
 
     public function user()
     {
-        return $this->belongsTo('User');
+        return $this->belongsTo(User::class);
     }
-
 }
 ```
 
-### Raw Expressions
-
-These expressions will be injected directly into the query.
+### Authentication
+If you want to use Laravel's native Auth functionality, register this included service provider:
 
 ```php
-User::whereRaw(['age' => array('$gt' => 30, '$lt' => 40)])->get();
+Jenssegers\Mongodb\Auth\PasswordResetServiceProvider::class,
 ```
 
-You can also perform raw expressions on the internal MongoCollection object. If this is executed on the model class, it will return a collection of models. If this is executed on the query builder, it will return the original response.
+This service provider will slightly modify the internal DatabaseReminderRepository to add support for MongoDB based password reminders.
+
+If you don't use password reminders, you don't have to register this service provider and everything else should work just fine.
+
+### Queues
+If you want to use MongoDB as your database backend, change the driver in `config/queue.php`:
 
 ```php
-// Returns a collection of User models.
-$models = User::raw(function($collection)
+'connections' => [
+    'database' => [
+        'driver' => 'mongodb',
+        'table' => 'jobs',
+        'queue' => 'default',
+        'expire' => 60,
+    ],
+],
+```
+
+If you want to use MongoDB to handle failed jobs, change the database in `config/queue.php`:
+
+```php
+'failed' => [
+    'driver' => env('QUEUE_FAILED_DRIVER', 'database'),
+    'database' => env('DB_CONNECTION', 'mongodb'),
+    'table' => 'failed_jobs',
+],
+```
+
+Or simply set your own `QUEUE_FAILED_DRIVER` environment variable to `mongodb`
+```env
+QUEUE_FAILED_DRIVER=mongodb
+```
+
+Last, add the service provider in `config/app.php`:
+
+```php
+Jenssegers\Mongodb\MongodbQueueServiceProvider::class,
+```
+
+Debugging
+---------
+
+### ->toSql()
+
+Hence we are in a NoSQL driver, it is counter-intuitive to use `toSql()` to output the string that will be executed.
+
+However, if you still need the string that looks like the sql for some inspection, you can use the `toSql()` method:
+
+```php
+User::where('some_field', '>', 300)
+    ->whereRaw(['age' => ['$gt' => 30, '$lt' => 40]])
+    ->toSql();
+
+// output
+"select * from "users" where "some_field" > ? and {"age":{"$gt":30,"$lt":40}}"
+```
+
+Upgrading
+---------
+
+#### Upgrading from version 2 to 3
+
+In this new major release which supports the new MongoDB PHP extension, we also moved the location of the Model class and replaced the MySQL model class with a trait.
+
+Please change all `Jenssegers\Mongodb\Model` references to `Jenssegers\Mongodb\Eloquent\Model` either at the top of your model files or your registered alias.
+
+```php
+use Jenssegers\Mongodb\Eloquent\Model;
+
+class User extends Model
 {
-    return $collection->find();
-});
+    //
+}
+```
 
-// Returns the original MongoCursor.
-$cursor = DB::collection('users')->raw(function($collection)
+If you are using hybrid relations, your MySQL classes should now extend the original Eloquent model class `Illuminate\Database\Eloquent\Model` instead of the removed `Jenssegers\Eloquent\Model`.
+
+Instead use the new `Jenssegers\Mongodb\Eloquent\HybridRelations` trait. This should make things more clear as there is only one single model class in this package.
+
+```php
+use Jenssegers\Mongodb\Eloquent\HybridRelations;
+
+class User extends Model
 {
-    return $collection->find();
-});
+
+    use HybridRelations;
+
+    protected $connection = 'mysql';
+}
 ```
 
-Optional: if you don't pass a closure to the raw method, the internal MongoCollection object will be accessible:
+Embedded relations now return an `Illuminate\Database\Eloquent\Collection` rather than a custom Collection class. If you were using one of the special methods that were available, convert them to Collection operations.
 
 ```php
-$model = User::raw()->findOne(['age' => ['$lt' => 18]]);
+$books = $user->books()->sortBy('title')->get();
 ```
-
-The internal MongoClient and MongoDB objects can be accessed like this:
-
-```php
-$client = DB::getMongoClient();
-$db = DB::getMongoDB();
-```
-
-### MongoDB specific operations
-
-**Cursor timeout**
-
-To prevent MongoCursorTimeout exceptions, you can manually set a timeout value that will be applied to the cursor:
-
-```php
-DB::collection('users')->timeout(-1)->get();
-```
-
-**Upsert**
-
-Update or insert a document. Additional options for the update method are passed directly to the native update method.
-
-```php
-DB::collection('users')->where('name', 'John')
-                       ->update($data, ['upsert' => true]);
-```
-
-**Projections**
-
-You can apply projections to your queries using the `project` method.
-
-```php
-DB::collection('items')->project(['tags' => ['$slice' => 1]])->get();
-DB::collection('items')->project(['tags' => ['$slice' => [3, 7]]])->get();
-```
-
-**Projections with Pagination**
-
-```php
-$limit = 25;
-$projections = ['id', 'name'];
-DB::collection('items')->paginate($limit, $projections);
-```
-
-
-**Push**
-
-Add items to an array.
-
-```php
-DB::collection('users')->where('name', 'John')->push('items', 'boots');
-DB::collection('users')->where('name', 'John')->push('messages', ['from' => 'Jane Doe', 'message' => 'Hi John']);
-```
-
-If you don't want duplicate items, set the third parameter to `true`:
-
-```php
-DB::collection('users')->where('name', 'John')->push('items', 'boots', true);
-```
-
-**Pull**
-
-Remove an item from an array.
-
-```php
-DB::collection('users')->where('name', 'John')->pull('items', 'boots');
-DB::collection('users')->where('name', 'John')->pull('messages', ['from' => 'Jane Doe', 'message' => 'Hi John']);
-```
-
-**Unset**
-
-Remove one or more fields from a document.
-
-```php
-DB::collection('users')->where('name', 'John')->unset('note');
-```
-
-You can also perform an unset on a model.
-
-```php
-$user = User::where('name', 'John')->first();
-$user->unset('note');
-```
-
-### Query Caching
-
-You may easily cache the results of a query using the remember method:
-
-```php
-$users = User::remember(10)->get();
-```
-
-*From: https://laravel.com/docs/4.2/queries#caching-queries*
-
-### Query Logging
-
-By default, Laravel keeps a log in memory of all queries that have been run for the current request. However, in some cases, such as when inserting a large number of rows, this can cause the application to use excess memory. To disable the log, you may use the `disableQueryLog` method:
-
-```php
-DB::connection()->disableQueryLog();
-```
-
-*From: https://laravel.com/docs/4.2/database#query-logging*

--- a/src/Jenssegers/Mongodb/Query/Grammar.php
+++ b/src/Jenssegers/Mongodb/Query/Grammar.php
@@ -6,4 +6,19 @@ use Illuminate\Database\Query\Grammars\Grammar as BaseGrammar;
 
 class Grammar extends BaseGrammar
 {
+    /**
+     * {@inheritdoc}
+     */
+    protected function compileWheresToArray($query)
+    {
+        return collect($query->wheres)->map(function ($where) use ($query) {
+            $baseWhere = $this->{"where{$where['type']}"}($query, $where);
+
+            if (isset($where['sql']) && is_array($where['sql'])) {
+                $baseWhere = json_encode($baseWhere);
+            }
+
+            return $where['boolean'].' '.$baseWhere;
+        })->all();
+    }
 }

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -573,7 +573,7 @@ class ModelTest extends TestCase
         $this->assertEquals(3, $count);
     }
 
-    public function toSqlTest(): void
+    public function testToSql(): void
     {
         $this->assertTrue(
             is_string(User::where('age', 30)->toSql())
@@ -581,6 +581,16 @@ class ModelTest extends TestCase
 
         $this->assertTrue(
             is_string(User::whereRaw(['age' => ['$gt' => 30, '$lt' => 40]])->toSql())
+        );
+
+        $this->assertEquals(
+            'select * from "users" where "some_field" > ?',
+            User::where('some_field', '>', 300)->toSql()
+        );
+
+        $this->assertEquals(
+            'select * from "users" where "some_field" > ? and {"age":{"$gt":30,"$lt":40}}',
+            User::where('some_field', '>', 300)->whereRaw(['age' => ['$gt' => 30, '$lt' => 40]])->toSql()
         );
     }
 }

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -440,7 +440,7 @@ class ModelTest extends TestCase
 
         Carbon::setTestNow($fakeDate);
         $item = Item::create(['name' => 'sword']);
-        
+
         $this->assertLessThan(1, $fakeDate->diffInSeconds($item->created_at));
     }
 
@@ -571,5 +571,16 @@ class ModelTest extends TestCase
         });
 
         $this->assertEquals(3, $count);
+    }
+
+    public function toSqlTest(): void
+    {
+        $this->assertTrue(
+            is_string(User::where('age', 30)->toSql())
+        );
+
+        $this->assertTrue(
+            is_string(User::whereRaw(['age' => ['$gt' => 30, '$lt' => 40]])->toSql())
+        );
     }
 }


### PR DESCRIPTION
See this open PR i closed a while: https://github.com/jenssegers/laravel-mongodb/pull/1887

It's good to make it work not only because of debugging (either it's not called SQL), but also you can cache query-by-query easier using packages like this: https://github.com/rennokki/laravel-eloquent-query-cache

~Needs testing.~

Actually it is safe, it detects arrays and automatically serializes them to string, which is exactly what's needed.