### PR TITLE
Check dates against `DateTimeInterface` instead of `DateTime`

### DIFF
--- a/src/Jenssegers/Mongodb/Eloquent/Model.php
+++ b/src/Jenssegers/Mongodb/Eloquent/Model.php
@@ -2,7 +2,7 @@
 
 namespace Jenssegers\Mongodb\Eloquent;
 
-use DateTime;
+use DateTimeInterface;
 use Illuminate\Contracts\Queue\QueueableCollection;
 use Illuminate\Contracts\Queue\QueueableEntity;
 use Illuminate\Database\Eloquent\Model as BaseModel;
@@ -85,7 +85,7 @@ abstract class Model extends BaseModel
         }
 
         // Let Eloquent convert the value to a DateTime instance.
-        if (!$value instanceof DateTime) {
+        if (!$value instanceof DateTimeInterface) {
             $value = parent::asDateTime($value);
         }
 

--- a/src/Jenssegers/Mongodb/Query/Builder.php
+++ b/src/Jenssegers/Mongodb/Query/Builder.php
@@ -3,7 +3,7 @@
 namespace Jenssegers\Mongodb\Query;
 
 use Closure;
-use DateTime;
+use DateTimeInterface;
 use Illuminate\Database\Query\Builder as BaseBuilder;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Support\Arr;
@@ -929,18 +929,18 @@ class Builder extends BaseBuilder
             if (isset($where['value'])) {
                 if (is_array($where['value'])) {
                     array_walk_recursive($where['value'], function (&$item, $key) {
-                        if ($item instanceof DateTime) {
+                        if ($item instanceof DateTimeInterface) {
                             $item = new UTCDateTime($item->format('Uv'));
                         }
                     });
                 } else {
-                    if ($where['value'] instanceof DateTime) {
+                    if ($where['value'] instanceof DateTimeInterface) {
                         $where['value'] = new UTCDateTime($where['value']->format('Uv'));
                     }
                 }
             } elseif (isset($where['values'])) {
                 array_walk_recursive($where['values'], function (&$item, $key) {
-                    if ($item instanceof DateTime) {
+                    if ($item instanceof DateTimeInterface) {
                         $item = new UTCDateTime($item->format('Uv'));
                     }
                 });

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -497,6 +497,9 @@ class ModelTest extends TestCase
         $user->setAttribute('birthday', new DateTime('1965-08-08 04.08.37.324'));
         $this->assertInstanceOf(Carbon::class, $user->birthday);
 
+        $user->setAttribute('birthday', new DateTimeImmutable('1965-08-08 04.08.37.324'));
+        $this->assertInstanceOf(Carbon::class, $user->birthday);
+
         //Test with create and array property
         $user = User::create(['name' => 'Jane Doe', 'entry' => ['date' => time()]]);
         $this->assertInstanceOf(Carbon::class, $user->getAttribute('entry.date'));

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -574,6 +574,33 @@ class QueryBuilderTest extends TestCase
         $this->assertCount(2, $users);
     }
 
+    public function testImmutableDates()
+    {
+        DB::collection('users')->insert([
+            ['name' => 'John Doe', 'birthday' => new UTCDateTime(Date::parse("1980-01-01 00:00:00")->format('Uv'))],
+            ['name' => 'Robert Roe', 'birthday' => new UTCDateTime(Date::parse("1982-01-01 00:00:00")->format('Uv'))],
+        ]);
+
+        $users = DB::collection('users')->where('birthday', '=', new DateTimeImmutable("1980-01-01 00:00:00"))->get();
+        $this->assertCount(1, $users);
+
+        $users = DB::collection('users')->where('birthday', new DateTimeImmutable("1980-01-01 00:00:00"))->get();
+        $this->assertCount(1, $users);
+
+        $users = DB::collection('users')->whereIn('birthday', [
+            new DateTimeImmutable("1980-01-01 00:00:00"),
+            new DateTimeImmutable("1982-01-01 00:00:00")
+        ])->get();
+        $this->assertCount(2, $users);
+
+        $users = DB::collection('users')->whereBetween('birthday', [
+            new DateTimeImmutable("1979-01-01 00:00:00"),
+            new DateTimeImmutable("1983-01-01 00:00:00")
+        ])->get();
+
+        $this->assertCount(2, $users);
+    }
+
     public function testOperators()
     {
         DB::collection('users')->insert([


### PR DESCRIPTION
Greeting! 👋 

I noticed that `where()` queries in which I used `DateTimeImmutable` objects returned empty results.

This change would allow the usage of `DateTimeImmutable` or `CarbonImmutable` in addition to `DateTime`/`Carbon` 🤞 

:octocat: 