### PR TITLE
Fix Query on whereDate, whereDay, whereMonth, whereYear

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -1166,13 +1166,15 @@ class Builder extends BaseBuilder
 
         $date = Carbon::parse($value);
 
-        $operator = $operator === '=' ? '$eq' : $this->conversion[$operator];
+        $operator = $this->conversion[$operator];
+        $operatorDay = $operator === '=' ? '$eq' : $operator;
+        $operatorMonthYear = $operator === '=' ? '$eq' : (in_array($operator, ['$gt', '$lt']) ? $operator . 'e' : $operator);
 
         return [
             '$expr' => [
                 '$and' => [
                     [
-                        $operator => [
+                        $operatorDay => [
                             [
                                 '$dayOfMonth' => '$'.$column
                             ],
@@ -1180,7 +1182,7 @@ class Builder extends BaseBuilder
                         ],
                     ],
                     [
-                        $operator => [
+                        $operatorMonthYear => [
                             [
                                 '$month' => '$'.$column
                             ],
@@ -1188,9 +1190,9 @@ class Builder extends BaseBuilder
                         ],
                     ],
                     [
-                        $operator => [
+                        $operatorMonthYear => [
                             [
-                                '$month' => '$'.$column
+                                '$year' => '$'.$column
                             ],
                             $date->year
                         ],

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -141,7 +141,7 @@ class Builder extends BaseBuilder
     /**
      * Set the projections.
      *
-     * @param array $columns
+     * @param  array  $columns
      * @return $this
      */
     public function project($columns)
@@ -153,7 +153,7 @@ class Builder extends BaseBuilder
 
     /**
      * Set the cursor timeout in seconds.
-     * @param int $seconds
+     * @param  int  $seconds
      * @return $this
      */
     public function timeout($seconds)
@@ -166,7 +166,7 @@ class Builder extends BaseBuilder
     /**
      * Set the cursor hint.
      *
-     * @param mixed $index
+     * @param  mixed  $index
      * @return $this
      */
     public function hint($index)
@@ -217,8 +217,8 @@ class Builder extends BaseBuilder
     /**
      * Execute the query as a fresh "select" statement.
      *
-     * @param array $columns
-     * @param bool $returnLazy
+     * @param  array  $columns
+     * @param  bool  $returnLazy
      * @return array|static[]|Collection|LazyCollection
      */
     public function getFresh($columns = [], $returnLazy = false)
@@ -522,10 +522,10 @@ class Builder extends BaseBuilder
     /**
      * Add a "where all" clause to the query.
      *
-     * @param string $column
-     * @param array $values
-     * @param string $boolean
-     * @param bool $not
+     * @param  string  $column
+     * @param  array  $values
+     * @param  string  $boolean
+     * @param  bool  $not
      * @return $this
      */
     public function whereAll($column, array $values, $boolean = 'and', $not = false)
@@ -729,8 +729,8 @@ class Builder extends BaseBuilder
     /**
      * Get an array with the values of a given column.
      *
-     * @param string $column
-     * @param string $key
+     * @param  string  $column
+     * @param  string  $key
      * @return array
      * @deprecated
      */
@@ -761,9 +761,9 @@ class Builder extends BaseBuilder
     /**
      * Append one or more values to an array.
      *
-     * @param mixed $column
-     * @param mixed $value
-     * @param bool $unique
+     * @param  mixed  $column
+     * @param  mixed  $value
+     * @param  bool  $unique
      * @return int
      */
     public function push($column, $value = null, $unique = false)
@@ -788,8 +788,8 @@ class Builder extends BaseBuilder
     /**
      * Remove one or more values from an array.
      *
-     * @param mixed $column
-     * @param mixed $value
+     * @param  mixed  $column
+     * @param  mixed  $value
      * @return int
      */
     public function pull($column, $value = null)
@@ -812,7 +812,7 @@ class Builder extends BaseBuilder
     /**
      * Remove one or more fields.
      *
-     * @param mixed $columns
+     * @param  mixed  $columns
      * @return int
      */
     public function drop($columns)
@@ -843,8 +843,8 @@ class Builder extends BaseBuilder
     /**
      * Perform an update query.
      *
-     * @param array $query
-     * @param array $options
+     * @param  array  $query
+     * @param  array  $options
      * @return int
      */
     protected function performUpdate($query, array $options = [])
@@ -866,7 +866,7 @@ class Builder extends BaseBuilder
     /**
      * Convert a key to ObjectID if needed.
      *
-     * @param mixed $id
+     * @param  mixed  $id
      * @return mixed
      */
     public function convertKey($id)
@@ -1000,7 +1000,7 @@ class Builder extends BaseBuilder
     }
 
     /**
-     * @param array $where
+     * @param  array  $where
      * @return array
      */
     protected function compileWhereAll(array $where)
@@ -1011,7 +1011,7 @@ class Builder extends BaseBuilder
     }
 
     /**
-     * @param array $where
+     * @param  array  $where
      * @return array
      */
     protected function compileWhereBasic(array $where)
@@ -1067,7 +1067,7 @@ class Builder extends BaseBuilder
     }
 
     /**
-     * @param array $where
+     * @param  array  $where
      * @return mixed
      */
     protected function compileWhereNested(array $where)
@@ -1078,7 +1078,7 @@ class Builder extends BaseBuilder
     }
 
     /**
-     * @param array $where
+     * @param  array  $where
      * @return array
      */
     protected function compileWhereIn(array $where)
@@ -1089,7 +1089,7 @@ class Builder extends BaseBuilder
     }
 
     /**
-     * @param array $where
+     * @param  array  $where
      * @return array
      */
     protected function compileWhereNotIn(array $where)
@@ -1100,7 +1100,7 @@ class Builder extends BaseBuilder
     }
 
     /**
-     * @param array $where
+     * @param  array  $where
      * @return array
      */
     protected function compileWhereNull(array $where)
@@ -1112,7 +1112,7 @@ class Builder extends BaseBuilder
     }
 
     /**
-     * @param array $where
+     * @param  array  $where
      * @return array
      */
     protected function compileWhereNotNull(array $where)
