### PR TITLE
Fix getDefaultDatabaseName to handle +srv URLs.

### DIFF
--- a/src/Jenssegers/Mongodb/Connection.php
+++ b/src/Jenssegers/Mongodb/Connection.php
@@ -128,7 +128,7 @@ class Connection extends BaseConnection
     protected function getDefaultDatabaseName($dsn, $config)
     {
         if (empty($config['database'])) {
-            if (preg_match('/^mongodb:\\/\\/.+\\/([^?&]+)/s', $dsn, $matches)) {
+            if (preg_match('/^mongodb(?:[+]srv)?:\\/\\/.+\\/([^?&]+)/s', $dsn, $matches)) {
                 $config['database'] = $matches[1];
             } else {
                 throw new InvalidArgumentException("Database is not properly configured.");


### PR DESCRIPTION
Fixes bug #1861.  I wasn't sure how to test this.  The updated method is protected, and the rest of the tests appear to rely on a test environment with a real Mongo instance.  I'm guessing that the targeted test environment doesn't currently support DNS SRV records.