### PR TITLE
Typecast $column to string when ordering

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -512,7 +512,7 @@ class Builder extends BaseBuilder
         if ($column == 'natural') {
             $this->orders['$natural'] = $direction;
         } else {
-            $this->orders[$column] = $direction;
+            $this->orders[(string) $column] = $direction;
         }
 
         return $this;


### PR DESCRIPTION
Since `$column` parameter in [Illuminate/Database/Query/Builder.php](https://github.com/laravel/framework/blob/9.x/src/Illuminate/Database/Query/Builder.php#L2204) can take other types than strings, it makes sense to typecast this into a string.

This came up when using [Filament Admin panel](https://github.com/filamentphp/filament/) with Mongo, where orderBy doesn't work since the [$column](url) passed to orderBy isn't a string, but a Stringable object. There are probably other places also with a similar need and I will provide more PR:s as I find them.