### PR TITLE
[4.x] use mongodb driver to check for dirtiness

### DIFF
--- a/src/Jenssegers/Mongodb/Eloquent/Model.php
+++ b/src/Jenssegers/Mongodb/Eloquent/Model.php
@@ -14,6 +14,8 @@ use Jenssegers\Mongodb\Query\Builder as QueryBuilder;
 use MongoDB\BSON\Binary;
 use MongoDB\BSON\ObjectID;
 use MongoDB\BSON\UTCDateTime;
+use function MongoDB\BSON\fromPHP;
+use MongoDB\Driver\Exception\UnexpectedValueException;
 
 abstract class Model extends BaseModel
 {
@@ -239,20 +241,11 @@ abstract class Model extends BaseModel
             return false;
         }
 
-        if ($this->isDateAttribute($key)) {
-            $current = $current instanceof UTCDateTime ? $this->asDateTime($current) : $current;
-            $original = $original instanceof UTCDateTime ? $this->asDateTime($original) : $original;
-
-            return $current == $original;
+        try {
+            return fromPHP([$current]) === fromPHP([$original]);
+        } catch (UnexpectedValueException $e) {
+            return false;
         }
-
-        if ($this->hasCast($key)) {
-            return $this->castAttribute($key, $current) ===
-                $this->castAttribute($key, $original);
-        }
-
-        return is_numeric($current) && is_numeric($original)
-            && strcmp((string) $current, (string) $original) === 0;
     }
 
     /**

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -555,11 +555,50 @@ class ModelTest extends TestCase
     public function testGetDirtyDates(): void
     {
         $user = new User();
-        $user->setRawAttributes(['name' => 'John Doe', 'birthday' => new DateTime('19 august 1989')], true);
+        $user->name = 'John Doe';
+        $user->birthday = new DateTime('19 august 1989');
+        $user->syncOriginal();
         $this->assertEmpty($user->getDirty());
 
         $user->birthday = new DateTime('19 august 1989');
         $this->assertEmpty($user->getDirty());
+    }
+
+    public function testGetDirty(): void
+    {
+        $ids = [
+            new ObjectId(),
+            new ObjectId(),
+        ];
+        $item = new Item([
+            'numbers' => [1, 2, 3],
+            'number' => 4,
+            'ids' => $ids,
+            'nullable' => 'value',
+            'fix' => 'fix',
+        ]);
+        $item->date = $item->fromDateTime(new DateTime('19 august 1989'));
+        $item->dates = [$item->fromDateTime(new DateTime('19 august 1989'))];
+        $item->save();
+
+        $item = $item->fresh();
+
+        $item->numbers = [1, 2, '3'];
+        $item->nullable = null;
+        $item->new_val = 'new';
+        $item->number = '4';
+        $item->ids = [
+            new ObjectId((string) $ids[0]),
+            new ObjectId((string) $ids[1]),
+        ];
+        $item->date = $item->fromDateTime(new DateTime('19 august 1989'));
+        $item->dates = [$item->fromDateTime(new DateTime('19 august 1989'))];
+        $this->assertEquals([
+            'numbers' => [1, 2, '3'],
+            'number' => '4',
+            'nullable' => null,
+            'new_val' => 'new',
+        ], $item->getDirty());
     }
 
     public function testChunkById(): void


### PR DESCRIPTION
Reopening of #1664 

> To check if a field is dirty we can simply use fromPHP() function of the mongodb driver. Besides, we shouldn't use the SQL-specific logic of Illuminate\Eloquent\Model::originalIsEquivalent()  for mongodb. In sql, fields keep their schema data types and changing  integer 1 to string '1' actually does nothing. However, in mongodb  fields accept their types as they are inserted/updated. Therefore, if we  change value of a field from (int)1 to (string)'1' we actually must regard it as dirty. This change is backward incompatible. Don't know if anyone likes the current behaviour more.
--


