### PR TITLE
fix: morphTo when relation name is in camel case

### DIFF
--- a/src/Eloquent/HybridRelations.php
+++ b/src/Eloquent/HybridRelations.php
@@ -174,10 +174,10 @@ trait HybridRelations
         if ($name === null) {
             [$current, $caller] = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2);
 
-            $name = Str::snake($caller['function']);
+            $name = $caller['function'];
         }
 
-        [$type, $id] = $this->getMorphs($name, $type, $id);
+        [$type, $id] = $this->getMorphs(Str::snake($name), $type, $id);
 
         // If the type value is null it is probably safe to assume we're eager loading
         // the relationship. When that is the case we will pass in a dummy query as

--- a/src/Eloquent/HybridRelations.php
+++ b/src/Eloquent/HybridRelations.php
@@ -16,9 +16,10 @@ trait HybridRelations
 {
     /**
      * Define a one-to-one relationship.
-     * @param string $related
-     * @param string $foreignKey
-     * @param string $localKey
+     *
+     * @param  string  $related
+     * @param  string  $foreignKey
+     * @param  string  $localKey
      * @return \Illuminate\Database\Eloquent\Relations\HasOne
      */
     public function hasOne($related, $foreignKey = null, $localKey = null)
@@ -39,11 +40,12 @@ trait HybridRelations
 
     /**
      * Define a polymorphic one-to-one relationship.
-     * @param string $related
-     * @param string $name
-     * @param string $type
-     * @param string $id
-     * @param string $localKey
+     *
+     * @param  string  $related
+     * @param  string  $name
+     * @param  string  $type
+     * @param  string  $id
+     * @param  string  $localKey
      * @return \Illuminate\Database\Eloquent\Relations\MorphOne
      */
     public function morphOne($related, $name, $type = null, $id = null, $localKey = null)
@@ -64,9 +66,10 @@ trait HybridRelations
 
     /**
      * Define a one-to-many relationship.
-     * @param string $related
-     * @param string $foreignKey
-     * @param string $localKey
+     *
+     * @param  string  $related
+     * @param  string  $foreignKey
+     * @param  string  $localKey
      * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
     public function hasMany($related, $foreignKey = null, $localKey = null)
@@ -87,11 +90,12 @@ trait HybridRelations
 
     /**
      * Define a polymorphic one-to-many relationship.
-     * @param string $related
-     * @param string $name
-     * @param string $type
-     * @param string $id
-     * @param string $localKey
+     *
+     * @param  string  $related
+     * @param  string  $name
+     * @param  string  $type
+     * @param  string  $id
+     * @param  string  $localKey
      * @return \Illuminate\Database\Eloquent\Relations\MorphMany
      */
     public function morphMany($related, $name, $type = null, $id = null, $localKey = null)
@@ -117,10 +121,11 @@ trait HybridRelations
 
     /**
      * Define an inverse one-to-one or many relationship.
-     * @param string $related
-     * @param string $foreignKey
-     * @param string $otherKey
-     * @param string $relation
+     *
+     * @param  string  $related
+     * @param  string  $foreignKey
+     * @param  string  $otherKey
+     * @param  string  $relation
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
     public function belongsTo($related, $foreignKey = null, $otherKey = null, $relation = null)
@@ -160,10 +165,11 @@ trait HybridRelations
 
     /**
      * Define a polymorphic, inverse one-to-one or many relationship.
-     * @param string $name
-     * @param string $type
-     * @param string $id
-     * @param string $ownerKey
+     *
+     * @param  string  $name
+     * @param  string  $type
+     * @param  string  $id
+     * @param  string  $ownerKey
      * @return \Illuminate\Database\Eloquent\Relations\MorphTo
      */
     public function morphTo($name = null, $type = null, $id = null, $ownerKey = null)
@@ -204,13 +210,14 @@ trait HybridRelations
 
     /**
      * Define a many-to-many relationship.
-     * @param string $related
-     * @param string $collection
-     * @param string $foreignKey
-     * @param string $otherKey
-     * @param string $parentKey
-     * @param string $relatedKey
-     * @param string $relation
+     *
+     * @param  string  $related
+     * @param  string  $collection
+     * @param  string  $foreignKey
+     * @param  string  $otherKey
+     * @param  string  $parentKey
+     * @param  string  $relatedKey
+     * @param  string  $relation
      * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
      */
     public function belongsToMany(
@@ -277,6 +284,7 @@ trait HybridRelations
 
     /**
      * Get the relationship name of the belongs to many.
+     *
      * @return string
      */
     protected function guessBelongsToManyRelation()

--- a/tests/RelationsTest.php
+++ b/tests/RelationsTest.php
@@ -370,21 +370,21 @@ class RelationsTest extends TestCase
         $this->assertEquals($photo->id, $client->photo->id);
 
         $photo = Photo::first();
-        $this->assertEquals($photo->imageable->name, $user->name);
+        $this->assertEquals($photo->hasImage->name, $user->name);
 
         $user = User::with('photos')->find($user->_id);
         $relations = $user->getRelations();
         $this->assertArrayHasKey('photos', $relations);
         $this->assertEquals(1, $relations['photos']->count());
 
-        $photos = Photo::with('imageable')->get();
+        $photos = Photo::with('hasImage')->get();
         $relations = $photos[0]->getRelations();
-        $this->assertArrayHasKey('imageable', $relations);
-        $this->assertInstanceOf(User::class, $photos[0]->imageable);
+        $this->assertArrayHasKey('hasImage', $relations);
+        $this->assertInstanceOf(User::class, $photos[0]->hasImage);
 
         $relations = $photos[1]->getRelations();
-        $this->assertArrayHasKey('imageable', $relations);
-        $this->assertInstanceOf(Client::class, $photos[1]->imageable);
+        $this->assertArrayHasKey('hasImage', $relations);
+        $this->assertInstanceOf(Client::class, $photos[1]->hasImage);
     }
 
     public function testHasManyHas(): void

--- a/tests/models/Client.php
+++ b/tests/models/Client.php
@@ -20,7 +20,7 @@ class Client extends Eloquent
 
     public function photo(): MorphOne
     {
-        return $this->morphOne('Photo', 'imageable');
+        return $this->morphOne('Photo', 'has_image');
     }
 
     public function addresses(): HasMany

--- a/tests/models/Photo.php
+++ b/tests/models/Photo.php
@@ -11,7 +11,7 @@ class Photo extends Eloquent
     protected $collection = 'photos';
     protected static $unguarded = true;
 
-    public function imageable(): MorphTo
+    public function hasImage(): MorphTo
     {
         return $this->morphTo();
     }

--- a/tests/models/User.php
+++ b/tests/models/User.php
@@ -12,6 +12,7 @@ use Jenssegers\Mongodb\Eloquent\Model as Eloquent;
 
 /**
  * Class User.
+ *
  * @property string $_id
  * @property string $name
  * @property string $email

--- a/tests/models/User.php
+++ b/tests/models/User.php
@@ -66,7 +66,7 @@ class User extends Eloquent implements AuthenticatableContract, CanResetPassword
 
     public function photos()
     {
-        return $this->morphMany('Photo', 'imageable');
+        return $this->morphMany('Photo', 'has_image');
     }
 
     public function addresses()


### PR DESCRIPTION
Commit e19e10a in this PR updates existing tests to use a 'multi-word' relation for the morph relationship. This means that:
- `imageable` is changed to `has_image` when passed as the `$name` parameter to `morphOne()` and `morphMany()`
Note that snake case is required here - the parent Eloquent [`getMorphs()`](https://github.com/laravel/framework/blob/74ad9ece6ce88dd947452cc77284087cf354916a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php#L717) method constructs the expected column names by appending '_id' and '_type' to the name that's passed.
- `imageable` is changed to `hasImage` when accessed as the relation name

That commit causes `RelationsTest::testMorph()` to fail, then commit c02e584 fixes the issue in line with how Eloquent's `morphTo()` method works, where `$name` variable defaults to the name of the calling function and is only snake-cased when passed to `getMorphs()` ([reference](https://github.com/laravel/framework/blob/74ad9ece6ce88dd947452cc77284087cf354916a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php#L246))