### PR TITLE
[Updated PR#1556] Allow setting hint option on QueryBuilder

### DIFF
--- a/src/Jenssegers/Mongodb/Query/Builder.php
+++ b/src/Jenssegers/Mongodb/Query/Builder.php
@@ -384,10 +384,12 @@ class Builder extends BaseBuilder
             if ($this->limit) {
                 $options['limit'] = $this->limit;
             }
+            if ($this->hint) {
+                $options['hint'] = $this->hint;
+            }
             if ($columns) {
                 $options['projection'] = $columns;
             }
-            // if ($this->hint)    $cursor->hint($this->hint);
 
             // Fix for legacy support, converts the results to arrays instead of objects.
             $options['typeMap'] = ['root' => 'array', 'document' => 'array'];

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -748,14 +748,14 @@ class QueryBuilderTest extends TestCase
 
         $results = DB::collection('items')->hint(['$natural' => -1])->get();
 
-        $this->assertArraySubset(['name' => 'spoon'], $results[0]);
-        $this->assertArraySubset(['name' => 'spork'], $results[1]);
-        $this->assertArraySubset(['name' => 'fork'], $results[2]);
+        $this->assertEquals('spoon', $results[0]['name']);
+        $this->assertEquals('spork', $results[1]['name']);
+        $this->assertEquals('fork', $results[2]['name']);
 
         $results = DB::collection('items')->hint(['$natural' => 1])->get();
 
-        $this->assertArraySubset(['name' => 'spoon'], $results[2]);
-        $this->assertArraySubset(['name' => 'spork'], $results[1]);
-        $this->assertArraySubset(['name' => 'fork'], $results[0]);
+        $this->assertEquals('spoon', $results[2]['name']);
+        $this->assertEquals('spork', $results[1]['name']);
+        $this->assertEquals('fork', $results[0]['name']);
     }
 }

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -737,4 +737,25 @@ class QueryBuilderTest extends TestCase
         $this->assertEquals('Herman', DB::collection('books')->value('author.first_name'));
         $this->assertEquals('Melville', DB::collection('books')->value('author.last_name'));
     }
+
+    public function testHintOptions()
+    {
+        DB::collection('items')->insert([
+            ['name' => 'fork',  'tags' => ['sharp', 'pointy']],
+            ['name' => 'spork', 'tags' => ['sharp', 'pointy', 'round', 'bowl']],
+            ['name' => 'spoon', 'tags' => ['round', 'bowl']],
+        ]);
+
+        $results = DB::collection('items')->hint(['$natural' => -1])->get();
+
+        $this->assertArraySubset(['name' => 'spoon'], $results[0]);
+        $this->assertArraySubset(['name' => 'spork'], $results[1]);
+        $this->assertArraySubset(['name' => 'fork'], $results[2]);
+
+        $results = DB::collection('items')->hint(['$natural' => 1])->get();
+
+        $this->assertArraySubset(['name' => 'spoon'], $results[2]);
+        $this->assertArraySubset(['name' => 'spork'], $results[1]);
+        $this->assertArraySubset(['name' => 'fork'], $results[0]);
+    }
 }


### PR DESCRIPTION
This PR was recreated from https://github.com/jenssegers/laravel-mongodb/pull/1556 with updated branch or resolved conflicting files.

--
The hint option allows us to use the $natural ordering meta operator.

I've added tests that validate that hint options are rather sent.

Thanks !
Co-Authored-By: Manan Jadhav <jadhavm@uwindsor.ca>