### PR TITLE
[hotfix] The Mongo version in CI for 4.0 uses actually the 4

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        php: [7.1, 7.2, 7.3, 7.4]
+        php: ['7.1', '7.2', '7.3', '7.4']
         os: ['ubuntu-latest']
-        mongodb: [3.6, 4.0, 4.2]
+        mongodb: ['3.6', '4.0', '4.2']
     services:
       mongo:
         image: mongo:${{ matrix.mongodb }}


### PR DESCRIPTION
It seems like the CI's Mongo version `4.0` is treated by Github Actions like `4` rather than actual `4.0`.

![mongo](https://user-images.githubusercontent.com/21983456/73052176-2331d280-3e8d-11ea-9f26-e197b8e9cd7c.png)

According to DockerHub, the `4` tag is associated to `4.2.2` and `4.2` rather than `4.0`:

![tag](https://user-images.githubusercontent.com/21983456/73052198-3349b200-3e8d-11ea-8760-122700764fb8.png)

When the matrix elements are changed to string values, the right mongo version is used.