### PR TITLE
Ignore local PHPUnit overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ composer.lock
 *.project
 .idea/
 .phpunit.result.cache
+phpunit.xml


### PR DESCRIPTION
It's me again 👋

while working on #2239, I copied the `phpunit.xml.dist` to `phpunit.xml` so that I could use my locally installed MongoDB instance with different connection parameters.

Since the repo already has the `phpunit.xml.dist`, I'd like to suggest ignoring `phpunit.xml` so that local overrides can be applied without risking to commit them to the repo by accident 🤞.

Long story short: see PR title 😂

:octocat: