### PR TITLE
cast foreign key to string in BelongsTo class

### DIFF
--- a/src/Jenssegers/Mongodb/Relations/BelongsTo.php
+++ b/src/Jenssegers/Mongodb/Relations/BelongsTo.php
@@ -3,6 +3,7 @@
 namespace Jenssegers\Mongodb\Relations;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model as EloquentModel;
 
 class BelongsTo extends \Illuminate\Database\Eloquent\Relations\BelongsTo
@@ -68,5 +69,33 @@ class BelongsTo extends \Illuminate\Database\Eloquent\Relations\BelongsTo
     protected function whereInMethod(EloquentModel $model, $key)
     {
         return 'whereIn';
+    }
+
+    public function match(array $models, Collection $results, $relation)
+    {
+        $foreign = $this->foreignKey;
+
+        $owner = $this->ownerKey;
+
+        // First we will get to build a dictionary of the child models by their primary
+        // key of the relationship, then we can easily match the children back onto
+        // the parents using that dictionary and the primary key of the children.
+        $dictionary = [];
+
+        foreach ($results as $result) {
+            $dictionary[$result->getAttribute($owner)] = $result;
+        }
+
+        // Once we have the dictionary constructed, we can loop through all the parents
+        // and match back onto their children using these keys of the dictionary and
+        // the primary key of the children to map them onto the correct instances.
+        foreach ($models as $model) {
+            $_id = (string) $model->{$foreign};
+            if (isset($dictionary[$_id])) {
+                $model->setRelation($relation, $dictionary[$_id]);
+            }
+        }
+
+        return $models;
     }
 }


### PR DESCRIPTION
cast foreign key to string in BelongsTo class to fix the bug `Illegal offset type in isset or empty` when the foreign key and other Key are instance of ObjectId class