### PR TITLE
removing unused dependency illuminate events

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,3 +13,5 @@ RUN apt-get update && \
 COPY --from=composer /usr/bin/composer /usr/local/bin/composer
 
 WORKDIR /code
+
+CMD [ "phpunit"]

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
         "illuminate/support": "^9.0",
         "illuminate/container": "^9.0",
         "illuminate/database": "^9.0",
-        "illuminate/events": "^9.0",
         "mongodb/mongodb": "^1.11"
     },
     "require-dev": {

--- a/tests/config/database.php
+++ b/tests/config/database.php
@@ -19,13 +19,13 @@ return [
 
         'dsn_mongodb' => [
             'driver' => 'mongodb',
-            'dsn' => "mongodb://" . env('MONGO_USER') .":" . env('MONGO_PASS') ."@$mongoHost:$mongoPort/admin",
+            'dsn' => "mongodb://".env('MONGO_USER').":".env('MONGO_PASS') ."@$mongoHost:$mongoPort/admin",
             'database' => env('MONGO_DATABASE', 'unittest'),
         ],
 
         'dsn_mongodb_db' => [
             'driver' => 'mongodb',
-            'dsn' => "mongodb://" . env('MONGO_USER') .":" . env('MONGO_PASS') ."@$mongoHost:$mongoPort/".env('MONGO_DATABASE', 'unittest') . "?authSource=admin",
+            'dsn' => "mongodb://".env('MONGO_USER').":".env('MONGO_PASS') ."@$mongoHost:$mongoPort/".env('MONGO_DATABASE', 'unittest') . "?authSource=admin",
         ],
 
         'mysql' => [

--- a/tests/config/database.php
+++ b/tests/config/database.php
@@ -19,13 +19,13 @@ return [
 
         'dsn_mongodb' => [
             'driver' => 'mongodb',
-            'dsn' => "mongodb://".env('MONGO_USER').":".env('MONGO_PASS') ."@$mongoHost:$mongoPort/admin",
+            'dsn' => 'mongodb://'.env('MONGO_USER').':'.env('MONGO_PASS') .'@$mongoHost:$mongoPort/admin',
             'database' => env('MONGO_DATABASE', 'unittest'),
         ],
 
         'dsn_mongodb_db' => [
             'driver' => 'mongodb',
-            'dsn' => "mongodb://".env('MONGO_USER').":".env('MONGO_PASS') ."@$mongoHost:$mongoPort/".env('MONGO_DATABASE', 'unittest') . "?authSource=admin",
+            'dsn' => 'mongodb://'.env('MONGO_USER').':'.env('MONGO_PASS') .'@$mongoHost:$mongoPort/'.env('MONGO_DATABASE', 'unittest') . '?authSource=admin',
         ],
 
         'mysql' => [

--- a/tests/config/database.php
+++ b/tests/config/database.php
@@ -19,13 +19,13 @@ return [
 
         'dsn_mongodb' => [
             'driver' => 'mongodb',
-            'dsn' => 'mongodb://'.env('MONGO_USER').':'.env('MONGO_PASS') .'@$mongoHost:$mongoPort/admin',
+            'dsn' => 'mongodb://'.env('MONGO_USER').':'.env('MONGO_PASS').'@$mongoHost:$mongoPort/admin',
             'database' => env('MONGO_DATABASE', 'unittest'),
         ],
 
         'dsn_mongodb_db' => [
             'driver' => 'mongodb',
-            'dsn' => 'mongodb://'.env('MONGO_USER').':'.env('MONGO_PASS') .'@$mongoHost:$mongoPort/'.env('MONGO_DATABASE', 'unittest') . '?authSource=admin',
+            'dsn' => 'mongodb://'.env('MONGO_USER').':'.env('MONGO_PASS').'@$mongoHost:$mongoPort/'.env('MONGO_DATABASE', 'unittest') . '?authSource=admin',
         ],
 
         'mysql' => [

--- a/tests/config/database.php
+++ b/tests/config/database.php
@@ -25,7 +25,7 @@ return [
 
         'dsn_mongodb_db' => [
             'driver' => 'mongodb',
-            'dsn' => 'mongodb://'.env('MONGO_USER').':'.env('MONGO_PASS').'@$mongoHost:$mongoPort/'.env('MONGO_DATABASE', 'unittest') . '?authSource=admin',
+            'dsn' => 'mongodb://'.env('MONGO_USER').':'.env('MONGO_PASS').'@$mongoHost:$mongoPort/'.env('MONGO_DATABASE', 'unittest').'?authSource=admin',
         ],
 
         'mysql' => [

--- a/tests/config/database.php
+++ b/tests/config/database.php
@@ -12,18 +12,20 @@ return [
             'name' => 'mongodb',
             'driver' => 'mongodb',
             'host' => $mongoHost,
+            'username' => env('MONGO_USER'),
+            'password' => env('MONGO_PASS'),
             'database' => env('MONGO_DATABASE', 'unittest'),
         ],
 
         'dsn_mongodb' => [
             'driver' => 'mongodb',
-            'dsn' => "mongodb://$mongoHost:$mongoPort",
+            'dsn' => "mongodb://" . env('MONGO_USER') .":" . env('MONGO_PASS') ."@$mongoHost:$mongoPort/admin",
             'database' => env('MONGO_DATABASE', 'unittest'),
         ],
 
         'dsn_mongodb_db' => [
             'driver' => 'mongodb',
-            'dsn' => "mongodb://$mongoHost:$mongoPort/".env('MONGO_DATABASE', 'unittest'),
+            'dsn' => "mongodb://" . env('MONGO_USER') .":" . env('MONGO_PASS') ."@$mongoHost:$mongoPort/".env('MONGO_DATABASE', 'unittest') . "?authSource=admin",
         ],
 
         'mysql' => [


### PR DESCRIPTION
issue is described here https://github.com/jenssegers/laravel-mongodb/issues/2442

i ran the tests and had to modify few things in terms of test configuration because the docker-compose was not giving a clear indication that tests passed because it was simply executing "php -a " as default from the php:cli container, this confusion for me took the longest than fixing the codel 

if you don't merge it i will add it to another packagist and publish the package, this is not a threat just simple dissapointment on how a popular opensource code has been managed, 

a major blocker to upgrade laravel 8 to 9 was cuased by this oversight, what would have been 15 minutes of a upgrade caused over 2 hours and over an hour out of the confusion regarding how phpunit was executed in docker-compose 

now next i am goin g to pushblish on packagist when you merge and if you merge thats upto you