### PR TITLE
[3.9] Fix/stringable sort

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -512,7 +512,7 @@ class Builder extends BaseBuilder
         if ($column == 'natural') {
             $this->orders['$natural'] = $direction;
         } else {
-            $this->orders[$column] = $direction;
+            $this->orders[(string) $column] = $direction;
         }
 
         return $this;

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -486,9 +486,9 @@ class QueryTest extends TestCase
  * Mockup class to test stringable objects.
  */
 class stringableObject implements Stringable {
-    private String $string;
+    private string $string;
 
-    public function __construct(String $string)
+    public function __construct(string $string)
     {
         $this->string = $string;
     }

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -486,9 +486,9 @@ class QueryTest extends TestCase
  * Mockup class to test stringable objects.
  */
 class stringableObject implements Stringable {
-    private $string;
+    private String $string;
 
-    public function __construct($string)
+    public function __construct(String $string)
     {
         $this->string = $string;
     }

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -241,7 +241,7 @@ class QueryTest extends TestCase
 
     public function testStringableOrder(): void
     {
-        $age = new stringableObject("age");
+        $age = new stringableObject('age');
 
         $user = User::whereNotNull('age')->orderBy($age, 'asc')->first();
         $this->assertEquals(13, $user->age);
@@ -483,7 +483,7 @@ class QueryTest extends TestCase
 }
 
 /**
- * Mockup class to test stringable objects
+ * Mockup class to test stringable objects.
  */
 class stringableObject implements Stringable {
 

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -241,7 +241,7 @@ class QueryTest extends TestCase
 
     public function testStringableOrder(): void
     {
-        $age = new stringableObject('age');
+        $age = str('age');
 
         $user = User::whereNotNull('age')->orderBy($age, 'asc')->first();
         $this->assertEquals(13, $user->age);

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -481,20 +481,3 @@ class QueryTest extends TestCase
         $this->assertEquals('Brett Boe', $subset[2]->name);
     }
 }
-
-/**
- * Mockup class to test stringable objects.
- */
-class stringableObject implements Stringable {
-    private string $string;
-
-    public function __construct(string $string)
-    {
-        $this->string = $string;
-    }
-
-    public function __toString()
-    {
-        return $this->string;
-    }
-}

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -239,6 +239,17 @@ class QueryTest extends TestCase
         $this->assertEquals(35, $user->age);
     }
 
+    public function testStringableOrder(): void
+    {
+        $age = new stringableObject("age");
+
+        $user = User::whereNotNull('age')->orderBy($age, 'asc')->first();
+        $this->assertEquals(13, $user->age);
+
+        $user = User::whereNotNull('age')->orderBy($age, 'desc')->first();
+        $this->assertEquals(37, $user->age);
+    }
+
     public function testGroupBy(): void
     {
         $users = User::groupBy('title')->get();
@@ -468,5 +479,23 @@ class QueryTest extends TestCase
         $this->assertEquals('Yvonne Yoe', $subset[0]->name);
         $this->assertEquals('John Doe', $subset[1]->name);
         $this->assertEquals('Brett Boe', $subset[2]->name);
+    }
+}
+
+/**
+ * Mockup class to test stringable objects
+ */
+class stringableObject implements Stringable {
+
+    private $string;
+
+    public function __construct($string)
+    {
+        $this->string = $string;
+    }
+
+    public function __toString()
+    {
+        return $this->string;
     }
 }

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -486,7 +486,6 @@ class QueryTest extends TestCase
  * Mockup class to test stringable objects.
  */
 class stringableObject implements Stringable {
-
     private $string;
 
     public function __construct($string)


### PR DESCRIPTION
This PR replaces an [older one](https://github.com/jenssegers/laravel-mongodb/pull/2419). This is a safe fix, where we type cast column value to `string` when ordering. This is more inline in how the Eloquent method that is overwritten works too.

There is a simple test to show how you can now pass objects that implement `Stringable` as a `$column` variable for `orderBy` method.

I wasn't sure where to add that mockable class, so I did put it directly into QueryTest.php file. 