### PR TITLE
[3.x] Fix guarded to return always true

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This package adds functionalities to the Eloquent model and Query builder for Mo
     - [Extending the base model](#extending-the-base-model)
     - [Soft Deletes](#soft-deletes)
     - [Dates](#dates)
+    - [Guarding attributes](#guarding-attributes)
     - [Basic Usage](#basic-usage)
     - [MongoDB-specific operators](#mongodb-specific-operators)
     - [MongoDB-specific Geo operations](#mongodb-specific-geo-operations)
@@ -240,7 +241,7 @@ use Jenssegers\Mongodb\Auth\User as Authenticatable;
 
 class User extends Authenticatable
 {
-    
+
 }
 ```
 
@@ -262,6 +263,13 @@ class User extends Model
 ```
 
 For more information check [Laravel Docs about Soft Deleting](http://laravel.com/docs/eloquent#soft-deleting).
+
+### Guarding attributes
+
+When choosing between guarding attributes or marking some as fillable, Taylor Otwell prefers the fillable route.
+This is in light of [recent security issues described here](https://blog.laravel.com/security-release-laravel-61835-7240).
+
+Keep in mind guarding still works, but you may experience unexpected behavior.
 
 ### Dates
 

--- a/src/Jenssegers/Mongodb/Eloquent/Model.php
+++ b/src/Jenssegers/Mongodb/Eloquent/Model.php
@@ -474,6 +474,17 @@ abstract class Model extends BaseModel
     }
 
     /**
+     * Checks if column exists on a table.  As this is a document model, just return true.  This also
+     * prevents calls to non-existent function Grammar::compileColumnListing()
+     * @param string $key
+     * @return bool
+     */
+    protected function isGuardableColumn($key)
+    {
+        return true;
+    }
+
+    /**
      * @inheritdoc
      */
     public function __call($method, $parameters)

--- a/src/Jenssegers/Mongodb/Schema/Builder.php
+++ b/src/Jenssegers/Mongodb/Schema/Builder.php
@@ -10,14 +10,6 @@ class Builder extends \Illuminate\Database\Schema\Builder
     /**
      * @inheritdoc
      */
-    public function __construct(Connection $connection)
-    {
-        $this->connection = $connection;
-    }
-
-    /**
-     * @inheritdoc
-     */
     public function hasColumn($table, $column)
     {
         return true;

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -722,4 +722,11 @@ class ModelTest extends TestCase
 
         $this->assertEquals(0, User::count());
     }
+
+    public function testGuardedModel()
+    {
+        Guarded::create(['var' => 'val']);
+
+        $this->assertEquals(1, Guarded::count());
+    }
 }

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -726,8 +726,24 @@ class ModelTest extends TestCase
 
     public function testGuardedModel()
     {
-        Guarded::create(['var' => 'val']);
+        $model = new Guarded();
 
-        $this->assertEquals(1, Guarded::count());
+        // foobar is properly guarded
+        $model->fill(['foobar' => 'ignored', 'name' => 'John Doe']);
+        $this->assertFalse(isset($model->foobar));
+        $this->assertSame('John Doe', $model->name);
+
+        // foobar is guarded to any level
+        $model->fill(['foobar->level2' => 'v2']);
+        $this->assertNull($model->getAttribute('foobar->level2'));
+
+        // multi level statement also guarded
+        $model->fill(['level1->level2' => 'v1']);
+        $this->assertNull($model->getAttribute('level1->level2'));
+
+        // level1 is still writable
+        $dataValues = ['array', 'of', 'values'];
+        $model->fill(['level1' => $dataValues]);
+        $this->assertEquals($dataValues, $model->getAttribute('level1'));
     }
 }

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -19,6 +19,7 @@ class ModelTest extends TestCase
         Soft::truncate();
         Book::truncate();
         Item::truncate();
+        Guarded::truncate();
     }
 
     public function testNewModel(): void

--- a/tests/models/Guarded.php
+++ b/tests/models/Guarded.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+use Jenssegers\Mongodb\Eloquent\Model as Eloquent;
+
+class Guarded extends Eloquent
+{
+    protected $connection = 'mongodb';
+    protected $collection = 'guarded';
+    protected $guarded = ['foobar'];
+}

--- a/tests/models/Guarded.php
+++ b/tests/models/Guarded.php
@@ -7,5 +7,5 @@ class Guarded extends Eloquent
 {
     protected $connection = 'mongodb';
     protected $collection = 'guarded';
-    protected $guarded = ['foobar'];
+    protected $guarded = ['foobar', 'level1->level2'];
 }


### PR DESCRIPTION
An update to Laravel has caused a breakdown when using guarded models.  See this for more info:

https://blog.laravel.com/security-release-laravel-61834-7232
https://github.com/laravel/framework/pull/33777

One error this caused is: `Call to a member function compileColumnListing() on null`

This is because `\Illuminate\Database\Schema\Builder::__construct()` now creates a grammar object, and our overloaded constructor does not.  I've removed our constructor to fall back to the parent's, as we aren't doing anything special in ours.

The next error is `BadMethodCallException : Method Jenssegers\Mongodb\Schema\Grammar::compileColumnListing does not exist`

This is because the new default behavior on guarded models is to query the schema for a column listing to ensure you are guarding actual fields.  Because we are a document model, I have overloaded `Model::isGuardableColumn()` to return true.  This aides in preventing all manner of checks and complications that don't really apply to Mongo models.

fixes #2078 