@@ -1124,7 +1124,7 @@ class Builder extends BaseBuilder
     }
 
     /**
-     * @param array $where
+     * @param  array  $where
      * @return array
      */
     protected function compileWhereBetween(array $where)
@@ -1157,7 +1157,7 @@ class Builder extends BaseBuilder
     }
 
     /**
-     * @param array $where
+     * @param  array  $where
      * @return array
      */
     protected function compileWhereDate(array $where)
@@ -1169,7 +1169,7 @@ class Builder extends BaseBuilder
 
         $operator = $this->conversion[$operator];
 
-        return match($operator) {
+        return match ($operator) {
             '=' => [
                 $column => [
                     '$gte' => $startOfDay,
@@ -1206,7 +1206,7 @@ class Builder extends BaseBuilder
     }
 
     /**
-     * @param array $where
+     * @param  array  $where
      * @return array
      */
     protected function compileWhereMonth(array $where)
@@ -1220,7 +1220,7 @@ class Builder extends BaseBuilder
             '$expr' => [
                 $operator => [
                     [
-                        '$month' => '$'.$column
+                        '$month' => '$'.$column,
                     ],
                     $value,
                 ],
@@ -1229,7 +1229,7 @@ class Builder extends BaseBuilder
     }
 
     /**
-     * @param array $where
+     * @param  array  $where
      * @return array
      */
     protected function compileWhereDay(array $where)
@@ -1243,7 +1243,7 @@ class Builder extends BaseBuilder
             '$expr' => [
                 $operator => [
                     [
-                        '$dayOfMonth' => '$'.$column
+                        '$dayOfMonth' => '$'.$column,
                     ],
                     $value,
                 ],
@@ -1252,7 +1252,7 @@ class Builder extends BaseBuilder
     }
 
     /**
-     * @param array $where
+     * @param  array $where
      * @return array
      */
     protected function compileWhereYear(array $where)
@@ -1265,16 +1265,16 @@ class Builder extends BaseBuilder
             '$expr' => [
                 $operator => [
                     [
-                        '$year' => '$'.$column
+                        '$year' => '$'.$column,
                     ],
-                    $value
+                    $value,
                 ],
             ],
         ];
     }
 
     /**
-     * @param array $where
+     * @param  array  $where
      * @return array
      */
     protected function compileWhereTime(array $where)
@@ -1288,7 +1288,7 @@ class Builder extends BaseBuilder
     }
 
     /**
-     * @param array $where
+     * @param  array  $where
      * @return mixed
      */
     protected function compileWhereRaw(array $where)
@@ -1299,7 +1299,7 @@ class Builder extends BaseBuilder
     /**
      * Set custom options for the query.
      *
-     * @param array $options
+     * @param  array  $options
      * @return $this
      */
     public function options(array $options)

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -141,7 +141,7 @@ class Builder extends BaseBuilder
     /**
      * Set the projections.
      *
-     * @param  array  $columns
+     * @param array $columns
      * @return $this
      */
     public function project($columns)
@@ -153,8 +153,7 @@ class Builder extends BaseBuilder
 
     /**
      * Set the cursor timeout in seconds.
-     *
-     * @param  int  $seconds
+     * @param int $seconds
      * @return $this
      */
     public function timeout($seconds)
@@ -167,7 +166,7 @@ class Builder extends BaseBuilder
     /**
      * Set the cursor hint.
      *
-     * @param  mixed  $index
+     * @param mixed $index
      * @return $this
      */
     public function hint($index)
@@ -218,8 +217,8 @@ class Builder extends BaseBuilder
     /**
      * Execute the query as a fresh "select" statement.
      *
-     * @param  array  $columns
-     * @param  bool  $returnLazy
+     * @param array $columns
+     * @param bool $returnLazy
      * @return array|static[]|Collection|LazyCollection
      */
     public function getFresh($columns = [], $returnLazy = false)
