### PR TITLE
[Updated PR#1476] Add explanation for database migration resets

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This package adds functionalities to the Eloquent model and Query builder for Mo
     - [Lumen](#lumen)
     - [Non-Laravel projects](#non-laravel-projects)
   - [Testing](#testing)
+  - [Database Testing](#database-testing)
   - [Configuration](#configuration)
   - [Eloquent](#eloquent)
     - [Extending the base model](#extending-the-base-model)
@@ -111,6 +112,21 @@ To run the test for this package, run:
 
 ```
 docker-compose up
+```
+
+Database Testing
+-------
+
+Resetting The Database After Each Test
+
+```php
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+```
+
+And inside each test classes.
+
+```php
+use DatabaseMigrations;
 ```
 
 Configuration

--- a/README.md
+++ b/README.md
@@ -129,16 +129,9 @@ Also inside each test classes, add:
 use DatabaseMigrations;
 ```
 
-Keep in mind that currently this isn't supported and should be removed:
-
-```php
-use DatabaseTransactions;
-```
-and
-
-```php
-use RefreshDatabase;
-```
+Keep in mind that these traits are not yet supported:
+- `use Database Transactions;`
+- `use RefreshDatabase;`
 
 Configuration
 -------------

--- a/README.md
+++ b/README.md
@@ -117,16 +117,27 @@ docker-compose up
 Database Testing
 -------
 
-Resetting The Database After Each Test
+To reset the database after each test, add:
 
 ```php
 use Illuminate\Foundation\Testing\DatabaseMigrations;
 ```
 
-And inside each test classes.
+Also inside each test classes, add:
 
 ```php
 use DatabaseMigrations;
+```
+
+Keep in mind that currently this isn't supported and should be removed:
+
+```php
+use DatabaseTransactions;
+```
+and
+
+```php
+use RefreshDatabase;
 ```
 
 Configuration


### PR DESCRIPTION
This PR was recreated from https://github.com/jenssegers/laravel-mongodb/pull/1476 with updated branch or resolved conflicting files.

--

Add Database Testing to index.
use DatabaseMigrations; instead of use RefreshDatabase; for laravel 5.6 compatibility issue (https://github.com/jenssegers/laravel-mongodb/issues/1475)

Co-Authored-By: theminer3746 <theminer@theminerdev.com>