### PR TITLE
BUGFIX: Can not 'call to a member function first() on array' in non-l…

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,12 @@ $capsule->getDatabaseManager()->extend('mongodb', function($config, $name) {
     return new Jenssegers\Mongodb\Connection($config);
 });
 ```
+Add a param `use_collections` in config array.
+```php
+$mongoConfig = [
+    'use_collections' => true,
+];
+```
 
 Testing
 -------

--- a/src/Jenssegers/Mongodb/Query/Builder.php
+++ b/src/Jenssegers/Mongodb/Query/Builder.php
@@ -136,6 +136,9 @@ class Builder extends BaseBuilder
         $this->connection = $connection;
         $this->processor = $processor;
         $this->useCollections = $this->shouldUseCollections();
+        if (!$this->useCollections) {
+            $this->useCollections = (bool)$connection->getConfig('use_collections') ?: false;
+        }
     }
 
     /**

--- a/src/Jenssegers/Mongodb/Query/Builder.php
+++ b/src/Jenssegers/Mongodb/Query/Builder.php
@@ -137,7 +137,7 @@ class Builder extends BaseBuilder
         $this->processor = $processor;
         $this->useCollections = $this->shouldUseCollections();
         if (!$this->useCollections) {
-            $this->useCollections = (bool)$connection->getConfig('use_collections') ?: false;
+            $this->useCollections = (bool) $connection->getConfig('use_collections') ?: false;
         }
     }
 

--- a/src/Jenssegers/Mongodb/Query/Builder.php
+++ b/src/Jenssegers/Mongodb/Query/Builder.php
@@ -136,9 +136,6 @@ class Builder extends BaseBuilder
         $this->connection = $connection;
         $this->processor = $processor;
         $this->useCollections = $this->shouldUseCollections();
-        if (!$this->useCollections) {
-            $this->useCollections = (bool) $connection->getConfig('use_collections') ?: false;
-        }
     }
 
     /**
@@ -152,8 +149,7 @@ class Builder extends BaseBuilder
             $version = filter_var(explode(')', $version)[0], FILTER_SANITIZE_NUMBER_FLOAT, FILTER_FLAG_ALLOW_FRACTION); // lumen
             return version_compare($version, '5.3', '>=');
         }
-
-        return true;
+        return (bool) $this->connection->getConfig('use_collections') ?: false;
     }
 
     /**


### PR DESCRIPTION
 Can not 'call to a member function first() on array' in non-laravel project.


  <b>0</b>: Call to a member function first() on array in <b>E:\new\yzc\storage\vendor\illuminate\database\Concerns\BuildsQueries.php</b> on line <b>77</b>


