### PR TITLE
Add doesntExist to passthru

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Sync passthru methods [#2194](https://github.com/jenssegers/laravel-mongodb/pull/2194) by [@simonschaufi](https://github.com/simonschaufi)
+
 ## [3.8.3] - 2021-02-21
 
 ### Changed

--- a/src/Jenssegers/Mongodb/Eloquent/Builder.php
+++ b/src/Jenssegers/Mongodb/Eloquent/Builder.php
@@ -16,18 +16,28 @@ class Builder extends EloquentBuilder
      * @var array
      */
     protected $passthru = [
-        'toSql',
+        'average',
+        'avg',
+        'count',
+        'dd',
+        'doesntExist',
+        'dump',
+        'exists',
+        'getBindings',
+        'getConnection',
+        'getGrammar',
         'insert',
         'insertGetId',
-        'pluck',
-        'count',
-        'min',
+        'insertOrIgnore',
+        'insertUsing',
         'max',
-        'avg',
-        'sum',
-        'exists',
-        'push',
+        'min',
+        'pluck',
         'pull',
+        'push',
+        'raw',
+        'sum',
+        'toSql'
     ];
 
     /**


### PR DESCRIPTION
Those calls should return the same result but instead the call to "doesntExist" returns an object.

```php
!$user->groups()->exists();
$user->groups()->doesntExist();
```

closes #1765 