### PR TITLE
[3.6] Remove Facade in Queue Service Provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [3.6.7] - 2020-12-17
+## [3.6.7] - 2020-12-18
 
 ### Changed
 - MongodbQueueServiceProvider does not use the DB Facade anymore [#2149](https://github.com/jenssegers/laravel-mongodb/pull/2149) by [@curosmj](https://github.com/curosmj)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [3.6.7] - 2020-12-17
+
+### Changed
+- MongodbQueueServiceProvider does not use the DB Facade anymore [#2149](https://github.com/jenssegers/laravel-mongodb/pull/2149) by [@curosmj](https://github.com/curosmj)
+
 ## [3.6.6] - 2020-10-29
 
 ### Changed

--- a/src/Jenssegers/Mongodb/MongodbQueueServiceProvider.php
+++ b/src/Jenssegers/Mongodb/MongodbQueueServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace Jenssegers\Mongodb;
 
-use Illuminate\Support\Facades\DB;
 use Illuminate\Queue\QueueServiceProvider;
 use Jenssegers\Mongodb\Queue\Failed\MongoFailedJobProvider;
 
@@ -14,7 +13,7 @@ class MongodbQueueServiceProvider extends QueueServiceProvider
     protected function registerFailedJobServices()
     {
         // Add compatible queue failer if mongodb is configured.
-        if (DB::connection(config('queue.failed.database'))->getDriverName() == 'mongodb') {
+        if ($this->app['db']->connection(config('queue.failed.database'))->getDriverName() == 'mongodb') {
             $this->app->singleton('queue.failer', function ($app) {
                 return new MongoFailedJobProvider($app['db'], config('queue.failed.database'), config('queue.failed.table'));
             });


### PR DESCRIPTION
I use this package in an environment where Facades are turned off and I don't want to turn them on. 

This PR removes the Facade use and replaces with plain old 'db' accessor on the $app