### PR TITLE
[3.8] Laravel 8 support

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        php: ['7.2', '7.3', '7.4']
+        php: ['7.3', '7.4']
         os: ['ubuntu-latest']
         mongodb: ['3.6', '4.0', '4.2', '4.4']
     services:

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -14,9 +14,9 @@ jobs:
     strategy:
       matrix:
         include:
-        - { os: ubuntu-latest, php: 7.2, mongodb: 3.6, experimental: true}	
-        - { os: ubuntu-latest, php: 7.2, mongodb: '4.0', experimental: true}	
-        - { os: ubuntu-latest, php: 7.2, mongodb: 4.2, experimental: true}	
+        - { os: ubuntu-latest, php: 7.2, mongodb: 3.6, experimental: true}
+        - { os: ubuntu-latest, php: 7.2, mongodb: '4.0', experimental: true}
+        - { os: ubuntu-latest, php: 7.2, mongodb: 4.2, experimental: true}
         - { os: ubuntu-latest, php: 7.2, mongodb: 4.4, experimental: true}
         - { os: ubuntu-latest, php: 7.3, mongodb: 3.6, experimental: false}
         - { os: ubuntu-latest, php: 7.3, mongodb: '4.0', experimental: false}
@@ -56,18 +56,22 @@ jobs:
       env:
         DEBUG: ${{secrets.DEBUG}}
     - name: Download Composer cache dependencies from cache
+      if: (!startsWith(matrix.php, '7.2'))
       id: composer-cache
       run: echo "::set-output name=dir::$(composer config cache-files-dir)"
     - name: Cache Composer dependencies
+      if: (!startsWith(matrix.php, '7.2'))
       uses: actions/cache@v1
       with:
         path: ${{ steps.composer-cache.outputs.dir }}
         key: ${{ matrix.os }}-composer-${{ hashFiles('**/composer.json') }}
         restore-keys: ${{ matrix.os }}-composer-
     - name: Install dependencies
+      if: (!startsWith(matrix.php, '7.2'))
       run: |
         composer install --no-interaction
     - name: Run tests
+      if: (!startsWith(matrix.php, '7.2'))
       run: |
         ./vendor/bin/phpunit --coverage-clover coverage.xml
       env:

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -14,6 +14,10 @@ jobs:
     strategy:
       matrix:
         include:
+        - { os: ubuntu-latest, php: 7.2, mongodb: 3.6, experimental: true}	
+        - { os: ubuntu-latest, php: 7.2, mongodb: '4.0', experimental: true}	
+        - { os: ubuntu-latest, php: 7.2, mongodb: 4.2, experimental: true}	
+        - { os: ubuntu-latest, php: 7.2, mongodb: 4.4, experimental: true}
         - { os: ubuntu-latest, php: 7.3, mongodb: 3.6, experimental: false}
         - { os: ubuntu-latest, php: 7.3, mongodb: '4.0', experimental: false}
         - { os: ubuntu-latest, php: 7.3, mongodb: 4.2, experimental: false}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Laravel 8 support by [@divine](https://github.com/divine).
+
+### Changed
+- Updated versions of all dependencies by [@divine](https://github.com/divine).
+
 ## [3.7.0] - 2020-09-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Make sure you have the MongoDB PHP driver installed. You can find installation i
  5.8.x    | 3.5.x
  6.x      | 3.6.x
  7.x      | 3.7.x
+ 8.x      | 3.8.x
 
 Install the package via Composer:
 

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "mongodb/mongodb": "^1.6"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.4|^9.0",
+        "phpunit/phpunit": "^9.0",
         "orchestra/testbench": "^6.0",
         "mockery/mockery": "^1.3.1",
         "doctrine/dbal": "^2.6"

--- a/composer.json
+++ b/composer.json
@@ -19,15 +19,15 @@
     ],
     "license": "MIT",
     "require": {
-        "illuminate/support": "^7.0",
-        "illuminate/container": "^7.0",
-        "illuminate/database": "^7.0",
-        "illuminate/events": "^7.0",
+        "illuminate/support": "^8.0",
+        "illuminate/container": "^8.0",
+        "illuminate/database": "^8.0",
+        "illuminate/events": "^8.0",
         "mongodb/mongodb": "^1.6"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.4|^9.0",
-        "orchestra/testbench": "^5.0",
+        "orchestra/testbench": "^6.0",
         "mockery/mockery": "^1.3.1",
         "doctrine/dbal": "^2.6"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         bootstrap="vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false" bootstrap="vendor/autoload.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+    </coverage>
     <testsuites>
         <testsuite name="all">
             <directory>tests/</directory>
@@ -37,11 +34,6 @@
             <file>tests/ValidationTest.php</file>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
     <php>
         <env name="MONGO_HOST" value="mongodb"/>
         <env name="MONGO_DATABASE" value="unittest"/>

--- a/src/Jenssegers/Mongodb/Relations/MorphTo.php
+++ b/src/Jenssegers/Mongodb/Relations/MorphTo.php
@@ -31,7 +31,7 @@ class MorphTo extends EloquentMorphTo
 
         $query = $instance->newQuery();
 
-        return $query->whereIn($key, $this->gatherKeysByType($type))->get();
+        return $query->whereIn($key, $this->gatherKeysByType($type, $instance->getKeyType()))->get();
     }
 
     /**

--- a/tests/QueueTest.php
+++ b/tests/QueueTest.php
@@ -37,7 +37,7 @@ class QueueTest extends TestCase
             'job' => 'test',
             'maxTries' => null,
             'maxExceptions' => null,
-            'delay' => null,
+            'backoff' => null,
             'timeout' => null,
             'data' => ['action' => 'QueueJobLifeCycle'],
         ]), $job->getRawBody());


### PR DESCRIPTION
- Bump dependencies
- Update test
- Remove PHP 7.2 from github ci
- Remove phpunit ^8.4
- Migrate phpunit configuration (`"Your XML configuration validates against a deprecated schema."`)

For all changes please check https://laravel.com/docs/8.x/upgrade

____

- [x] Queue The **retryAfter** method [hasn't changed](https://github.com/laravel/framework/blob/8.x/src/Illuminate/Queue/DatabaseQueue.php#L41)
- [x] Queue **timeoutAt** property isn't used directly within this library
```php
use Illuminate\Queue\Jobs\DatabaseJob;
class MongoJob extends DatabaseJob
```

- [x] Queue the **allOnQueue()** / **allOnConnection()** methods isn't used directly within this library
