### PR TITLE
[Updated PR#1145] Fix paginate in EmbedsMany

### DIFF
--- a/src/Jenssegers/Mongodb/Relations/EmbedsMany.php
+++ b/src/Jenssegers/Mongodb/Relations/EmbedsMany.php
@@ -273,7 +273,7 @@ class EmbedsMany extends EmbedsOneOrMany
      */
     public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null)
     {
-        $page = Paginator::resolveCurrentPage();
+        $page = $page ?: Paginator::resolveCurrentPage($pageName);
         $perPage = $perPage ?: $this->related->getPerPage();
 
         $results = $this->getEmbedded();

--- a/src/Jenssegers/Mongodb/Relations/EmbedsMany.php
+++ b/src/Jenssegers/Mongodb/Relations/EmbedsMany.php
@@ -264,8 +264,7 @@ class EmbedsMany extends EmbedsOneOrMany
 
         return $this->setEmbedded($records);
     }
-
-
+    
     /**
      * @param null $perPage
      * @param array $columns

--- a/src/Jenssegers/Mongodb/Relations/EmbedsMany.php
+++ b/src/Jenssegers/Mongodb/Relations/EmbedsMany.php
@@ -5,6 +5,7 @@ namespace Jenssegers\Mongodb\Relations;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Model as EloquentModel;
+use Illuminate\Pagination\AbstractPaginator;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Pagination\Paginator;
 use MongoDB\BSON\ObjectID;
@@ -264,26 +265,38 @@ class EmbedsMany extends EmbedsOneOrMany
         return $this->setEmbedded($records);
     }
 
+
     /**
-     * Get a paginator for the "select" statement.
-     * @param int $perPage
-     * @return \Illuminate\Pagination\AbstractPaginator
+     * @param null $perPage
+     * @param array $columns
+     * @param string $pageName
+     * @param null $page
+     * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
      */
-    public function paginate($perPage = null)
+    public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null)
     {
         $page = Paginator::resolveCurrentPage();
         $perPage = $perPage ?: $this->related->getPerPage();
 
         $results = $this->getEmbedded();
-
-        $total = count($results);
-
+        $results = $this->toCollection($results);
+        $total = $results->count();
         $start = ($page - 1) * $perPage;
-        $sliced = array_slice($results, $start, $perPage);
 
-        return new LengthAwarePaginator($sliced, $total, $perPage, $page, [
-            'path' => Paginator::resolveCurrentPath(),
-        ]);
+        $sliced = $results->slice(
+            $start,
+            $perPage
+        );
+
+        return new LengthAwarePaginator(
+            $sliced,
+            $total,
+            $perPage,
+            $page,
+            [
+                'path' => Paginator::resolveCurrentPath()
+            ]
+        );
     }
 
     /**

--- a/src/Jenssegers/Mongodb/Relations/EmbedsMany.php
+++ b/src/Jenssegers/Mongodb/Relations/EmbedsMany.php
@@ -5,7 +5,6 @@ namespace Jenssegers\Mongodb\Relations;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Model as EloquentModel;
-use Illuminate\Pagination\AbstractPaginator;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Pagination\Paginator;
 use MongoDB\BSON\ObjectID;
@@ -264,7 +263,7 @@ class EmbedsMany extends EmbedsOneOrMany
 
         return $this->setEmbedded($records);
     }
-    
+
     /**
      * @param null $perPage
      * @param array $columns


### PR DESCRIPTION
This PR was recreated from #1145 
--

As describe [here](https://laravel.com/api/5.0/Illuminate/Pagination/LengthAwarePaginator.html), `$items` (a parameter of `LengthAwarePaginator`) need to be an instance of Collection. I also converted the `slice()` operation with the collection's method and I have updated the docs.

Co-Authored-By: @SamsamBabadi 