### PR TITLE
[fix] Correct import class for DB in Queue

### DIFF
--- a/src/Jenssegers/Mongodb/MongodbQueueServiceProvider.php
+++ b/src/Jenssegers/Mongodb/MongodbQueueServiceProvider.php
@@ -2,7 +2,7 @@
 
 namespace Jenssegers\Mongodb;
 
-use DB;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Queue\QueueServiceProvider;
 use Jenssegers\Mongodb\Queue\Failed\MongoFailedJobProvider;
 


### PR DESCRIPTION
PR https://github.com/jenssegers/laravel-mongodb/pull/1851 had incorrect class import, we need to define correct path `use Illuminate\Support\Facades\DB;` instead of `use DB;`

Closes https://github.com/jenssegers/laravel-mongodb/issues/1868