### PR TITLE
always call connection logQuery function to broadcast QueryExecuted event

### DIFF
--- a/src/Jenssegers/Mongodb/Collection.php
+++ b/src/Jenssegers/Mongodb/Collection.php
@@ -41,34 +41,32 @@ class Collection
         $start = microtime(true);
         $result = call_user_func_array([$this->collection, $method], $parameters);
 
-        if ($this->connection->logging()) {
-            // Once we have run the query we will calculate the time that it took to run and
-            // then log the query, bindings, and execution time so we will report them on
-            // the event that the developer needs them. We'll log time in milliseconds.
-            $time = $this->connection->getElapsedTime($start);
+        // Once we have run the query we will calculate the time that it took to run and
+        // then log the query, bindings, and execution time so we will report them on
+        // the event that the developer needs them. We'll log time in milliseconds.
+        $time = $this->connection->getElapsedTime($start);
 
-            $query = [];
+        $query = [];
 
-            // Convert the query parameters to a json string.
-            array_walk_recursive($parameters, function (&$item, $key) {
-                if ($item instanceof ObjectID) {
-                    $item = (string) $item;
-                }
-            });
-
-            // Convert the query parameters to a json string.
-            foreach ($parameters as $parameter) {
-                try {
-                    $query[] = json_encode($parameter);
-                } catch (Exception $e) {
-                    $query[] = '{...}';
-                }
+        // Convert the query parameters to a json string.
+        array_walk_recursive($parameters, function (&$item, $key) {
+            if ($item instanceof ObjectID) {
+                $item = (string) $item;
             }
+        });
 
-            $queryString = $this->collection->getCollectionName() . '.' . $method . '(' . implode(',', $query) . ')';
-
-            $this->connection->logQuery($queryString, [], $time);
+        // Convert the query parameters to a json string.
+        foreach ($parameters as $parameter) {
+            try {
+                $query[] = json_encode($parameter);
+            } catch (Exception $e) {
+                $query[] = '{...}';
+            }
         }
+
+        $queryString = $this->collection->getCollectionName() . '.' . $method . '(' . implode(',', $query) . ')';
+
+        $this->connection->logQuery($queryString, [], $time);
 
         return $result;
     }

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -23,7 +23,6 @@ class CollectionTest extends TestCase
         $mongoCollection->expects($this->once())->method('getCollectionName')->willReturn('name-collection');
 
         $connection = $this->getMockBuilder(Connection::class)->disableOriginalConstructor()->getMock();
-        $connection->expects($this->once())->method('logging')->willReturn(true);
         $connection->expects($this->once())->method('getElapsedTime')->willReturn($time);
         $connection->expects($this->once())->method('logQuery')->with($queryString, [], $time);
 


### PR DESCRIPTION
fixes https://github.com/jenssegers/laravel-mongodb/issues/2068

Queries *will only* be added to the in memory connection query log if
the query log is enabled using `DB::connection('mongodb')->enableQueryLog();`