### PR TITLE
Fix truncate on models

### DIFF
--- a/src/Jenssegers/Mongodb/Query/Builder.php
+++ b/src/Jenssegers/Mongodb/Query/Builder.php
@@ -700,7 +700,11 @@ class Builder extends BaseBuilder
      */
     public function truncate()
     {
-        $result = $this->collection->drop();
+        $options = [
+            'typeMap' => ['root' => 'object', 'document' => 'object'],
+        ];
+
+        $result = $this->collection->drop($options);
 
         return (1 == (int) $result->ok);
     }

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -572,4 +572,13 @@ class ModelTest extends TestCase
 
         $this->assertEquals(3, $count);
     }
+
+    public function testTruncateModel()
+    {
+        User::create(['name' => 'John Doe']);
+
+        User::truncate();
+
+        $this->assertEquals(0, User::count());
+    }
 }

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -175,7 +175,8 @@ class QueryBuilderTest extends TestCase
     public function testTruncate()
     {
         DB::collection('users')->insert(['name' => 'John Doe']);
-        DB::collection('users')->truncate();
+        $result = DB::collection('users')->truncate();
+        $this->assertEquals(1, $result);
         $this->assertEquals(0, DB::collection('users')->count());
     }
 


### PR DESCRIPTION
According to docs array or object might be returned on drop, so we need to add options.

See https://docs.mongodb.com/php-library/v1.5/reference/method/MongoDBCollection-drop

Related issue: https://github.com/jenssegers/laravel-mongodb/issues/1948

However, not sure about `$this->assertEquals(1, $result);` since truncate actually returns void  https://github.com/laravel/framework/blob/6.x/src/Illuminate/Database/Query/Builder.php#L2804

Closes #1948 