### PR TITLE
[Updated PR#1886] Fix Regex example

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,7 +460,7 @@ Selects documents where values match a specified regular expression.
 ```php
 use MongoDB\BSON\Regex;
 
-User::where('name', 'regex', new Regex("/.*doe/i"))->get();
+User::where('name', 'regex', new Regex('.*doe', 'i'))->get();
 ```
 
 **NOTE:** you can also use the Laravel regexp operations. These are a bit more flexible and will automatically convert your regular expression string to a `MongoDB\BSON\Regex` object.


### PR DESCRIPTION
This PR was recreated from https://github.com/jenssegers/laravel-mongodb/pull/1886 with updated branch or resolved conflicting files.

--

Fixed a regex example which accepts two parameters instead of one http://docs.php.net/manual/en/mongodb-bson-regex.construct.php#refsect1-mongodb-bson-regex.construct-examples

Co-Authored-By: ryan7n <ryan7n@users.noreply.github.com>