### PR TITLE
[4.x] Remove shouldUseCollections function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,4 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 ### Removed
 - EmbedsOne and EmbedsMany relations by [@divine](https://github.com/divine).
+- shouldUseCollections function by [@divine](https://github.com/divine).

--- a/src/Jenssegers/Mongodb/Query/Builder.php
+++ b/src/Jenssegers/Mongodb/Query/Builder.php
@@ -116,12 +116,6 @@ class Builder extends BaseBuilder
     ];
 
     /**
-     * Check if we need to return Collections instead of plain arrays (laravel >= 5.3 )
-     * @var boolean
-     */
-    protected $useCollections;
-
-    /**
      * @inheritdoc
      */
     public function __construct(Connection $connection, Processor $processor)
@@ -129,22 +123,6 @@ class Builder extends BaseBuilder
         $this->grammar = new Grammar;
         $this->connection = $connection;
         $this->processor = $processor;
-        $this->useCollections = $this->shouldUseCollections();
-    }
-
-    /**
-     * Returns true if Laravel or Lumen >= 5.3
-     * @return bool
-     */
-    protected function shouldUseCollections()
-    {
-        if (function_exists('app')) {
-            $version = app()->version();
-            $version = filter_var(explode(')', $version)[0], FILTER_SANITIZE_NUMBER_FLOAT, FILTER_FLAG_ALLOW_FRACTION); // lumen
-            return version_compare($version, '5.3', '>=');
-        }
-
-        return true;
     }
 
     /**
@@ -285,7 +263,7 @@ class Builder extends BaseBuilder
                                 'aggregate' => $totalResults
                             ]
                         ];
-                        return $this->useCollections ? new Collection($results) : $results;
+                        return new Collection($results);
                     } elseif ($function == 'count') {
                         // Translate count into sum.
                         $group['aggregate'] = ['$sum' => 1];
@@ -342,7 +320,7 @@ class Builder extends BaseBuilder
             $results = iterator_to_array($this->collection->aggregate($pipeline, $options));
 
             // Return results
-            return $this->useCollections ? new Collection($results) : $results;
+            return new Collection($results);
         } // Distinct query
         elseif ($this->distinct) {
             // Return distinct results directly
@@ -355,7 +333,7 @@ class Builder extends BaseBuilder
                 $result = $this->collection->distinct($column);
             }
 
-            return $this->useCollections ? new Collection($result) : $result;
+            return new Collection($result);
         } // Normal query
         else {
             $columns = [];
@@ -404,7 +382,7 @@ class Builder extends BaseBuilder
 
             // Return results as an array with numeric keys
             $results = iterator_to_array($cursor, false);
-            return $this->useCollections ? new Collection($results) : $results;
+            return new Collection($results);
         }
     }
 
@@ -659,7 +637,7 @@ class Builder extends BaseBuilder
         }
 
         $p = Arr::pluck($results, $column, $key);
-        return $this->useCollections ? new Collection($p) : $p;
+        return new Collection($p);
     }
 
     /**


### PR DESCRIPTION
Remove shouldUseCollections function which checks Laravel version > 5.3, it was introduced to support version 5.3 in https://github.com/jenssegers/laravel-mongodb/pull/925