### PR TITLE
[3.6] Backport of #1992 to 3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - MongodbQueueServiceProvider does not use the DB Facade anymore [#2149](https://github.com/jenssegers/laravel-mongodb/pull/2149) by [@curosmj](https://github.com/curosmj)
+- Add escape regex chars to DB Presence Verifier [#1992](https://github.com/jenssegers/laravel-mongodb/pull/1992) by [@andrei-gafton-rtgt](https://github.com/andrei-gafton-rtgt).
+
 
 ## [3.6.6] - 2020-10-29
 

--- a/src/Jenssegers/Mongodb/Validation/DatabasePresenceVerifier.php
+++ b/src/Jenssegers/Mongodb/Validation/DatabasePresenceVerifier.php
@@ -16,7 +16,7 @@ class DatabasePresenceVerifier extends \Illuminate\Validation\DatabasePresenceVe
      */
     public function getCount($collection, $column, $value, $excludeId = null, $idColumn = null, array $extra = [])
     {
-        $query = $this->table($collection)->where($column, 'regex', "/$value/i");
+        $query = $this->table($collection)->where($column, 'regex', "/" . preg_quote($value) . "/i");
 
         if ($excludeId !== null && $excludeId != 'NULL') {
             $query->where($idColumn ?: 'id', '<>', $excludeId);

--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -41,6 +41,26 @@ class ValidationTest extends TestCase
             ['name' => 'required|unique:users']
         );
         $this->assertFalse($validator->fails());
+
+        User::create(['name' => 'Johnny Cash', 'email' => 'johnny.cash+200@gmail.com']);
+
+        $validator = Validator::make(
+            ['email' => 'johnny.cash+200@gmail.com'],
+            ['email' => 'required|unique:users']
+        );
+        $this->assertTrue($validator->fails());
+
+        $validator = Validator::make(
+            ['email' => 'johnny.cash+20@gmail.com'],
+            ['email' => 'required|unique:users']
+        );
+        $this->assertFalse($validator->fails());
+
+        $validator = Validator::make(
+            ['email' => 'johnny.cash+1@gmail.com'],
+            ['email' => 'required|unique:users']
+        );
+        $this->assertFalse($validator->fails());
     }
 
     public function testExists(): void

--- a/tests/models/User.php
+++ b/tests/models/User.php
@@ -13,6 +13,7 @@ use Jenssegers\Mongodb\Eloquent\Model as Eloquent;
  * Class User
  * @property string $_id
  * @property string $name
+ * @property string $email
  * @property string $title
  * @property int $age
  * @property \Carbon\Carbon $birthday


### PR DESCRIPTION
Add escape regex chars to DB Presence Verifier [#1992](https://github.com/jenssegers/laravel-mongodb/pull/1992) by [@andrei-gafton-rtgt](https://github.com/andrei-gafton-rtgt).