### PR TITLE
Fix issue parsing millisecond-precision dates before 1970.

### DIFF
--- a/src/Jenssegers/Mongodb/Eloquent/Model.php
+++ b/src/Jenssegers/Mongodb/Eloquent/Model.php
@@ -99,7 +99,13 @@ abstract class Model extends BaseModel
     {
         // Convert UTCDateTime instances.
         if ($value instanceof UTCDateTime) {
-            return Date::createFromTimestampMs($value->toDateTime()->format('Uv'));
+            $date = $value->toDateTime();
+
+            $seconds = $date->format('U');
+            $milliseconds = abs($date->format('v'));
+            $timestampMs = sprintf('%d%03d', $seconds, $milliseconds);
+
+            return Date::createFromTimestampMs($timestampMs);
         }
 
         return parent::asDateTime($value);

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -425,6 +425,10 @@ class ModelTest extends TestCase
         $user = User::create(['name' => 'Jane Doe', 'birthday' => '2005-08-08']);
         $this->assertInstanceOf(Carbon::class, $user->birthday);
 
+        // test millisecond-precision dates after 1970:
+        $user = User::create(['name' => 'Jane Doe', 'birthday' => new DateTime('2010-08-08 04.08.37.324')]);
+        $this->assertInstanceOf(Carbon::class, $user->birthday);
+
         $user = User::create(['name' => 'Jane Doe', 'entry' => ['date' => '2005-08-08']]);
         $this->assertInstanceOf(Carbon::class, $user->getAttribute('entry.date'));
 

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -429,6 +429,10 @@ class ModelTest extends TestCase
         $user = User::create(['name' => 'Jane Doe', 'birthday' => new DateTime('2010-08-08 04.08.37.324')]);
         $this->assertInstanceOf(Carbon::class, $user->birthday);
 
+        // test millisecond-precision dates before 1970:
+        $user = User::create(['name' => 'Jane Doe', 'birthday' => new DateTime('1965-08-08 04.08.37.324')]);
+        $this->assertInstanceOf(Carbon::class, $user->birthday);
+
         $user = User::create(['name' => 'Jane Doe', 'entry' => ['date' => '2005-08-08']]);
         $this->assertInstanceOf(Carbon::class, $user->getAttribute('entry.date'));
 


### PR DESCRIPTION
This pull request adds some tests & a fix for an issue I ran into where pre-1970 dates with millisecond-precision could not be properly cast into a `Carbon` instance.

References #2026.