### PR TITLE
[3.8] Add support for cursor pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [Unreleased
+
+### Added
+- Support for cursor pagination [#2358](https://github.com/jenssegers/laravel-mongodb/pull/2358) by [@Jeroenwv](https://github.com/Jeroenwv).
 
 ## [3.8.4] - 2021-05-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## [Unreleased
+## [Unreleased]
 
 ### Added
 - Support for cursor pagination [#2358](https://github.com/jenssegers/laravel-mongodb/pull/2358) by [@Jeroenwv](https://github.com/Jeroenwv).

--- a/src/Eloquent/Builder.php
+++ b/src/Eloquent/Builder.php
@@ -216,4 +216,35 @@ class Builder extends EloquentBuilder
     {
         return $this->query->getConnection();
     }
+
+    /**
+     * @inheritdoc
+     */
+    protected function ensureOrderForCursorPagination($shouldReverse = false)
+    {
+        if (empty($this->query->orders)) {
+            $this->enforceOrderBy();
+        }
+
+        if ($shouldReverse) {
+            $this->query->orders = collect($this->query->orders)->map(function ($direction) {
+                return $direction === 1 ? -1 : 1;
+            })->toArray();
+        }
+
+        return $this->mapMongodbOrdersToEloquentOrders($this->query->orders);
+    }
+
+    private function mapMongodbOrdersToEloquentOrders($orders) {
+        $eloquentOrders = [];
+
+        foreach($orders as $column => $direction) {
+            $eloquentOrders[] = [
+                'column' => $column,
+                'direction' => $direction === 1 ? 'asc' : 'desc',
+            ];
+        }
+
+        return collect($eloquentOrders);
+    }
 }

--- a/src/Eloquent/Builder.php
+++ b/src/Eloquent/Builder.php
@@ -193,7 +193,7 @@ class Builder extends EloquentBuilder
      * wiil be reverted
      * Issue in laravel frawework https://github.com/laravel/framework/issues/27791.
      *
-     * @param array $values
+     * @param  array  $values
      * @return array
      */
     protected function addUpdatedAtColumn(array $values)

--- a/src/Eloquent/Builder.php
+++ b/src/Eloquent/Builder.php
@@ -13,6 +13,7 @@ class Builder extends EloquentBuilder
 
     /**
      * The methods that should be returned from query builder.
+     *
      * @var array
      */
     protected $passthru = [
@@ -191,6 +192,7 @@ class Builder extends EloquentBuilder
      * TODO Remove if https://github.com/laravel/framework/commit/6484744326531829341e1ff886cc9b628b20d73e
      * wiil be reverted
      * Issue in laravel frawework https://github.com/laravel/framework/issues/27791.
+     *
      * @param array $values
      * @return array
      */
@@ -235,10 +237,11 @@ class Builder extends EloquentBuilder
         return $this->mapMongodbOrdersToEloquentOrders($this->query->orders);
     }
 
-    private function mapMongodbOrdersToEloquentOrders($orders) {
+    private function mapMongodbOrdersToEloquentOrders($orders)
+    {
         $eloquentOrders = [];
 
-        foreach($orders as $column => $direction) {
+        foreach ($orders as $column => $direction) {
             $eloquentOrders[] = [
                 'column' => $column,
                 'direction' => $direction === 1 ? 'asc' : 'desc',

--- a/src/Eloquent/Builder.php
+++ b/src/Eloquent/Builder.php
@@ -234,20 +234,11 @@ class Builder extends EloquentBuilder
             })->toArray();
         }
 
-        return $this->mapMongodbOrdersToEloquentOrders($this->query->orders);
-    }
-
-    private function mapMongodbOrdersToEloquentOrders($orders)
-    {
-        $eloquentOrders = [];
-
-        foreach ($orders as $column => $direction) {
-            $eloquentOrders[] = [
+        return collect($this->query->orders)->map(function ($direction, $column) {
+            return [
                 'column' => $column,
                 'direction' => $direction === 1 ? 'asc' : 'desc',
             ];
-        }
-
-        return collect($eloquentOrders);
+        })->values();
     }
 }

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -383,6 +383,29 @@ class QueryTest extends TestCase
         $this->assertEquals(1, $results->currentPage());
     }
 
+    public function testCursorPaginate(): void
+    {
+        $results = User::cursorPaginate(2);
+        $this->assertEquals(2, $results->count());
+        $this->assertNotNull($results->first()->title);
+        $this->assertNotNull($results->nextCursor());
+        $this->assertTrue($results->onFirstPage());
+
+        $results = User::cursorPaginate(2, ['name', 'age']);
+        $this->assertEquals(2, $results->count());
+        $this->assertNull($results->first()->title);
+
+        $results = User::orderBy('age', 'desc')->cursorPaginate(2, ['name', 'age']);
+        $this->assertEquals(2, $results->count());
+        $this->assertEquals(37, $results->first()->age);
+        $this->assertNull($results->first()->title);
+
+        $results = User::whereNotNull('age')->orderBy('age', 'asc')->cursorPaginate(2, ['name', 'age']);
+        $this->assertEquals(2, $results->count());
+        $this->assertEquals(13, $results->first()->age);
+        $this->assertNull($results->first()->title);
+    }
+
     public function testUpdate(): void
     {
         $this->assertEquals(1, User::where(['name' => 'John Doe'])->update(['name' => 'Jim Morrison']));


### PR DESCRIPTION
This commit adds support for Laravel cursor pagination.

This is done by solving a difference in how Eloquent order configuration is set on the Builder class between this package and Laravel itself. For this the ensureOrderForCursorPagination method is overwritten.

Fixes #2312