### PR TITLE
Fix a typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -751,7 +751,7 @@ The belongsToMany relation will not use a pivot "table" but will push id's to a 
 If you want to define custom keys for your relation, set it to `null`:
 
 ```php
-use Jenssegers\Mongodb\Eloquent\Mode;
+use Jenssegers\Mongodb\Eloquent\Model;
 
 class User extends Model
 {


### PR DESCRIPTION
`belongsToMany` operation is imporing the `Model` with a typo. Fixed it.