### PR TITLE
add a check to see if the model is MySQL or Mongo collection

### DIFF
--- a/src/Jenssegers/Mongodb/Relations/BelongsToMany.php
+++ b/src/Jenssegers/Mongodb/Relations/BelongsToMany.php
@@ -224,8 +224,9 @@ class BelongsToMany extends EloquentBelongsToMany
         $ids = (array) $ids;
 
         // Detach all ids from the parent model.
-        $this->parent->pull($this->getRelatedKey(), $ids);
-
+        if ($this->parent instanceof MongodbEloquentModel){
+            $this->parent->pull($this->getRelatedKey(), $ids);
+        }
         // Prepare the query to select all related objects.
         if (count($ids) > 0) {
             $query->whereIn($this->related->getKeyName(), $ids);


### PR DESCRIPTION
right now when implementing the relationship Many-to-Many with MySql, all is working but when trying to detach from the MySQL model an error
BadMethodCallException with message 'Call to undefined method App\Models\User::pull()'
is showing because that MySQL model is not a collection and can't use pull on it

so I added a check to see if the model is a mongo collection or not and then will call the pull method
similar issues: #2002