### PR TITLE
[3.x] Fix refresh() on EmbedsOne

### DIFF
--- a/src/Jenssegers/Mongodb/Relations/EmbedsOne.php
+++ b/src/Jenssegers/Mongodb/Relations/EmbedsOne.php
@@ -29,6 +29,17 @@ class EmbedsOne extends EmbedsOneOrMany
     }
 
     /**
+     * @inheritdoc
+     */
+    public function getEager()
+    {
+        $eager = $this->get();
+
+        // EmbedsOne only brings one result, Eager needs a collection!
+        return $this->toCollection([$eager]);
+    }
+
+    /**
      * Save a new model and attach it to the parent model.
      * @param Model $model
      * @return Model|bool

--- a/src/Jenssegers/Mongodb/Relations/EmbedsOne.php
+++ b/src/Jenssegers/Mongodb/Relations/EmbedsOne.php
@@ -8,9 +8,7 @@ use MongoDB\BSON\ObjectID;
 
 class EmbedsOne extends EmbedsOneOrMany
 {
-    /**
-     * @inheritdoc
-     */
+
     public function initRelation(array $models, $relation)
     {
         foreach ($models as $model) {
@@ -20,17 +18,11 @@ class EmbedsOne extends EmbedsOneOrMany
         return $models;
     }
 
-    /**
-     * @inheritdoc
-     */
     public function getResults()
     {
         return $this->toModel($this->getEmbedded());
     }
 
-    /**
-     * @inheritdoc
-     */
     public function getEager()
     {
         $eager = $this->get();

--- a/tests/EmbeddedRelationsTest.php
+++ b/tests/EmbeddedRelationsTest.php
@@ -614,6 +614,36 @@ class EmbeddedRelationsTest extends TestCase
         $this->assertNull($user->father);
     }
 
+    public function testEmbedsOneRefresh()
+    {
+        $user = User::create(['name' => 'John Doe']);
+        $father = new User(['name' => 'Mark Doe']);
+
+        $user->father()->associate($father);
+        $user->save();
+
+        $user->refresh();
+
+        $this->assertNotNull($user->father);
+        $this->assertEquals('Mark Doe', $user->father->name);
+    }
+
+    public function testEmbedsOneEmptyRefresh()
+    {
+        $user = User::create(['name' => 'John Doe']);
+        $father = new User(['name' => 'Mark Doe']);
+
+        $user->father()->associate($father);
+        $user->save();
+
+        $user->father()->dissociate();
+        $user->save();
+
+        $user->refresh();
+
+        $this->assertNull($user->father);
+    }
+
     public function testEmbedsManyToArray()
     {
         /** @var User $user */
@@ -623,6 +653,22 @@ class EmbeddedRelationsTest extends TestCase
         $user->addresses()->save(new Address(['city' => 'Brussels']));
 
         $array = $user->toArray();
+        $this->assertArrayHasKey('addresses', $array);
+        $this->assertIsArray($array['addresses']);
+    }
+
+    public function testEmbedsManyRefresh()
+    {
+        /** @var User $user */
+        $user = User::create(['name' => 'John Doe']);
+        $user->addresses()->save(new Address(['city' => 'New York']));
+        $user->addresses()->save(new Address(['city' => 'Paris']));
+        $user->addresses()->save(new Address(['city' => 'Brussels']));
+
+        $user->refresh();
+
+        $array = $user->toArray();
+
         $this->assertArrayHasKey('addresses', $array);
         $this->assertIsArray($array['addresses']);
     }


### PR DESCRIPTION
Fixes #1995 

Model::refresh() throws TypeError exception when using EmbedOne