### PR TITLE
[3.x] fix cast paginate per page to int

### DIFF
--- a/src/Jenssegers/Mongodb/Query/Builder.php
+++ b/src/Jenssegers/Mongodb/Query/Builder.php
@@ -382,7 +382,7 @@ class Builder extends BaseBuilder
                 $options['skip'] = $this->offset;
             }
             if ($this->limit) {
-                $options['limit'] = $this->limit;
+                $options['limit'] = (int) $this->limit;
             }
             if ($this->hint) {
                 $options['hint'] = $this->hint;

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -327,6 +327,20 @@ class QueryTest extends TestCase
         $this->assertEquals(1, $results->currentPage());
     }
 
+    public function testThatPaginateCastsPerPageParameter()
+    {
+        $results = User::paginate('2');
+        $this->assertEquals(2, $results->count());
+        $this->assertNotNull($results->first()->title);
+        $this->assertEquals(9, $results->total());
+
+        $results = User::paginate('2', ['name', 'age']);
+        $this->assertEquals(2, $results->count());
+        $this->assertNull($results->first()->title);
+        $this->assertEquals(9, $results->total());
+        $this->assertEquals(1, $results->currentPage());
+    }
+
     public function testUpdate(): void
     {
         $this->assertEquals(1, User::where(['name' => 'John Doe'])->update(['name' => 'Jim Morrison']));


### PR DESCRIPTION
Cast per_page parameter Collection::paginate to an integer
Added additional test for this case.
Resolves #1750