### PR TITLE
query like on integer fields support

### DIFF
--- a/src/Jenssegers/Mongodb/Query/Builder.php
+++ b/src/Jenssegers/Mongodb/Query/Builder.php
@@ -993,6 +993,7 @@ class Builder extends BaseBuilder
     protected function compileWhereBasic(array $where)
     {
         extract($where);
+        $is_numeric = false;
 
         // Replace like or not like with a Regex instance.
         if (in_array($operator, ['like', 'not like'])) {
@@ -1003,17 +1004,23 @@ class Builder extends BaseBuilder
             }
 
             // Convert to regular expression.
-            $regex = preg_replace('#(^|[^\\\])%#', '$1.*', preg_quote($value));
+            $regex          = preg_replace('#(^|[^\\\])%#', '$1.*', preg_quote($value));
+            $plain_value    = $value;
 
             // Convert like to regular expression.
             if (!Str::startsWith($value, '%')) {
                 $regex = '^' . $regex;
+            } else {
+                $plain_value = Str::replaceFirst('%', null, $plain_value);
             }
             if (!Str::endsWith($value, '%')) {
                 $regex .= '$';
+            } else {
+                $plain_value = Str::replaceLast('%', null, $plain_value);
             }
 
-            $value = new Regex($regex, 'i');
+            $is_numeric = is_numeric($plain_value);
+            $value      = new Regex($regex, 'i');
         } // Manipulate regexp operations.
         elseif (in_array($operator, ['regexp', 'not regexp', 'regex', 'not regex'])) {
             // Automatically convert regular expression strings to Regex objects.
@@ -1032,7 +1039,11 @@ class Builder extends BaseBuilder
         }
 
         if (!isset($operator) || $operator == '=') {
-            $query = [$column => $value];
+            if ($is_numeric) {
+                $query = ['$where' => '/^'.$value->getPattern().'/.test(this.'.$column.')'];
+            } else {
+                $query = [$column => $value];
+            }
         } elseif (array_key_exists($operator, $this->conversion)) {
             $query = [$column => [$this->conversion[$operator] => $value]];
         } else {

--- a/src/Jenssegers/Mongodb/Query/Builder.php
+++ b/src/Jenssegers/Mongodb/Query/Builder.php
@@ -1004,8 +1004,8 @@ class Builder extends BaseBuilder
             }
 
             // Convert to regular expression.
-            $regex          = preg_replace('#(^|[^\\\])%#', '$1.*', preg_quote($value));
-            $plain_value    = $value;
+            $regex = preg_replace('#(^|[^\\\])%#', '$1.*', preg_quote($value));
+            $plain_value = $value;
 
             // Convert like to regular expression.
             if (!Str::startsWith($value, '%')) {
@@ -1020,7 +1020,7 @@ class Builder extends BaseBuilder
             }
 
             $is_numeric = is_numeric($plain_value);
-            $value      = new Regex($regex, 'i');
+            $value = new Regex($regex, 'i');
         } // Manipulate regexp operations.
         elseif (in_array($operator, ['regexp', 'not regexp', 'regex', 'not regex'])) {
             // Automatically convert regular expression strings to Regex objects.

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -69,6 +69,15 @@ class QueryTest extends TestCase
 
         $users = User::where('name', 'like', 't%')->get();
         $this->assertCount(1, $users);
+
+        $users = User::where('age', 'like', '%35%')->get();
+        $this->assertCount(3, $users);
+
+        $users = User::where('age', 'like', '3%')->get();
+        $this->assertCount(6, $users);
+
+        $users = User::where('age', 'like', '%3')->get();
+        $this->assertCount(4, $users);
     }
 
     public function testNotLike(): void


### PR DESCRIPTION
Fix for like query on integer fields which is discussed #2016 issue is ready.