### PR TITLE
tests: for sorting

### DIFF
--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -352,4 +352,51 @@ class QueryTest extends TestCase
         $this->assertEquals(2, Scoped::withoutGlobalScopes()->update(['name' => 'Jimmy']));
         $this->assertCount(2, Scoped::withoutGlobalScopes()->where(['name' => 'Jimmy'])->get());
     }
+
+    public function testUnsorted(): void
+    {
+        $unsortedResults = User::get();
+
+        $unsortedSubset = $unsortedResults->where('age', 35)->values();
+
+        $this->assertEquals('John Doe', $unsortedSubset[0]->name);
+        $this->assertEquals('Brett Boe', $unsortedSubset[1]->name);
+        $this->assertEquals('Yvonne Yoe', $unsortedSubset[2]->name);
+    }
+
+    public function testSort(): void
+    {
+        $results = User::orderBy('age')->get();
+
+        $this->assertEquals($results->sortBy('age')->pluck('age')->all(), $results->pluck('age')->all());
+    }
+
+    public function testSortOrder(): void
+    {
+        $results = User::orderBy('age', 'desc')->get();
+
+        $this->assertEquals($results->sortByDesc('age')->pluck('age')->all(), $results->pluck('age')->all());
+    }
+
+    public function testMultipleSort(): void
+    {
+        $results = User::orderBy('age')->orderBy('name')->get();
+
+        $subset = $results->where('age', 35)->values();
+
+        $this->assertEquals('Brett Boe', $subset[0]->name);
+        $this->assertEquals('John Doe', $subset[1]->name);
+        $this->assertEquals('Yvonne Yoe', $subset[2]->name);
+    }
+
+    public function testMultipleSortOrder(): void
+    {
+        $results = User::orderBy('age')->orderBy('name', 'desc')->get();
+
+        $subset = $results->where('age', 35)->values();
+
+        $this->assertEquals('Yvonne Yoe', $subset[0]->name);
+        $this->assertEquals('John Doe', $subset[1]->name);
+        $this->assertEquals('Brett Boe', $subset[2]->name);
+    }
 }


### PR DESCRIPTION
This PR adds tests for sorting results from MongoDB - first a test to ensure that the results are unsorted as expected when no sort is applied, then tests for single and multiple sorts with/without a sort order.

https://github.com/jenssegers/laravel-mongodb/issues/1508 (and the fact that this was added to the v4 project board) seems to suggest that applying multiple sorts isn't supported, but everything seems to be working as expected unless I've totally misunderstood the issue?