@@ -523,10 +522,10 @@ class Builder extends BaseBuilder
     /**
      * Add a "where all" clause to the query.
      *
-     * @param  string  $column
-     * @param  array  $values
-     * @param  string  $boolean
-     * @param  bool  $not
+     * @param string $column
+     * @param array $values
+     * @param string $boolean
+     * @param bool $not
      * @return $this
      */
     public function whereAll($column, array $values, $boolean = 'and', $not = false)
@@ -730,8 +729,8 @@ class Builder extends BaseBuilder
     /**
      * Get an array with the values of a given column.
      *
-     * @param  string  $column
-     * @param  string  $key
+     * @param string $column
+     * @param string $key
      * @return array
      *
      * @deprecated
@@ -763,9 +762,9 @@ class Builder extends BaseBuilder
     /**
      * Append one or more values to an array.
      *
-     * @param  mixed  $column
-     * @param  mixed  $value
-     * @param  bool  $unique
+     * @param mixed $column
+     * @param mixed $value
+     * @param bool $unique
      * @return int
      */
     public function push($column, $value = null, $unique = false)
@@ -790,8 +789,8 @@ class Builder extends BaseBuilder
     /**
      * Remove one or more values from an array.
      *
-     * @param  mixed  $column
-     * @param  mixed  $value
+     * @param mixed $column
+     * @param mixed $value
      * @return int
      */
     public function pull($column, $value = null)
@@ -814,7 +813,7 @@ class Builder extends BaseBuilder
     /**
      * Remove one or more fields.
      *
-     * @param  mixed  $columns
+     * @param mixed $columns
      * @return int
      */
     public function drop($columns)
@@ -845,8 +844,8 @@ class Builder extends BaseBuilder
     /**
      * Perform an update query.
      *
-     * @param  array  $query
-     * @param  array  $options
+     * @param array $query
+     * @param array $options
      * @return int
      */
     protected function performUpdate($query, array $options = [])
@@ -868,7 +867,7 @@ class Builder extends BaseBuilder
     /**
      * Convert a key to ObjectID if needed.
      *
-     * @param  mixed  $id
+     * @param mixed $id
      * @return mixed
      */
     public function convertKey($id)
@@ -1002,7 +1001,7 @@ class Builder extends BaseBuilder
     }
 
     /**
-     * @param  array  $where
+     * @param array $where
      * @return array
      */
     protected function compileWhereAll(array $where)
@@ -1013,7 +1012,7 @@ class Builder extends BaseBuilder
     }
 
     /**
-     * @param  array  $where
+     * @param array $where
      * @return array
      */
     protected function compileWhereBasic(array $where)
@@ -1069,7 +1068,7 @@ class Builder extends BaseBuilder
     }
 
     /**
-     * @param  array  $where
+     * @param array $where
      * @return mixed
      */
     protected function compileWhereNested(array $where)
@@ -1080,7 +1079,7 @@ class Builder extends BaseBuilder
     }
 
     /**
-     * @param  array  $where
+     * @param array $where
      * @return array
      */
     protected function compileWhereIn(array $where)
@@ -1091,7 +1090,7 @@ class Builder extends BaseBuilder
     }
 
     /**
-     * @param  array  $where
+     * @param array $where
      * @return array
      */
     protected function compileWhereNotIn(array $where)
@@ -1102,7 +1101,7 @@ class Builder extends BaseBuilder
     }
 
     /**
-     * @param  array  $where
+     * @param array $where
      * @return array
      */
     protected function compileWhereNull(array $where)
@@ -1114,7 +1113,7 @@ class Builder extends BaseBuilder
     }
 
     /**
-     * @param  array  $where
+     * @param array $where
      * @return array
      */
     protected function compileWhereNotNull(array $where)
@@ -1126,7 +1125,7 @@ class Builder extends BaseBuilder
     }
 
     /**
-     * @param  array  $where
+     * @param array $where
      * @return array
      */
     protected function compileWhereBetween(array $where)
@@ -1159,7 +1158,7 @@ class Builder extends BaseBuilder
     }
 
     /**
-     * @param  array  $where
+     * @param array $where
      * @return array
      */
     protected function compileWhereDate(array $where)
@@ -1171,7 +1170,7 @@ class Builder extends BaseBuilder
 
         $operator = $this->conversion[$operator];
 
