### PR TITLE
Pass timeout in milliseconds

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -380,7 +380,7 @@ class Builder extends BaseBuilder
 
             // Apply order, offset, limit and projection
             if ($this->timeout) {
-                $options['maxTimeMS'] = $this->timeout;
+                $options['maxTimeMS'] = $this->timeout * 1000;
             }
             if ($this->orders) {
                 $options['sort'] = $this->orders;


### PR DESCRIPTION
Fixes #2460.

I decided to convert the value where the timeout is applied, as the property is public and users may have already passed a timeout in seconds to the property. If that is not how users are expected to use the `timeout` property, please let me know.

Testing this is a bit difficult, so I decided to use a command subscriber and inspect the command sent to the server to ensure we're sending the correct timeout value.