### PR TITLE
[Updated PR#1468] Fix assertObjectNotHasAttribute cannot test magic attributes

### DIFF
--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -361,7 +361,7 @@ class ModelTest extends TestCase
 
         $user1->unset('note1');
 
-        $this->assertObjectNotHasAttribute('note1', $user1);
+        $this->assertFalse(isset($user1->note1));
         $this->assertTrue(isset($user1->note2));
         $this->assertTrue(isset($user2->note1));
         $this->assertTrue(isset($user2->note2));
@@ -370,15 +370,15 @@ class ModelTest extends TestCase
         $user1 = User::find($user1->_id);
         $user2 = User::find($user2->_id);
 
-        $this->assertObjectNotHasAttribute('note1', $user1);
+        $this->assertFalse(isset($user1->note1));
         $this->assertTrue(isset($user1->note2));
         $this->assertTrue(isset($user2->note1));
         $this->assertTrue(isset($user2->note2));
 
         $user2->unset(['note1', 'note2']);
 
-        $this->assertObjectNotHasAttribute('note1', $user2);
-        $this->assertObjectNotHasAttribute('note2', $user2);
+        $this->assertFalse(isset($user2->note1));
+        $this->assertFalse(isset($user2->note2));
     }
 
     public function testDates(): void


### PR DESCRIPTION
This PR was recreated from https://github.com/jenssegers/laravel-mongodb/pull/1468 with updated branch or resolved conflicting files.

--

fix tests: assertObjectNotHasAttribute cannot test magic attributes

assertObjectNotHasAttribute() actually tests nothing. Go ahead and change note1 to note2 in tests and you see nothing fails.