### PR TITLE
[Updated PR#1534]  UTCDateTime conversion now includes milliseconds

### DIFF
--- a/src/Jenssegers/Mongodb/Auth/DatabaseTokenRepository.php
+++ b/src/Jenssegers/Mongodb/Auth/DatabaseTokenRepository.php
@@ -17,7 +17,7 @@ class DatabaseTokenRepository extends BaseDatabaseTokenRepository
         return [
             'email' => $email,
             'token' => $this->hasher->make($token),
-            'created_at' => new UTCDateTime(time() * 1000),
+            'created_at' => new UTCDateTime(now()->format('Uv')),
         ];
     }
 
@@ -37,7 +37,7 @@ class DatabaseTokenRepository extends BaseDatabaseTokenRepository
     protected function tokenRecentlyCreated($createdAt)
     {
         $createdAt = $this->convertDateTime($createdAt);
-        
+
         return parent::tokenRecentlyCreated($createdAt);
     }
 

--- a/src/Jenssegers/Mongodb/Auth/DatabaseTokenRepository.php
+++ b/src/Jenssegers/Mongodb/Auth/DatabaseTokenRepository.php
@@ -17,7 +17,7 @@ class DatabaseTokenRepository extends BaseDatabaseTokenRepository
         return [
             'email' => $email,
             'token' => $this->hasher->make($token),
-            'created_at' => new UTCDateTime(now()->format('Uv')),
+            'created_at' => new UTCDateTime(Date::now()->format('Uv')),
         ];
     }
 

--- a/src/Jenssegers/Mongodb/Auth/DatabaseTokenRepository.php
+++ b/src/Jenssegers/Mongodb/Auth/DatabaseTokenRepository.php
@@ -5,6 +5,7 @@ namespace Jenssegers\Mongodb\Auth;
 use DateTime;
 use DateTimeZone;
 use Illuminate\Auth\Passwords\DatabaseTokenRepository as BaseDatabaseTokenRepository;
+use Illuminate\Support\Facades\Date;
 use MongoDB\BSON\UTCDateTime;
 
 class DatabaseTokenRepository extends BaseDatabaseTokenRepository

--- a/src/Jenssegers/Mongodb/Eloquent/Model.php
+++ b/src/Jenssegers/Mongodb/Eloquent/Model.php
@@ -2,7 +2,6 @@
 
 namespace Jenssegers\Mongodb\Eloquent;
 
-use Illuminate\Support\Carbon;
 use DateTime;
 use Illuminate\Contracts\Queue\QueueableCollection;
 use Illuminate\Contracts\Queue\QueueableEntity;

--- a/src/Jenssegers/Mongodb/Eloquent/Model.php
+++ b/src/Jenssegers/Mongodb/Eloquent/Model.php
@@ -2,7 +2,7 @@
 
 namespace Jenssegers\Mongodb\Eloquent;
 
-use Carbon\Carbon;
+use Illuminate\Support\Carbon;
 use DateTime;
 use Illuminate\Contracts\Queue\QueueableCollection;
 use Illuminate\Contracts\Queue\QueueableEntity;

