### PR TITLE
fix: whereBelongsTo

### DIFF
--- a/src/Relations/BelongsTo.php
+++ b/src/Relations/BelongsTo.php
@@ -73,10 +73,7 @@ class BelongsTo extends \Illuminate\Database\Eloquent\Relations\BelongsTo
         return 'whereIn';
     }
 
-    /**
-     * @return string
-     */
-    public function getQualifiedForeignKeyName()
+    public function getQualifiedForeignKeyName(): string
     {
         return $this->foreignKey;
     }

--- a/src/Relations/BelongsTo.php
+++ b/src/Relations/BelongsTo.php
@@ -72,4 +72,12 @@ class BelongsTo extends \Illuminate\Database\Eloquent\Relations\BelongsTo
     {
         return 'whereIn';
     }
+
+    /**
+     * @return string
+     */
+    public function getQualifiedForeignKeyName()
+    {
+        return $this->foreignKey;
+    }
 }

--- a/tests/RelationsTest.php
+++ b/tests/RelationsTest.php
@@ -543,7 +543,7 @@ class RelationsTest extends TestCase
         Item::create(['user_id' => $user->_id]);
         Item::create(['user_id' => null]);
 
-        $items = Item::query()->whereBelongsTo($user)->get();
+        $items = Item::whereBelongsTo($user)->get();
 
         $this->assertCount(3, $items);
     }

--- a/tests/RelationsTest.php
+++ b/tests/RelationsTest.php
@@ -534,4 +534,17 @@ class RelationsTest extends TestCase
         $this->assertEquals([$user->_id], $client->user_ids);
         $this->assertEquals([$client->_id], $user->client_ids);
     }
+
+    public function testWhereBelongsTo()
+    {
+        $user = User::create(['name' => 'John Doe']);
+        Item::create(['user_id' => $user->_id]);
+        Item::create(['user_id' => $user->_id]);
+        Item::create(['user_id' => $user->_id]);
+        Item::create(['user_id' => null]);
+
+        $items = Item::query()->whereBelongsTo($user)->get();
+
+        $this->assertCount(3, $items);
+    }
 }


### PR DESCRIPTION
this pr focusing fix whereBelongsTo() method.

Before:
`items.find({"items.user_id":{"$in":["..."]}},{"typeMap":{"root":"array","document":"array"}})`
After:
`items.find({"user_id":{"$in":["..."]}},{"typeMap":{"root":"array","document":"array"}})`