### PR TITLE
Add Model query whereDate support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,10 @@ This package adds functionalities to the Eloquent model and Query builder for Mo
   - [Configuration](#configuration)
   - [Eloquent](#eloquent)
     - [Extending the base model](#extending-the-base-model)
+    - [Extending the Authenticable base model](#extending-the-authenticable-base-model)
     - [Soft Deletes](#soft-deletes)
-    - [Dates](#dates)
     - [Guarding attributes](#guarding-attributes)
+    - [Dates](#dates)
     - [Basic Usage](#basic-usage)
     - [MongoDB-specific operators](#mongodb-specific-operators)
     - [MongoDB-specific Geo operations](#mongodb-specific-geo-operations)
@@ -44,9 +45,10 @@ This package adds functionalities to the Eloquent model and Query builder for Mo
     - [Authentication](#authentication)
     - [Queues](#queues)
       - [Laravel specific](#laravel-specific)
-      - [Lumen specific](#Lumen-specific)
+      - [Lumen specific](#lumen-specific)
   - [Upgrading](#upgrading)
       - [Upgrading from version 2 to 3](#upgrading-from-version-2-to-3)
+  - [Security contact information](#security-contact-information)
 
 Installation
 ------------
@@ -355,6 +357,14 @@ $posts = Post::whereBetween('votes', [1, 100])->get();
 ```php
 $users = User::whereNull('age')->get();
 ```
+
+**whereDate**
+
+```php
+$users = User::whereDate('birthday', '2021-5-12')->get();
+```
+The usage is the same as `whereMonth` / `whereDay` / `whereYear` / `whereTime`
+
 
 **Advanced wheres**
 

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -1137,6 +1137,76 @@ class Builder extends BaseBuilder
 
     /**
      * @param array $where
+     * @return array
+     */
+    protected function compileWhereDate(array $where)
+    {
+        extract($where);
+
+        $where['operator'] = $operator;
+        $where['value'] = $value;
+
+        return $this->compileWhereBasic($where);
+    }
+
+    /**
+     * @param array $where
+     * @return array
+     */
+    protected function compileWhereMonth(array $where)
+    {
+        extract($where);
+
+        $where['operator'] = $operator;
+        $where['value'] = $value;
+
+        return $this->compileWhereBasic($where);
+    }
+
+    /**
+     * @param array $where
+     * @return array
+     */
+    protected function compileWhereDay(array $where)
+    {
+        extract($where);
+
+        $where['operator'] = $operator;
+        $where['value'] = $value;
+
+        return $this->compileWhereBasic($where);
+    }
+
+    /**
+     * @param array $where
+     * @return array
+     */
+    protected function compileWhereYear(array $where)
+    {
+        extract($where);
+
+        $where['operator'] = $operator;
+        $where['value'] = $value;
+
+        return $this->compileWhereBasic($where);
+    }
+
+    /**
+     * @param array $where
+     * @return array
+     */
+    protected function compileWhereTime(array $where)
+    {
+        extract($where);
+
+        $where['operator'] = $operator;
+        $where['value'] = $value;
+
+        return $this->compileWhereBasic($where);
+    }
+
+    /**
+     * @param array $where
      * @return mixed
      */
     protected function compileWhereRaw(array $where)

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -18,12 +18,19 @@ class QueryTest extends TestCase
         User::create(['name' => 'Tommy Toe', 'age' => 33, 'title' => 'user']);
         User::create(['name' => 'Yvonne Yoe', 'age' => 35, 'title' => 'admin']);
         User::create(['name' => 'Error', 'age' => null, 'title' => null]);
+        Birthday::create(['name' => 'Mark Moe', 'birthday' => '2020-04-10', 'day' => '10', 'month' => '04', "year" => '2020', 'time' => '10:53:11']);
+        Birthday::create(['name' => 'Jane Doe', 'birthday' => '2021-05-12', 'day' => '12', 'month' => '05', "year" => '2021', 'time' => '10:53:12']);
+        Birthday::create(['name' => 'Harry Hoe', 'birthday' => '2021-05-11', 'day' => '11', 'month' => '05', "year" => '2021', 'time' => '10:53:13']);
+        Birthday::create(['name' => 'Robert Doe', 'birthday' => '2021-05-12', 'day' => '12', 'month' => '05', "year" => '2021', 'time' => '10:53:14']);
+        Birthday::create(['name' => 'Mark Moe', 'birthday' => '2021-05-12', 'day' => '12', 'month' => '05', "year" => '2021', 'time' => '10:53:15']);
+        Birthday::create(['name' => 'Mark Moe', 'birthday' => '2022-05-12', 'day' => '12', 'month' => '05', "year" => '2022', 'time' => '10:53:16']);
     }
 
     public function tearDown(): void
     {
         User::truncate();
         Scoped::truncate();
+        Birthday::truncate();
         parent::tearDown();
     }
 
@@ -161,6 +168,54 @@ class QueryTest extends TestCase
     {
         $users = User::whereNotNull('age')->get();
         $this->assertCount(8, $users);
+    }
+
+    public function testWhereDate(): void
+    {
+        $birthdayCount = Birthday::whereDate('birthday', '2021-05-12')->get();
+        $this->assertCount(3, $birthdayCount);
+
+        $birthdayCount = Birthday::whereDate('birthday', '2021-05-11')->get();
+        $this->assertCount(1, $birthdayCount);
+    }
+
+    public function testWhereDay(): void
+    {
+        $day = Birthday::whereDay('day', '12')->get();
+        $this->assertCount(4, $day);
+
+        $day = Birthday::whereDay('day', '11')->get();
+        $this->assertCount(1, $day);
+    }
+
+    public function testWhereMonth(): void
+    {
+        $month = Birthday::whereMonth('month', '04')->get();
+        $this->assertCount(1, $month);
+
+        $month = Birthday::whereMonth('month', '05')->get();
+        $this->assertCount(5, $month);
+    }
+
+    public function testWhereYear(): void
+    {
+        $year = Birthday::whereYear('year', '2021')->get();
+        $this->assertCount(4, $year);
+
+        $year = Birthday::whereYear('year', '2022')->get();
+        $this->assertCount(1, $year);
+
+        $year = Birthday::whereYear('year', '<', '2021')->get();
+        $this->assertCount(1, $year);
+    }
+
+    public function testWhereTime(): void
+    {
+        $time = Birthday::whereTime('time', '10:53:11')->get();
+        $this->assertCount(1, $time);
+
+        $time = Birthday::whereTime('time', '>=', '10:53:14')->get();
+        $this->assertCount(3, $time);
     }
 
     public function testOrder(): void

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -18,12 +18,12 @@ class QueryTest extends TestCase
         User::create(['name' => 'Tommy Toe', 'age' => 33, 'title' => 'user']);
         User::create(['name' => 'Yvonne Yoe', 'age' => 35, 'title' => 'admin']);
         User::create(['name' => 'Error', 'age' => null, 'title' => null]);
-        Birthday::create(['name' => 'Mark Moe', 'birthday' => '2020-04-10', 'day' => '10', 'month' => '04', "year" => '2020', 'time' => '10:53:11']);
-        Birthday::create(['name' => 'Jane Doe', 'birthday' => '2021-05-12', 'day' => '12', 'month' => '05', "year" => '2021', 'time' => '10:53:12']);
-        Birthday::create(['name' => 'Harry Hoe', 'birthday' => '2021-05-11', 'day' => '11', 'month' => '05', "year" => '2021', 'time' => '10:53:13']);
-        Birthday::create(['name' => 'Robert Doe', 'birthday' => '2021-05-12', 'day' => '12', 'month' => '05', "year" => '2021', 'time' => '10:53:14']);
-        Birthday::create(['name' => 'Mark Moe', 'birthday' => '2021-05-12', 'day' => '12', 'month' => '05', "year" => '2021', 'time' => '10:53:15']);
-        Birthday::create(['name' => 'Mark Moe', 'birthday' => '2022-05-12', 'day' => '12', 'month' => '05', "year" => '2022', 'time' => '10:53:16']);
+        Birthday::create(['name' => 'Mark Moe', 'birthday' => '2020-04-10', 'day' => '10', 'month' => '04', 'year' => '2020', 'time' => '10:53:11']);
+        Birthday::create(['name' => 'Jane Doe', 'birthday' => '2021-05-12', 'day' => '12', 'month' => '05', 'year' => '2021', 'time' => '10:53:12']);
+        Birthday::create(['name' => 'Harry Hoe', 'birthday' => '2021-05-11', 'day' => '11', 'month' => '05', 'year' => '2021', 'time' => '10:53:13']);
+        Birthday::create(['name' => 'Robert Doe', 'birthday' => '2021-05-12', 'day' => '12', 'month' => '05', 'year' => '2021', 'time' => '10:53:14']);
+        Birthday::create(['name' => 'Mark Moe', 'birthday' => '2021-05-12', 'day' => '12', 'month' => '05', 'year' => '2021', 'time' => '10:53:15']);
+        Birthday::create(['name' => 'Mark Moe', 'birthday' => '2022-05-12', 'day' => '12', 'month' => '05', 'year' => '2022', 'time' => '10:53:16']);
     }
 
     public function tearDown(): void

--- a/tests/models/Birthday.php
+++ b/tests/models/Birthday.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+use Jenssegers\Mongodb\Eloquent\Model as Eloquent;
+
+/**
+ * Class Birthday.
+ * @property string $name
+ * @property string $birthday
+ * @property string $day
+ * @property string $month
+ * @property string $year
+ * @property string $time
+ */
+class Birthday extends Eloquent
+{
+    protected $connection = 'mongodb';
+    protected $collection = 'birthday';
+    protected $fillable = ['name', 'birthday', 'day', 'month', 'year', 'time'];
+}


### PR DESCRIPTION
**issue**: Not supprt `whereDate` query.
![image](https://user-images.githubusercontent.com/19749521/117798069-4b606300-b283-11eb-8fa5-9fd5cbc8a2d4.png)

**solutions**:
According to the document:  
- Laravel doc: [queries#additional-where-clauses](https://laravel.com/docs/8.x/queries#additional-where-clauses)
- Dcat admin doc: [dcat-admin/2.x/query-filtering/8097#5fc732](https://learnku.com/docs/dcat-admin/2.x/query-filtering/8097#5fc732)

So I hope to add `whereXXX`, in order to compatible with laravel and facilitate `dcat admin` to use mongodb.