--- a/src/Jenssegers/Mongodb/Eloquent/Model.php
+++ b/src/Jenssegers/Mongodb/Eloquent/Model.php
@@ -118,7 +118,7 @@ abstract class Model extends BaseModel
      */
     public function freshTimestamp()
     {
-        return new UTCDateTime(now()->format('Uv'));
+        return new UTCDateTime(Date::now()->format('Uv'));
     }
 
     /**

--- a/src/Jenssegers/Mongodb/Eloquent/Model.php
+++ b/src/Jenssegers/Mongodb/Eloquent/Model.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Queue\QueueableEntity;
 use Illuminate\Database\Eloquent\Model as BaseModel;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Str;
 use Jenssegers\Mongodb\Query\Builder as QueryBuilder;
 use MongoDB\BSON\Binary;

--- a/src/Jenssegers/Mongodb/Eloquent/Model.php
+++ b/src/Jenssegers/Mongodb/Eloquent/Model.php
@@ -89,7 +89,7 @@ abstract class Model extends BaseModel
             $value = parent::asDateTime($value);
         }
 
-        return new UTCDateTime($value->getTimestamp() * 1000);
+        return new UTCDateTime($value->format('Uv'));
     }
 
     /**
@@ -99,7 +99,7 @@ abstract class Model extends BaseModel
     {
         // Convert UTCDateTime instances.
         if ($value instanceof UTCDateTime) {
-            return Carbon::createFromTimestamp($value->toDateTime()->getTimestamp());
+            return Carbon::createFromTimestampMs($value->toDateTime()->format('Uv'));
         }
 
         return parent::asDateTime($value);

--- a/src/Jenssegers/Mongodb/Eloquent/Model.php
+++ b/src/Jenssegers/Mongodb/Eloquent/Model.php
@@ -99,7 +99,7 @@ abstract class Model extends BaseModel
     {
         // Convert UTCDateTime instances.
         if ($value instanceof UTCDateTime) {
-            return Carbon::createFromTimestampMs($value->toDateTime()->format('Uv'));
+            return Date::createFromTimestampMs($value->toDateTime()->format('Uv'));
         }
 
         return parent::asDateTime($value);

--- a/src/Jenssegers/Mongodb/Eloquent/Model.php
+++ b/src/Jenssegers/Mongodb/Eloquent/Model.php
@@ -118,7 +118,7 @@ abstract class Model extends BaseModel
      */
     public function freshTimestamp()
     {
-        return new UTCDateTime(Carbon::now());
+        return new UTCDateTime(now()->format('Uv'));
     }
 
     /**

--- a/src/Jenssegers/Mongodb/Query/Builder.php
+++ b/src/Jenssegers/Mongodb/Query/Builder.php
@@ -294,7 +294,7 @@ class Builder extends BaseBuilder
                     }
                 }
             }
-            
+
             // The _id field is mandatory when using grouping.
             if ($group && empty($group['_id'])) {
                 $group['_id'] = null;
@@ -930,18 +930,18 @@ class Builder extends BaseBuilder
                 if (is_array($where['value'])) {
                     array_walk_recursive($where['value'], function (&$item, $key) {
                         if ($item instanceof DateTime) {
-                            $item = new UTCDateTime($item->getTimestamp() * 1000);
+                            $item = new UTCDateTime($item->format('Uv'));
                         }
                     });
                 } else {
                     if ($where['value'] instanceof DateTime) {
-                        $where['value'] = new UTCDateTime($where['value']->getTimestamp() * 1000);
+                        $where['value'] = new UTCDateTime($where['value']->format('Uv'));
                     }
                 }
             } elseif (isset($where['values'])) {
                 array_walk_recursive($where['values'], function (&$item, $key) {
                     if ($item instanceof DateTime) {
-                        $item = new UTCDateTime($item->getTimestamp() * 1000);
+                        $item = new UTCDateTime($item->format('Uv'));
                     }
                 });
             }

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -546,7 +546,7 @@ class QueryBuilderTest extends TestCase
     public function testDates()
     {
         DB::collection('users')->insert([
-            ['name' => 'John Doe', 'birthday' => new UTCDateTime(Carbon::parse("1980-01-01 00:00:00")->format('Uv'))],
+            ['name' => 'John Doe', 'birthday' => new UTCDateTime(Date::parse("1980-01-01 00:00:00")->format('Uv'))],
             ['name' => 'Jane Doe', 'birthday' => new UTCDateTime(Carbon::parse("1981-01-01 00:00:00")->format('Uv'))],
             ['name' => 'Robert Roe', 'birthday' => new UTCDateTime(Carbon::parse("1982-01-01 00:00:00")->format('Uv'))],
             ['name' => 'Mark Moe', 'birthday' => new UTCDateTime(Carbon::parse("1983-01-01 00:00:00")->format('Uv'))],

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-use Carbon\Carbon;
+use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\DB;
 use Jenssegers\Mongodb\Collection;
 use Jenssegers\Mongodb\Query\Builder;

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -1,6 +1,7 @@
 <?php
 declare(strict_types=1);
 
+use Carbon\Carbon;
 use Illuminate\Support\Facades\DB;
 use Jenssegers\Mongodb\Collection;
 use Jenssegers\Mongodb\Query\Builder;
@@ -545,14 +546,14 @@ class QueryBuilderTest extends TestCase
     public function testDates()
     {
         DB::collection('users')->insert([
-            ['name' => 'John Doe', 'birthday' => new UTCDateTime(1000 * strtotime("1980-01-01 00:00:00"))],
-            ['name' => 'Jane Doe', 'birthday' => new UTCDateTime(1000 * strtotime("1981-01-01 00:00:00"))],
-            ['name' => 'Robert Roe', 'birthday' => new UTCDateTime(1000 * strtotime("1982-01-01 00:00:00"))],
-            ['name' => 'Mark Moe', 'birthday' => new UTCDateTime(1000 * strtotime("1983-01-01 00:00:00"))],
+            ['name' => 'John Doe', 'birthday' => new UTCDateTime(Carbon::parse("1980-01-01 00:00:00")->format('Uv'))],
+            ['name' => 'Jane Doe', 'birthday' => new UTCDateTime(Carbon::parse("1981-01-01 00:00:00")->format('Uv'))],
+            ['name' => 'Robert Roe', 'birthday' => new UTCDateTime(Carbon::parse("1982-01-01 00:00:00")->format('Uv'))],
+            ['name' => 'Mark Moe', 'birthday' => new UTCDateTime(Carbon::parse("1983-01-01 00:00:00")->format('Uv'))],
         ]);
 
         $user = DB::collection('users')
-            ->where('birthday', new UTCDateTime(1000 * strtotime("1980-01-01 00:00:00")))
+            ->where('birthday', new UTCDateTime(Carbon::parse("1980-01-01 00:00:00")->format('Uv')))
             ->first();
         $this->assertEquals('John Doe', $user['name']);
 

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -547,13 +547,13 @@ class QueryBuilderTest extends TestCase
     {
         DB::collection('users')->insert([
             ['name' => 'John Doe', 'birthday' => new UTCDateTime(Date::parse("1980-01-01 00:00:00")->format('Uv'))],
-            ['name' => 'Jane Doe', 'birthday' => new UTCDateTime(Carbon::parse("1981-01-01 00:00:00")->format('Uv'))],
-            ['name' => 'Robert Roe', 'birthday' => new UTCDateTime(Carbon::parse("1982-01-01 00:00:00")->format('Uv'))],
-            ['name' => 'Mark Moe', 'birthday' => new UTCDateTime(Carbon::parse("1983-01-01 00:00:00")->format('Uv'))],
+            ['name' => 'Jane Doe', 'birthday' => new UTCDateTime(Date::parse("1981-01-01 00:00:00")->format('Uv'))],
+            ['name' => 'Robert Roe', 'birthday' => new UTCDateTime(Date::parse("1982-01-01 00:00:00")->format('Uv'))],
+            ['name' => 'Mark Moe', 'birthday' => new UTCDateTime(Date::parse("1983-01-01 00:00:00")->format('Uv'))],
         ]);
 
         $user = DB::collection('users')
-            ->where('birthday', new UTCDateTime(Carbon::parse("1980-01-01 00:00:00")->format('Uv')))
+            ->where('birthday', new UTCDateTime(Date::parse("1980-01-01 00:00:00")->format('Uv')))
             ->first();
         $this->assertEquals('John Doe', $user['name']);
 


### PR DESCRIPTION
This PR was recreated from #1534 
--

Currently laravel-mongodb strips out the millisecond value of the datetime when retrieving records or querying mongo. This PR fixes the date conversion to include the millisecond part of the date. The PR also saves created_at and updated_at with millisecond precision now.

This PR only works for PHP7 and above as I couldn't find anywhere specifying that PHP5 is supported, and travis is only testing on PHP7.

Co-Authored-By: @Flambe