-        return match ($operator) {
+        return match($operator) {
             '=' => [
                 $column => [
                     '$gte' => $startOfDay,
@@ -1208,7 +1207,7 @@ class Builder extends BaseBuilder
     }
 
     /**
-     * @param  array  $where
+     * @param array $where
      * @return array
      */
     protected function compileWhereMonth(array $where)
@@ -1222,7 +1221,7 @@ class Builder extends BaseBuilder
             '$expr' => [
                 $operator => [
                     [
-                        '$month' => '$'.$column,
+                        '$month' => '$'.$column
                     ],
                     $value,
                 ],
@@ -1231,7 +1230,7 @@ class Builder extends BaseBuilder
     }
 
     /**
-     * @param  array  $where
+     * @param array $where
      * @return array
      */
     protected function compileWhereDay(array $where)
@@ -1245,7 +1244,7 @@ class Builder extends BaseBuilder
             '$expr' => [
                 $operator => [
                     [
-                        '$dayOfMonth' => '$'.$column,
+                        '$dayOfMonth' => '$'.$column
                     ],
                     $value,
                 ],
@@ -1254,7 +1253,7 @@ class Builder extends BaseBuilder
     }
 
     /**
-     * @param  array  $where
+     * @param array $where
      * @return array
      */
     protected function compileWhereYear(array $where)
@@ -1267,16 +1266,16 @@ class Builder extends BaseBuilder
             '$expr' => [
                 $operator => [
                     [
-                        '$year' => '$'.$column,
+                        '$year' => '$'.$column
                     ],
-                    $value,
+                    $value
                 ],
             ],
         ];
     }
 
     /**
-     * @param  array  $where
+     * @param array $where
      * @return array
      */
     protected function compileWhereTime(array $where)
@@ -1290,7 +1289,7 @@ class Builder extends BaseBuilder
     }
 
     /**
-     * @param  array  $where
+     * @param array $where
      * @return mixed
      */
     protected function compileWhereRaw(array $where)
@@ -1301,7 +1300,7 @@ class Builder extends BaseBuilder
     /**
      * Set custom options for the query.
      *
-     * @param  array  $options
+     * @param array $options
      * @return $this
      */
     public function options(array $options)

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -1231,6 +1231,7 @@ class Builder extends BaseBuilder
         extract($where);
 
         $operator = $operator === '=' ? '$eq' : $this->conversion[$operator];
