### PR TITLE
[Fix] Format exception to string in failed jobs

### DIFF
--- a/src/Jenssegers/Mongodb/Queue/Failed/MongoFailedJobProvider.php
+++ b/src/Jenssegers/Mongodb/Queue/Failed/MongoFailedJobProvider.php
@@ -12,11 +12,14 @@ class MongoFailedJobProvider extends DatabaseFailedJobProvider
      * @param string $connection
      * @param string $queue
      * @param string $payload
+     * @param  \Exception  $exception
      * @return void
      */
     public function log($connection, $queue, $payload, $exception)
     {
         $failed_at = Carbon::now()->getTimestamp();
+
+        $exception = (string) $exception;
 
         $this->getTable()->insert(compact('connection', 'queue', 'payload', 'failed_at', 'exception'));
     }


### PR DESCRIPTION
Format exception to string in failed job so it can be saved correctly.

See: https://github.com/laravel/framework/blob/6.x/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php#L59

Closes: https://github.com/jenssegers/laravel-mongodb/issues/1800, https://github.com/jenssegers/laravel-mongodb/pull/1524, https://github.com/jenssegers/laravel-mongodb/pull/1480