### PR TITLE
[fix] Make newPivotQuery function public

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Make sure you have the MongoDB PHP driver installed. You can find installation i
  5.6.x    | 3.4.x
  5.7.x    | 3.4.x
  5.8.x    | 3.5.x
- 6.0.x    | 3.6.x
+ 6.x      | 3.6.x
 
 Install the package via Composer:
 

--- a/src/Jenssegers/Mongodb/Relations/BelongsToMany.php
+++ b/src/Jenssegers/Mongodb/Relations/BelongsToMany.php
@@ -265,7 +265,7 @@ class BelongsToMany extends EloquentBelongsToMany
     /**
      * @inheritdoc
      */
-    protected function newPivotQuery()
+    public function newPivotQuery()
     {
         return $this->newRelatedQuery();
     }


### PR DESCRIPTION
This is an urgent change, probably we need to release new version `3.6.3` as soon as possible.

PR https://github.com/laravel/framework/pull/31677 changed newPivotQuery function from `protected` to `public` and that's the reason why builds are failing.

> PHP Fatal error:  Access level to Jenssegers\Mongodb\Relations\BelongsToMany::newPivotQuery() must be public (as in class Illuminate\Database\Eloquent\Relations\BelongsToMany) in /home/runner/work/laravel-mongodb/laravel-mongodb/src/Jenssegers/Mongodb/Relations/BelongsToMany.php on line 268