### PR TITLE
Add custom operator in select

### DIFF
--- a/src/Jenssegers/Mongodb/Query/Builder.php
+++ b/src/Jenssegers/Mongodb/Query/Builder.php
@@ -239,11 +239,21 @@ class Builder extends BaseBuilder
             // Add grouping columns to the $group part of the aggregation pipeline.
             if ($this->groups) {
                 foreach ($this->groups as $column) {
-                    $group['_id'][$column] = '$' . $column;
+                      // in this condition we check if user wants to select with another operator
+                      // if $colunm is array it means user wants diffrent operator
+                      if (is_array($column)) {
+                        $value = array_values($column);
+                        $key = str_replace('.', '_', $value[0]);
 
-                    // When grouping, also add the $last operator to each grouped field,
-                    // this mimics MySQL's behaviour a bit.
-                    $group[$column] = ['$last' => '$' . $column];
+                        // When grouping, we can add custom operators like MySQL
+                        $group[$key] = ['$' . array_keys($column)[0] => '$' . $value[0]];
+                    } else {
+                        $key = str_replace('.', '_', $column);
+
+                        // When grouping, also add the $last operator to each grouped field,
+                        // this mimics MySQL's behaviour a bit.
+                        $group[$key] = ['$last' => '$' . $column];
+                    }
                 }
 
                 // Do the same for other columns that are selected.

--- a/src/Jenssegers/Mongodb/Query/Builder.php
+++ b/src/Jenssegers/Mongodb/Query/Builder.php
@@ -237,30 +237,27 @@ class Builder extends BaseBuilder
             $unwinds = [];
 
             // Add grouping columns to the $group part of the aggregation pipeline.
-            if ($this->groups) {
+             if ($this->groups) {
                 foreach ($this->groups as $column) {
-                      // in this condition we check if user wants to select with another operator
-                      // if $colunm is array it means user wants diffrent operator
-                      if (is_array($column)) {
-                        $value = array_values($column);
-                        $key = str_replace('.', '_', $value[0]);
+                    $group['_id'][$column] = '$' . $column;
 
-                        // When grouping, we can add custom operators like MySQL
-                        $group[$key] = ['$' . array_keys($column)[0] => '$' . $value[0]];
-                    } else {
-                        $key = str_replace('.', '_', $column);
-
-                        // When grouping, also add the $last operator to each grouped field,
-                        // this mimics MySQL's behaviour a bit.
-                        $group[$key] = ['$last' => '$' . $column];
-                    }
+                    // When grouping, also add the $last operator to each grouped field,
+                    // this mimics MySQL's behaviour a bit.
+                    $group[$column] = ['$last' => '$' . $column];
                 }
 
                 // Do the same for other columns that are selected.
                 foreach ($this->columns as $column) {
-                    $key = str_replace('.', '_', $column);
+                    if (is_array($column)) {
+                        $value = array_values($column);
+                        $key = str_replace('.', '_', $value[0]);
 
-                    $group[$key] = ['$last' => '$' . $column];
+                        $group[$key] = ['$' . array_keys($column)[0] => '$' . $value[0]];
+                    } else {
+                        $key = str_replace('.', '_', $column);
+
+                        $group[$key] = ['$last' => '$' . $column];
+                    }
                 }
             }
 

--- a/src/Jenssegers/Mongodb/Query/Builder.php
+++ b/src/Jenssegers/Mongodb/Query/Builder.php
@@ -246,7 +246,7 @@ class Builder extends BaseBuilder
                     $group[$column] = ['$last' => '$' . $column];
                 }
 
-                // Do the same for other columns that are selected.
+                // Do the same for other columns that are selected. 
                 foreach ($this->columns as $column) {
                     if (is_array($column)) {
                         $value = array_values($column);

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -211,6 +211,10 @@ class QueryTest extends TestCase
         $users = User::select('name')->groupBy('age')->skip(1)->take(2)->orderBy('age', 'desc')->get();
         $this->assertCount(2, $users);
         $this->assertNotNull($users[0]->name);
+        
+        $users = User::select(['name',['sum'=>'age']])->groupBy('title')->get();
+        $this->assertCount(3, $users);
+        $this->assertEquals(103, $users[0]->age);
     }
 
     public function testCount(): void


### PR DESCRIPTION
Hi, i was using this package and every thing was OK until i ran into a problem. the problem was this:
i want to add groupBy on a table and select sum of some fields but when i searched in git i found that this package only groups data by last operator.

i update the query builder and add new rule to select grouped field with other operators. syntax is like this:
```
Subsidiary::where('supplier_id', $request->get('supplier'))->groupBy('supplier_id')->select([
            ['sum' => 'whole_debit'],
            ['sum' => 'whole_credit'],
            'type',
        ])->paginate(20)
```

i hope you like it :)