### PR TITLE
:sparkles: updated mongodb to 1.9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,10 +19,10 @@
     ],
     "license": "MIT",
     "require": {
-        "illuminate/support": "^8.0",
-        "illuminate/container": "^8.0",
-        "illuminate/database": "^8.0",
-        "illuminate/events": "^8.0",
+        "illuminate/support": "^8.52",
+        "illuminate/container": "^8.52",
+        "illuminate/database": "^8.52",
+        "illuminate/events": "^8.52",
         "mongodb/mongodb": "^1.9"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "illuminate/container": "^8.0",
         "illuminate/database": "^8.0",
         "illuminate/events": "^8.0",
-        "mongodb/mongodb": "^1.6"
+        "mongodb/mongodb": "^1.9"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",


### PR DESCRIPTION
Hello,

This PR allows laravel-mongodb to use PHP 8

Resolves #2308