### PR TITLE
Fix styleci risky error

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,1 +1,2 @@
+risky: true
 preset: laravel


### PR DESCRIPTION
The risky 'empty_return' fixer cannot be enabled because risky mode is not enabled.

See https://github.styleci.io/analyses/WNGwke