+        $value = str_starts_with($value, '0') ? intval(str_replace('0', '', $value)) : $value;
 
         return [
             '$expr' => [
@@ -1253,6 +1254,7 @@ class Builder extends BaseBuilder
         extract($where);
         
         $operator = $operator === '=' ? '$eq' : $this->conversion[$operator];
+        $value = str_starts_with($value, '0') ? intval(str_replace('0', '', $value)) : $value;
 
         return [
             '$expr' => [

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -153,7 +153,7 @@ class Builder extends BaseBuilder
 
     /**
      * Set the cursor timeout in seconds.
-     * 
+     *
      * @param  int  $seconds
      * @return $this
      */
@@ -733,7 +733,7 @@ class Builder extends BaseBuilder
      * @param  string  $column
      * @param  string  $key
      * @return array
-     * 
+     *
      * @deprecated
      */
     public function lists($column, $key = null)
@@ -1260,7 +1260,7 @@ class Builder extends BaseBuilder
     protected function compileWhereYear(array $where)
     {
         extract($where);
-        
+
         $operator = $operator === '=' ? '$eq' : $this->conversion[$operator];
 
         return [

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -1281,40 +1281,10 @@ class Builder extends BaseBuilder
     {
         extract($where);
 
-        $operator = $operator === '=' ? '$eq' : $this->conversion[$operator];
+        $where['operator'] = $operator;
+        $where['value'] = $value;
 
-        $time = Carbon::parse($value);
-
-        return [
-            '$expr' => [
-                '$and' => [
-                    [
-                        $operator => [
-                            [
-                                '$hour' => '$'.$column
-                            ],
-                            $time->hour
-                        ],
-                    ],
-                    [
-                        $operator => [
-                            [
-                                '$minute' => '$'.$column
-                            ],
-                            $time->minute
-                        ],
-                    ],
-                    [
-                        $operator => [
-                            [
-                                '$second' => '$'.$column
-                            ],
-                            $time->second
-                        ],
-                    ],
-                ],
-            ],
-        ];
+        return $this->compileWhereBasic($where);
     }
 
     /**

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -153,6 +153,7 @@ class Builder extends BaseBuilder
 
     /**
      * Set the cursor timeout in seconds.
+     * 
      * @param  int  $seconds
      * @return $this
      */
@@ -732,6 +733,7 @@ class Builder extends BaseBuilder
      * @param  string  $column
      * @param  string  $key
      * @return array
+     * 
      * @deprecated
      */
     public function lists($column, $key = null)
@@ -1252,7 +1254,7 @@ class Builder extends BaseBuilder
     }
 
     /**
-     * @param  array $where
+     * @param  array  $where
      * @return array
      */
     protected function compileWhereYear(array $where)

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -1209,6 +1209,7 @@ class Builder extends BaseBuilder
         extract($where);
 
         $operator = $operator === '=' ? '$eq' : $this->conversion[$operator];
+        $value = str_starts_with($value, '0') ? intval(str_replace('0', '', $value)) : $value;
 
         return [
             '$expr' => [
@@ -1254,7 +1255,6 @@ class Builder extends BaseBuilder
         extract($where);
         
         $operator = $operator === '=' ? '$eq' : $this->conversion[$operator];
-        $value = str_starts_with($value, '0') ? intval(str_replace('0', '', $value)) : $value;
 
         return [
             '$expr' => [

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -7,6 +7,7 @@ use DateTimeInterface;
 use Illuminate\Database\Query\Builder as BaseBuilder;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\LazyCollection;
 use Illuminate\Support\Str;
@@ -1163,10 +1164,40 @@ class Builder extends BaseBuilder
     {
         extract($where);
 
-        $where['operator'] = $operator;
-        $where['value'] = $value;
+        $date = Carbon::parse($value);
 
-        return $this->compileWhereBasic($where);
+        $operator = $operator === '=' ? '$eq' : $this->conversion[$operator];
+
+        return [
+            '$expr' => [
+                '$and' => [
+                    [
+                        $operator => [
+                            [
+                                '$dayOfMonth' => '$'.$column
+                            ],
+                            $date->day
+                        ],
+                    ],
+                    [
+                        $operator => [
+                            [
+                                '$month' => '$'.$column
+                            ],
+                            $date->month
+                        ],
+                    ],
+                    [
+                        $operator => [
+                            [
+                                '$month' => '$'.$column
+                            ],
+                            $date->year
+                        ],
+                    ],
+                ],
+            ],
+        ];
     }
 
     /**
@@ -1177,10 +1208,18 @@ class Builder extends BaseBuilder
     {
         extract($where);
 
-        $where['operator'] = $operator;
-        $where['value'] = $value;
+        $operator = $operator === '=' ? '$eq' : $this->conversion[$operator];
 
-        return $this->compileWhereBasic($where);
+        return [
+            '$expr' => [
+                $operator => [
+                    [
+                        '$month' => '$'.$column
+                    ],
+                    $value,
+                ],
+            ],
+        ];
     }
 
     /**
@@ -1191,10 +1230,18 @@ class Builder extends BaseBuilder
     {
         extract($where);
 
-        $where['operator'] = $operator;
-        $where['value'] = $value;
+        $operator = $operator === '=' ? '$eq' : $this->conversion[$operator];
 
-        return $this->compileWhereBasic($where);
+        return [
+            '$expr' => [
+                $operator => [
+                    [
+                        '$dayOfMonth' => '$'.$column
+                    ],
+                    $value,
+                ],
+            ],
+        ];
     }
 
     /**
@@ -1204,11 +1251,19 @@ class Builder extends BaseBuilder
     protected function compileWhereYear(array $where)
     {
         extract($where);
+        
+        $operator = $operator === '=' ? '$eq' : $this->conversion[$operator];
 
-        $where['operator'] = $operator;
-        $where['value'] = $value;
-
-        return $this->compileWhereBasic($where);
+        return [
+            '$expr' => [
+                $operator => [
+                    [
+                        '$year' => '$'.$column
+                    ],
+                    $value
+                ],
+            ],
+        ];
     }
 
     /**
@@ -1219,10 +1274,40 @@ class Builder extends BaseBuilder
     {
         extract($where);
 
-        $where['operator'] = $operator;
-        $where['value'] = $value;
+        $operator = $operator === '=' ? '$eq' : $this->conversion[$operator];
 
-        return $this->compileWhereBasic($where);
+        $time = Carbon::parse($value);
+
+        return [
+            '$expr' => [
+                '$and' => [
+                    [
+                        $operator => [
+                            [
+                                '$hour' => '$'.$column
+                            ],
+                            $time->hour
+                        ],
+                    ],
+                    [
+                        $operator => [
+                            [
+                                '$minute' => '$'.$column
+                            ],
+                            $time->minute
+                        ],
+                    ],
+                    [
+                        $operator => [
+                            [
+                                '$second' => '$'.$column
+                            ],
+                            $time->second
+                        ],
+                    ],
+                ],
+            ],
+        ];
     }
 
     /**

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -20,12 +20,12 @@ class QueryTest extends TestCase
         User::create(['name' => 'Tommy Toe', 'age' => 33, 'title' => 'user']);
         User::create(['name' => 'Yvonne Yoe', 'age' => 35, 'title' => 'admin']);
         User::create(['name' => 'Error', 'age' => null, 'title' => null]);
-        Birthday::create(['name' => 'Mark Moe', 'birthday' => Carbon::parse('2020-04-10 10:53:11')->toDateTimeString());
-        Birthday::create(['name' => 'Jane Doe', 'birthday' => Carbon::parse('2021-05-12 10:53:12')->toDateTimeString());
-        Birthday::create(['name' => 'Harry Hoe', 'birthday' => Carbon::parse('2021-05-11 10:53:13')->toDateTimeString());
-        Birthday::create(['name' => 'Robert Doe', 'birthday' => Carbon::parse('2021-05-12 10:53:14')->toDateTimeString());
-        Birthday::create(['name' => 'Mark Moe', 'birthday' => Carbon::parse('2021-05-12 10:53:15')->toDateTimeString());
-        Birthday::create(['name' => 'Mark Moe', 'birthday' => Carbon::parse('2021-05-12 10:53:16')->toDateTimeString());
+        Birthday::create(['name' => 'Mark Moe', 'birthday' => Carbon::parse('2020-04-10 10:53:11')->toDateTimeString(), 'time' => '10:53:11');
+        Birthday::create(['name' => 'Jane Doe', 'birthday' => Carbon::parse('2021-05-12 10:53:12')->toDateTimeString(), 'time' => '10:53:12');
+        Birthday::create(['name' => 'Harry Hoe', 'birthday' => Carbon::parse('2021-05-11 10:53:13')->toDateTimeString(), 'time' => '10:53:13');
+        Birthday::create(['name' => 'Robert Doe', 'birthday' => Carbon::parse('2021-05-12 10:53:14')->toDateTimeString(), 'time' => '10:53:14');
+        Birthday::create(['name' => 'Mark Moe', 'birthday' => Carbon::parse('2021-05-12 10:53:15')->toDateTimeString(), 'time' => '10:53:15');
+        Birthday::create(['name' => 'Mark Moe', 'birthday' => Carbon::parse('2021-05-12 10:53:16')->toDateTimeString(), 'time' => '10:53:16');
     }
 
     public function tearDown(): void
@@ -213,10 +213,10 @@ class QueryTest extends TestCase
 
     public function testWhereTime(): void
     {
-        $time = Birthday::whereTime('birthday', '10:53:11')->get();
+        $time = Birthday::whereTime('time', '10:53:11')->get();
         $this->assertCount(1, $time);
 
-        $time = Birthday::whereTime('birthday', '>=', '10:53:14')->get();
+        $time = Birthday::whereTime('time', '>=', '10:53:14')->get();
         $this->assertCount(3, $time);
     }
 

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -20,12 +20,12 @@ class QueryTest extends TestCase
         User::create(['name' => 'Tommy Toe', 'age' => 33, 'title' => 'user']);
         User::create(['name' => 'Yvonne Yoe', 'age' => 35, 'title' => 'admin']);
         User::create(['name' => 'Error', 'age' => null, 'title' => null]);
-        Birthday::create(['name' => 'Mark Moe', 'birthday' => Carbon::parse('2020-04-10 10:53:11')->toDateTimeString(), 'time' => '10:53:11');
-        Birthday::create(['name' => 'Jane Doe', 'birthday' => Carbon::parse('2021-05-12 10:53:12')->toDateTimeString(), 'time' => '10:53:12');
-        Birthday::create(['name' => 'Harry Hoe', 'birthday' => Carbon::parse('2021-05-11 10:53:13')->toDateTimeString(), 'time' => '10:53:13');
-        Birthday::create(['name' => 'Robert Doe', 'birthday' => Carbon::parse('2021-05-12 10:53:14')->toDateTimeString(), 'time' => '10:53:14');
-        Birthday::create(['name' => 'Mark Moe', 'birthday' => Carbon::parse('2021-05-12 10:53:15')->toDateTimeString(), 'time' => '10:53:15');
-        Birthday::create(['name' => 'Mark Moe', 'birthday' => Carbon::parse('2021-05-12 10:53:16')->toDateTimeString(), 'time' => '10:53:16');
+        Birthday::create(['name' => 'Mark Moe', 'birthday' => Carbon::parse('2020-04-10 10:53:11')->toDateTimeString(), 'time' => '10:53:11']);
+        Birthday::create(['name' => 'Jane Doe', 'birthday' => Carbon::parse('2021-05-12 10:53:12')->toDateTimeString(), 'time' => '10:53:12']);
+        Birthday::create(['name' => 'Harry Hoe', 'birthday' => Carbon::parse('2021-05-11 10:53:13')->toDateTimeString(), 'time' => '10:53:13']);
+        Birthday::create(['name' => 'Robert Doe', 'birthday' => Carbon::parse('2021-05-12 10:53:14')->toDateTimeString(), 'time' => '10:53:14']);
+        Birthday::create(['name' => 'Mark Moe', 'birthday' => Carbon::parse('2021-05-12 10:53:15')->toDateTimeString(), 'time' => '10:53:15']);
+        Birthday::create(['name' => 'Mark Moe', 'birthday' => Carbon::parse('2021-05-12 10:53:16')->toDateTimeString(), 'time' => '10:53:16']);
     }
 
     public function tearDown(): void

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -20,12 +20,12 @@ class QueryTest extends TestCase
         User::create(['name' => 'Tommy Toe', 'age' => 33, 'title' => 'user']);
         User::create(['name' => 'Yvonne Yoe', 'age' => 35, 'title' => 'admin']);
         User::create(['name' => 'Error', 'age' => null, 'title' => null]);
-        Birthday::create(['name' => 'Mark Moe', 'birthday' => Carbon::parse('2020-04-10 10:53:11')->toDateTimeString(), 'time' => '10:53:11']);
-        Birthday::create(['name' => 'Jane Doe', 'birthday' => Carbon::parse('2021-05-12 10:53:12')->toDateTimeString(), 'time' => '10:53:12']);
-        Birthday::create(['name' => 'Harry Hoe', 'birthday' => Carbon::parse('2021-05-11 10:53:13')->toDateTimeString(), 'time' => '10:53:13']);
-        Birthday::create(['name' => 'Robert Doe', 'birthday' => Carbon::parse('2021-05-12 10:53:14')->toDateTimeString(), 'time' => '10:53:14']);
-        Birthday::create(['name' => 'Mark Moe', 'birthday' => Carbon::parse('2021-05-12 10:53:15')->toDateTimeString(), 'time' => '10:53:15']);
-        Birthday::create(['name' => 'Mark Moe', 'birthday' => Carbon::parse('2021-05-12 10:53:16')->toDateTimeString(), 'time' => '10:53:16']);
+        Birthday::create(['name' => 'Mark Moe', 'birthday' => '2020-04-10', 'day' => '10', 'month' => '04', 'year' => '2020', 'time' => '10:53:11']);
+        Birthday::create(['name' => 'Jane Doe', 'birthday' => '2021-05-12', 'day' => '12', 'month' => '05', 'year' => '2021', 'time' => '10:53:12']);
+        Birthday::create(['name' => 'Harry Hoe', 'birthday' => '2021-05-11', 'day' => '11', 'month' => '05', 'year' => '2021', 'time' => '10:53:13']);
+        Birthday::create(['name' => 'Robert Doe', 'birthday' => '2021-05-12', 'day' => '12', 'month' => '05', 'year' => '2021', 'time' => '10:53:14']);
+        Birthday::create(['name' => 'Mark Moe', 'birthday' => '2021-05-12', 'day' => '12', 'month' => '05', 'year' => '2021', 'time' => '10:53:15']);
+        Birthday::create(['name' => 'Mark Moe', 'birthday' => '2022-05-12', 'day' => '12', 'month' => '05', 'year' => '2022', 'time' => '10:53:16']);
     }
 
     public function tearDown(): void
@@ -183,31 +183,31 @@ class QueryTest extends TestCase
 
     public function testWhereDay(): void
     {
-        $day = Birthday::whereDay('birthday', 12)->get();
+        $day = Birthday::whereDay('day', '12')->get();
         $this->assertCount(4, $day);
 
-        $day = Birthday::whereDay('birthday', 11)->get();
+        $day = Birthday::whereDay('day', '11')->get();
         $this->assertCount(1, $day);
     }
 
     public function testWhereMonth(): void
     {
-        $month = Birthday::whereMonth('birthday', 4)->get();
+        $month = Birthday::whereMonth('month', '04')->get();
         $this->assertCount(1, $month);
 
-        $month = Birthday::whereMonth('birthday', 5)->get();
+        $month = Birthday::whereMonth('month', '05')->get();
         $this->assertCount(5, $month);
     }
 
     public function testWhereYear(): void
     {
-        $year = Birthday::whereYear('birthday', 2021)->get();
+        $year = Birthday::whereYear('year', '2021')->get();
         $this->assertCount(4, $year);
 
-        $year = Birthday::whereYear('birthday', 2022)->get();
+        $year = Birthday::whereYear('year', '2022')->get();
         $this->assertCount(1, $year);
 
-        $year = Birthday::whereYear('birthday', '<', 2021)->get();
+        $year = Birthday::whereYear('year', '<', '2021')->get();
         $this->assertCount(1, $year);
     }
 

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use Carbon\Carbon;
+
 class QueryTest extends TestCase
 {
     protected static $started = false;
@@ -18,12 +20,12 @@ class QueryTest extends TestCase
         User::create(['name' => 'Tommy Toe', 'age' => 33, 'title' => 'user']);
         User::create(['name' => 'Yvonne Yoe', 'age' => 35, 'title' => 'admin']);
         User::create(['name' => 'Error', 'age' => null, 'title' => null]);
-        Birthday::create(['name' => 'Mark Moe', 'birthday' => '2020-04-10', 'day' => '10', 'month' => '04', 'year' => '2020', 'time' => '10:53:11']);
-        Birthday::create(['name' => 'Jane Doe', 'birthday' => '2021-05-12', 'day' => '12', 'month' => '05', 'year' => '2021', 'time' => '10:53:12']);
-        Birthday::create(['name' => 'Harry Hoe', 'birthday' => '2021-05-11', 'day' => '11', 'month' => '05', 'year' => '2021', 'time' => '10:53:13']);
-        Birthday::create(['name' => 'Robert Doe', 'birthday' => '2021-05-12', 'day' => '12', 'month' => '05', 'year' => '2021', 'time' => '10:53:14']);
-        Birthday::create(['name' => 'Mark Moe', 'birthday' => '2021-05-12', 'day' => '12', 'month' => '05', 'year' => '2021', 'time' => '10:53:15']);
-        Birthday::create(['name' => 'Mark Moe', 'birthday' => '2022-05-12', 'day' => '12', 'month' => '05', 'year' => '2022', 'time' => '10:53:16']);
+        Birthday::create(['name' => 'Mark Moe', 'birthday' => Carbon::parse('2020-04-10 10:53:11')->toDateTimeString());
+        Birthday::create(['name' => 'Jane Doe', 'birthday' => Carbon::parse('2021-05-12 10:53:12')->toDateTimeString());
+        Birthday::create(['name' => 'Harry Hoe', 'birthday' => Carbon::parse('2021-05-11 10:53:13')->toDateTimeString());
+        Birthday::create(['name' => 'Robert Doe', 'birthday' => Carbon::parse('2021-05-12 10:53:14')->toDateTimeString());
+        Birthday::create(['name' => 'Mark Moe', 'birthday' => Carbon::parse('2021-05-12 10:53:15')->toDateTimeString());
+        Birthday::create(['name' => 'Mark Moe', 'birthday' => Carbon::parse('2021-05-12 10:53:16')->toDateTimeString());
     }
 
     public function tearDown(): void
@@ -181,40 +183,40 @@ class QueryTest extends TestCase
 
     public function testWhereDay(): void
     {
-        $day = Birthday::whereDay('day', '12')->get();
+        $day = Birthday::whereDay('birthday', 12)->get();
         $this->assertCount(4, $day);
 
-        $day = Birthday::whereDay('day', '11')->get();
+        $day = Birthday::whereDay('birthday', 11)->get();
         $this->assertCount(1, $day);
     }
 
     public function testWhereMonth(): void
     {
-        $month = Birthday::whereMonth('month', '04')->get();
+        $month = Birthday::whereMonth('birthday', 4)->get();
         $this->assertCount(1, $month);
 
-        $month = Birthday::whereMonth('month', '05')->get();
+        $month = Birthday::whereMonth('birthday', 5)->get();
         $this->assertCount(5, $month);
     }
 
     public function testWhereYear(): void
     {
-        $year = Birthday::whereYear('year', '2021')->get();
+        $year = Birthday::whereYear('birthday', 2021)->get();
         $this->assertCount(4, $year);
 
-        $year = Birthday::whereYear('year', '2022')->get();
+        $year = Birthday::whereYear('birthday', 2022)->get();
         $this->assertCount(1, $year);
 
-        $year = Birthday::whereYear('year', '<', '2021')->get();
+        $year = Birthday::whereYear('birthday', '<', 2021)->get();
         $this->assertCount(1, $year);
     }
 
     public function testWhereTime(): void
     {
-        $time = Birthday::whereTime('time', '10:53:11')->get();
+        $time = Birthday::whereTime('birthday', '10:53:11')->get();
         $this->assertCount(1, $time);
 
-        $time = Birthday::whereTime('time', '>=', '10:53:14')->get();
+        $time = Birthday::whereTime('birthday', '>=', '10:53:14')->get();
         $this->assertCount(3, $time);
     }
 

--- a/tests/models/Birthday.php
+++ b/tests/models/Birthday.php
@@ -9,14 +9,10 @@ use Jenssegers\Mongodb\Eloquent\Model as Eloquent;
  *
  * @property string $name
  * @property string $birthday
- * @property string $day
- * @property string $month
- * @property string $year
- * @property string $time
  */
 class Birthday extends Eloquent
 {
     protected $connection = 'mongodb';
     protected $collection = 'birthday';
-    protected $fillable = ['name', 'birthday', 'day', 'month', 'year', 'time'];
+    protected $fillable = ['name', 'birthday'];
 }

--- a/tests/models/Birthday.php
+++ b/tests/models/Birthday.php
@@ -9,10 +9,11 @@ use Jenssegers\Mongodb\Eloquent\Model as Eloquent;
  *
  * @property string $name
  * @property string $birthday
+ * @property string $time
  */
 class Birthday extends Eloquent
 {
     protected $connection = 'mongodb';
     protected $collection = 'birthday';
-    protected $fillable = ['name', 'birthday'];
+    protected $fillable = ['name', 'birthday', 'time'];
 }


### PR DESCRIPTION
Fix issues #2334 

So basically, current whereDate, whereDay, whereMonth and whereYear is query on different column with specific need (like whereDate you need column that has value YYYY-MM-DD etc) using basic comparison.

As we all know that isnt how whereDate works on sql, this PR will generate query using built in ```$dayOfMonth, $month, $year``` on whereDay, whereMonth, and whereYear, while whereDate basically generate range date(since mongodb doesnt have date() equivalent like on sql).

Example:
Collection on mongodb
```js
db.birthdays.insert([
    { '_id': 1, 'name': 'John Doe', 'birthday_at': new Date('2002-02-01') },
    { '_id': 2, 'name': 'Nash Doe', 'birthday_at': new Date('1992-06-20') },
    { '_id': 3, 'name': 'Jane Doe', 'birthday_at': new Date('2000-01-15') },
]);
```

Eloquent if this merged
```php
Birthday::whereDate('birthday_at', '2002-02-01')->get();
// generated query: birthdays.find({ 'birthday_at' => { '$gte' => '2002-02-01T00:00:00.000Z', '$lte' => '2002-02-01T23:59:59.999Z' } })

Birthday::whereDay('birthday_at', 15)->get();
// generated query: birthdays.find({ '$expr' => { '$eq' => [{ '$dayOfMonth' => 'birthday_at' }, 15] } })

Birthday::whereMonth('birthday_at', 6)->get();
// generated query: birthdays.find({ '$expr' => { '$eq' => [{ '$month' => 'birthday_at' }, 6] } })

Birthday::whereYear('birthday_at', 2002)->get();
// generated query: birthdays.find({ '$expr' => { '$eq' => [{ '$year' => 'birthday_at' }, 2002] } })

```

Note:
1. whereTime isnt possible to fix rn since i cant find logic to query like time() on sql