### PR TITLE
Transaction support

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -57,7 +57,7 @@ jobs:
             -   uses: actions/checkout@v2
             -   name: Create MongoDB Replica Set
                 run: |
-                    docker run --name mongodb -p 27017:27017 -e MONGO_INITDB_DATABASE=unittest --detach mongo:${{ matrix.mongodb }} mongod --replSet rs
+                    docker run --name mongodb -p 27017:27017 -e MONGO_INITDB_DATABASE=unittest --detach mongo:${{ matrix.mongodb }} mongod --replSet rs --setParameter transactionLifetimeLimitSeconds=5
                     until docker exec --tty mongodb mongo 127.0.0.1:27017 --eval "db.runCommand({ ping: 1 })"; do
                     sleep 1
                     done

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -58,10 +58,10 @@ jobs:
             -   name: Create MongoDB Replica Set
                 run: |
                     docker run --name mongodb -p 27017:27017 -e MONGO_INITDB_DATABASE=unittest --detach mongo:${{ matrix.mongodb }} mongod --replSet rs
-                    until docker exec --tty mongodb mongo 127.0.0.1:27017 --eval "db.serverStatus()"; do
+                    until docker exec --tty mongodb mongo 127.0.0.1:27017 --eval "db.runCommand({ ping: 1 })"; do
                     sleep 1
                     done
-                    sudo docker exec --tty mongodb mongo 127.0.0.1:27017 --eval "rs.initiate({\"_id\":\"rs\",\"members\":[{\"_id\":0,\"host\":\"127.0.0.1:27017\" }]})"
+                    sudo docker exec --tty mongodb mongo 127.0.0.1:27017 --eval "rs.initiate()"
             -   name: "Installing php"
                 uses: shivammathur/setup-php@v2
                 with:

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -44,10 +44,6 @@ jobs:
                     - '8.0'
                     - '8.1'
         services:
-            mongo:
-                image: mongo:${{ matrix.mongodb }}
-                ports:
-                    - 27017:27017
             mysql:
                 image: mysql:5.7
                 ports:
@@ -59,6 +55,13 @@ jobs:
 
         steps:
             -   uses: actions/checkout@v2
+            -   name: Create MongoDB Replica Set
+                run: |
+                    docker run --name mongodb -p 27017:27017 -e MONGO_INITDB_DATABASE=unittest --detach mongo:${{ matrix.mongodb }} mongod --replSet rs
+                    until docker exec --tty mongodb mongo 127.0.0.1:27017 --eval "db.serverStatus()"; do
+                    sleep 1
+                    done
+                    sudo docker exec --tty mongodb mongo 127.0.0.1:27017 --eval "rs.initiate({\"_id\":\"rs\",\"members\":[{\"_id\":0,\"host\":\"127.0.0.1:27017\" }]})"
             -   name: "Installing php"
                 uses: shivammathur/setup-php@v2
                 with:
@@ -88,7 +91,7 @@ jobs:
                 run: |
                     ./vendor/bin/phpunit --coverage-clover coverage.xml
                 env:
-                    MONGODB_URI: 'mongodb://127.0.0.1/'
+                    MONGODB_URI: 'mongodb://127.0.0.1/?replicaSet=rs'
                     MYSQL_HOST: 0.0.0.0
                     MYSQL_PORT: 3307
             -   uses: codecov/codecov-action@v1

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -61,7 +61,7 @@ jobs:
                     until docker exec --tty mongodb mongo 127.0.0.1:27017 --eval "db.runCommand({ ping: 1 })"; do
                     sleep 1
                     done
-                    sudo docker exec --tty mongodb mongo 127.0.0.1:27017 --eval "rs.initiate()"
+                    sudo docker exec --tty mongodb mongo 127.0.0.1:27017 --eval "rs.initiate({\"_id\":\"rs\",\"members\":[{\"_id\":0,\"host\":\"127.0.0.1:27017\" }]})"
             -   name: "Installing php"
                 uses: shivammathur/setup-php@v2
                 with:

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -62,6 +62,9 @@ jobs:
                     sleep 1
                     done
                     sudo docker exec --tty mongodb mongo 127.0.0.1:27017 --eval "rs.initiate({\"_id\":\"rs\",\"members\":[{\"_id\":0,\"host\":\"127.0.0.1:27017\" }]})"
+            -   name: Show MongoDB server status
+                run: |
+                    docker exec --tty mongodb mongo 127.0.0.1:27017 --eval "db.runCommand({ serverStatus: 1 })"
             -   name: "Installing php"
                 uses: shivammathur/setup-php@v2
                 with:

--- a/README.md
+++ b/README.md
@@ -970,16 +970,14 @@ If you are familiar with [Eloquent Queries](http://laravel.com/docs/queries), th
 To see the available operations, check the [Eloquent](#eloquent) section.
 
 Transactions
--------
+------------
 Transactions require MongoDB version ^4.0 as well as deployment of replica set or sharded clusters. You can find more information [in the MongoDB docs](https://docs.mongodb.com/manual/core/transactions/)
 
 ### Basic Usage
 
-Transaction supports all operations.
-
 ```php
 DB::transaction(function () {
-    User::create(['name' => 'john', 'age' => 19, 'title' => 'admin', 'email' => 'klinsonup@gmail.com']);
+    User::create(['name' => 'john', 'age' => 19, 'title' => 'admin', 'email' => 'john@example.com']);
     DB::collection('users')->where('name', 'john')->update(['age' => 20]);
     DB::collection('users')->where('name', 'john')->delete();
 });
@@ -988,24 +986,32 @@ DB::transaction(function () {
 ```php
 // begin a transaction
 DB::beginTransaction();
-User::create(['name' => 'john', 'age' => 19, 'title' => 'admin', 'email' => 'klinsonup@gmail.com']);
+User::create(['name' => 'john', 'age' => 19, 'title' => 'admin', 'email' => 'john@example.com']);
 DB::collection('users')->where('name', 'john')->update(['age' => 20]);
 DB::collection('users')->where('name', 'john')->delete();
 
-// you can commit your changes
+// commit changes
 DB::commit();
-
-// you can also rollback them
-//DB::rollBack();
 ```
+
+To abort a transaction, call the `rollBack` method at any point during the transaction:
+```php
+DB::beginTransaction();
+User::create(['name' => 'john', 'age' => 19, 'title' => 'admin', 'email' => 'john@example.com']);
+
+// Abort the transaction, discarding any data created as part of it
+DB::rollBack();
+```
+
 **NOTE:** Transactions in MongoDB cannot be nested. DB::beginTransaction() function will start new transactions in a new created or existing session and will raise the RuntimeException when transactions already exist. See more in MongoDB official docs [Transactions and Sessions](https://www.mongodb.com/docs/manual/core/transactions/#transactions-and-sessions)
 ```php
-// This code will raise a RuntimeException
 DB::beginTransaction();
-    User::create(['name' => 'john', 'age' => 20, 'title' => 'admin']);
-    DB::beginTransaction()
-        DB::collection('users')->where('name', 'john')->update(['age' => 20]);
-    DB::commit()
+User::create(['name' => 'john', 'age' => 20, 'title' => 'admin']);
+
+// This call to start a nested transaction will raise a RuntimeException
+DB::beginTransaction();
+DB::collection('users')->where('name', 'john')->update(['age' => 20]);
+DB::commit();
 DB::rollBack();
 ```
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ This package adds functionalities to the Eloquent model and Query builder for Mo
   - [Query Builder](#query-builder)
     - [Basic Usage](#basic-usage-2)
     - [Available operations](#available-operations)
+  - [Transactions](#transactions)
   - [Schema](#schema)
     - [Basic Usage](#basic-usage-3)
     - [Geospatial indexes](#geospatial-indexes)
@@ -967,6 +968,46 @@ If you are familiar with [Eloquent Queries](http://laravel.com/docs/queries), th
 
 ### Available operations
 To see the available operations, check the [Eloquent](#eloquent) section.
+
+Transactions
+-------
+Transactions require MongoDB version ^4.0 as well as deployment of replica set or sharded clusters. You can find more information [in the MongoDB docs](https://docs.mongodb.com/manual/core/transactions/)
+
+### Basic Usage
+
+Transaction supports all operations.
+
+```php
+DB::transaction(function () {
+    User::create(['name' => 'john', 'age' => 19, 'title' => 'admin', 'email' => 'klinsonup@gmail.com']);
+    DB::collection('users')->where('name', 'john')->update(['age' => 20]);
+    DB::collection('users')->where('name', 'john')->delete();
+});
+```
+
+```php
+// begin a transaction
+DB::beginTransaction();
+User::create(['name' => 'john', 'age' => 19, 'title' => 'admin', 'email' => 'klinsonup@gmail.com']);
+DB::collection('users')->where('name', 'john')->update(['age' => 20]);
+DB::collection('users')->where('name', 'john')->delete();
+
+// you can commit your changes
+DB::commit();
+
+// you can also rollback them
+//DB::rollBack();
+```
+**NOTE:** Transactions in MongoDB cannot be nested. DB::beginTransaction() function will start new transactions in a new created or existing session and will raise the RuntimeException when transactions already exist. See more in MongoDB official docs [Transactions and Sessions](https://www.mongodb.com/docs/manual/core/transactions/#transactions-and-sessions)
+```php
+// This code will raise a RuntimeException
+DB::beginTransaction();
+    User::create(['name' => 'john', 'age' => 20, 'title' => 'admin']);
+    DB::beginTransaction()
+        DB::collection('users')->where('name', 'john')->update(['age' => 20]);
+    DB::commit()
+DB::rollBack();
+```
 
 Schema
 ------

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -19,6 +19,9 @@
             <file>tests/QueryBuilderTest.php</file>
             <file>tests/QueryTest.php</file>
         </testsuite>
+        <testsuite name="transaction">
+            <file>tests/TransactionTest.php</file>
+        </testsuite>
         <testsuite name="model">
             <file>tests/ModelTest.php</file>
             <file>tests/RelationsTest.php</file>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -39,7 +39,7 @@
     </testsuites>
     <php>
         <env name="MONGODB_URI" value="mongodb://127.0.0.1/" />
-        <env name="MONGO_DATABASE" value="unittest"/>
+        <env name="MONGODB_DATABASE" value="unittest"/>
         <env name="MYSQL_HOST" value="mysql"/>
         <env name="MYSQL_PORT" value="3306"/>
         <env name="MYSQL_DATABASE" value="unittest"/>

--- a/src/Concerns/ManagesTransactions.php
+++ b/src/Concerns/ManagesTransactions.php
@@ -84,8 +84,6 @@ trait ManagesTransactions
         $attemptsLeft = $attempts;
         $callbackResult = null;
 
-        $session = $this->getSessionOrCreate();
-
         $callbackFunction = function (Session $session) use ($callback, &$attemptsLeft, &$callbackResult) {
             $attemptsLeft--;
 
@@ -95,10 +93,10 @@ trait ManagesTransactions
                 return;
             }
 
-            $callbackResult = $callback();
+            $callbackResult = $callback($this);
         };
 
-        with_transaction($session, $callbackFunction, $options);
+        with_transaction($this->getSessionOrCreate(), $callbackFunction, $options);
 
         return $callbackResult;
     }

--- a/src/Concerns/ManagesTransactions.php
+++ b/src/Concerns/ManagesTransactions.php
@@ -8,9 +8,14 @@ use MongoDB\Driver\Exception\RuntimeException;
 use MongoDB\Driver\Session;
 use function MongoDB\with_transaction;
 
+/**
+ * @see https://docs.mongodb.com/manual/core/transactions/
+ */
 trait ManagesTransactions
 {
     protected ?Session $session = null;
+
+    protected $transactions = 0;
 
     /**
      * @return Client
@@ -43,12 +48,7 @@ trait ManagesTransactions
     }
 
     /**
-     * Use the existing or create new session and start a transaction in session.
-     *
-     * In version 4.0, MongoDB supports multi-document transactions on replica sets.
-     * In version 4.2, MongoDB introduces distributed transactions, which adds support for multi-document transactions on sharded clusters and incorporates the existing support for multi-document transactions on replica sets.
-     *
-     * @see https://docs.mongodb.com/manual/core/transactions/
+     * Starts a transaction on the active session. An active session will be created if none exists.
      */
     public function beginTransaction(array $options = []): void
     {
@@ -66,7 +66,7 @@ trait ManagesTransactions
     }
 
     /**
-     * Rollback transaction in this session.
+     * Abort transaction in this session.
      */
     public function rollBack($toLevel = null): void
     {

--- a/src/Concerns/ManagesTransactions.php
+++ b/src/Concerns/ManagesTransactions.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Jenssegers\Mongodb\Concerns;
+
+use Closure;
+use MongoDB\Client;
+use MongoDB\Driver\Exception\RuntimeException;
+use MongoDB\Driver\Session;
+use function MongoDB\with_transaction;
+
+trait ManagesTransactions
+{
+    protected ?Session $session = null;
+
+    /**
+     * @return Client
+     */
+    abstract public function getMongoClient();
+
+    public function getSession(): ?Session
+    {
+        return $this->session;
+    }
+
+    private function getSessionOrCreate(): Session
+    {
+        if ($this->session === null) {
+            $this->session = $this->getMongoClient()->startSession();
+        }
+
+        return $this->session;
+    }
+
+    private function getSessionOrThrow(): Session
+    {
+        $session = $this->getSession();
+
+        if ($session === null) {
+            throw new RuntimeException('There is no active session.');
+        }
+
+        return $session;
+    }
+
+    /**
+     * Use the existing or create new session and start a transaction in session.
+     *
+     * In version 4.0, MongoDB supports multi-document transactions on replica sets.
+     * In version 4.2, MongoDB introduces distributed transactions, which adds support for multi-document transactions on sharded clusters and incorporates the existing support for multi-document transactions on replica sets.
+     *
+     * @see https://docs.mongodb.com/manual/core/transactions/
+     */
+    public function beginTransaction(array $options = []): void
+    {
+        $this->getSessionOrCreate()->startTransaction($options);
+        $this->transactions = 1;
+    }
+
+    /**
+     * Commit transaction in this session.
+     */
+    public function commit(): void
+    {
+        $this->getSessionOrThrow()->commitTransaction();
+        $this->transactions = 0;
+    }
+
+    /**
+     * Rollback transaction in this session.
+     */
+    public function rollBack($toLevel = null): void
+    {
+        $this->getSessionOrThrow()->abortTransaction();
+        $this->transactions = 0;
+    }
+
+    /**
+     * Static transaction function realize the with_transaction functionality provided by MongoDB.
+     *
+     * @param  int  $attempts
+     */
+    public function transaction(Closure $callback, $attempts = 1, array $options = []): mixed
+    {
+        $attemptsLeft = $attempts;
+        $callbackResult = null;
+
+        $session = $this->getSessionOrCreate();
+
+        $callbackFunction = function (Session $session) use ($callback, &$attemptsLeft, &$callbackResult) {
+            $attemptsLeft--;
+
+            if ($attemptsLeft < 0) {
+                $session->abortTransaction();
+
+                return;
+            }
+
+            $callbackResult = $callback();
+        };
+
+        with_transaction($session, $callbackFunction, $options);
+
+        return $callbackResult;
+    }
+}

--- a/src/Concerns/ManagesTransactions.php
+++ b/src/Concerns/ManagesTransactions.php
@@ -95,7 +95,7 @@ trait ManagesTransactions
                 return;
             }
 
-            // Catch, store and re-throw any exception thrown during execution
+            // Catch, store, and re-throw any exception thrown during execution
             // of the callable. The last exception is re-thrown if the transaction
             // was aborted because the number of callback attempts has been exceeded.
             try {

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -5,11 +5,14 @@ namespace Jenssegers\Mongodb;
 use Illuminate\Database\Connection as BaseConnection;
 use Illuminate\Support\Arr;
 use InvalidArgumentException;
+use Jenssegers\Mongodb\Concerns\ManagesTransactions;
 use MongoDB\Client;
 use MongoDB\Database;
 
 class Connection extends BaseConnection
 {
+    use ManagesTransactions;
+
     /**
      * The MongoDB database handler.
      *

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -734,7 +734,7 @@ class Builder extends BaseBuilder
     public function truncate(): bool
     {
         $options = $this->inheritConnectionOptions();
-        $result = $this->collection->deleteMany($options);
+        $result = $this->collection->deleteMany([], $options);
 
         return 1 === (int) $result->isAcknowledged();
     }

--- a/tests/TransactionTest.php
+++ b/tests/TransactionTest.php
@@ -3,7 +3,6 @@
 use Illuminate\Support\Facades\DB;
 use Jenssegers\Mongodb\Eloquent\Model;
 use MongoDB\BSON\ObjectId;
-use MongoDB\Driver\ReadPreference;
 use MongoDB\Driver\Server;
 
 class TransactionTest extends TestCase
@@ -425,6 +424,6 @@ class TransactionTest extends TestCase
 
     private function getPrimaryServerType(): int
     {
-        return DB::getMongoClient()->getManager()->selectServer(new ReadPreference(ReadPreference::RP_PRIMARY))->getType();
+        return DB::getMongoClient()->getManager()->selectServer()->getType();
     }
 }

--- a/tests/TransactionTest.php
+++ b/tests/TransactionTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\DB;
+use Jenssegers\Mongodb\Connection;
 use Jenssegers\Mongodb\Eloquent\Model;
 use MongoDB\BSON\ObjectId;
 use MongoDB\Driver\Server;
@@ -316,7 +317,7 @@ class TransactionTest extends TestCase
     {
         User::create(['name' => 'klinson', 'age' => 20, 'title' => 'admin']);
 
-        DB::transaction(function (): void {
+        DB::transaction(function (Connection $connection): void {
             User::create(['name' => 'alcaeus', 'age' => 38, 'title' => 'admin']);
             User::where(['name' => 'klinson'])->update(['age' => 21]);
         });

--- a/tests/TransactionTest.php
+++ b/tests/TransactionTest.php
@@ -1,0 +1,430 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use Jenssegers\Mongodb\Eloquent\Model;
+use MongoDB\BSON\ObjectId;
+use MongoDB\Driver\ReadPreference;
+use MongoDB\Driver\Server;
+
+class TransactionTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        if ($this->getPrimaryServerType() === Server::TYPE_STANDALONE) {
+            $this->markTestSkipped('Transactions are not supported on standalone servers');
+        }
+
+        User::truncate();
+    }
+
+    public function tearDown(): void
+    {
+        User::truncate();
+
+        parent::tearDown();
+    }
+
+    public function testCreateWithCommit(): void
+    {
+        DB::beginTransaction();
+        /** @var User $klinson */
+        $klinson = User::create(['name' => 'klinson', 'age' => 20, 'title' => 'admin']);
+        DB::commit();
+
+        $this->assertInstanceOf(Model::class, $klinson);
+        $this->assertTrue($klinson->exists);
+        $this->assertEquals('klinson', $klinson->name);
+
+        $check = User::find($klinson->_id);
+        $this->assertInstanceOf(User::class, $check);
+        $this->assertEquals($klinson->name, $check->name);
+    }
+
+    public function testCreateRollBack(): void
+    {
+        DB::beginTransaction();
+        /** @var User $klinson */
+        $klinson = User::create(['name' => 'klinson', 'age' => 20, 'title' => 'admin']);
+        DB::rollBack();
+
+        $this->assertInstanceOf(Model::class, $klinson);
+        $this->assertTrue($klinson->exists);
+        $this->assertEquals('klinson', $klinson->name);
+
+        $this->assertFalse(User::where('_id', $klinson->_id)->exists());
+    }
+
+    public function testInsertWithCommit(): void
+    {
+        DB::beginTransaction();
+        DB::collection('users')->insert(['name' => 'klinson', 'age' => 20, 'title' => 'admin']);
+        DB::commit();
+
+        $this->assertTrue(DB::collection('users')->where('name', 'klinson')->exists());
+    }
+
+    public function testInsertWithRollBack(): void
+    {
+        DB::beginTransaction();
+        DB::collection('users')->insert(['name' => 'klinson', 'age' => 20, 'title' => 'admin']);
+        DB::rollBack();
+
+        $this->assertFalse(DB::collection('users')->where('name', 'klinson')->exists());
+    }
+
+    public function testEloquentCreateWithCommit(): void
+    {
+        DB::beginTransaction();
+        /** @var User $klinson */
+        $klinson = User::getModel();
+        $klinson->name = 'klinson';
+        $klinson->save();
+        DB::commit();
+
+        $this->assertTrue($klinson->exists);
+        $this->assertNotNull($klinson->getIdAttribute());
+
+        $check = User::find($klinson->_id);
+        $this->assertInstanceOf(User::class, $check);
+        $this->assertEquals($check->name, $klinson->name);
+    }
+
+    public function testEloquentCreateWithRollBack(): void
+    {
+        DB::beginTransaction();
+        /** @var User $klinson */
+        $klinson = User::getModel();
+        $klinson->name = 'klinson';
+        $klinson->save();
+        DB::rollBack();
+
+        $this->assertTrue($klinson->exists);
+        $this->assertNotNull($klinson->getIdAttribute());
+
+        $this->assertFalse(User::where('_id', $klinson->_id)->exists());
+    }
+
+    public function testInsertGetIdWithCommit(): void
+    {
+        DB::beginTransaction();
+        $userId = DB::collection('users')->insertGetId(['name' => 'klinson', 'age' => 20, 'title' => 'admin']);
+        DB::commit();
+
+        $this->assertInstanceOf(ObjectId::class, $userId);
+
+        $user = DB::collection('users')->find((string) $userId);
+        $this->assertEquals('klinson', $user['name']);
+    }
+
+    public function testInsertGetIdWithRollBack(): void
+    {
+        DB::beginTransaction();
+        $userId = DB::collection('users')->insertGetId(['name' => 'klinson', 'age' => 20, 'title' => 'admin']);
+        DB::rollBack();
+
+        $this->assertInstanceOf(ObjectId::class, $userId);
+        $this->assertFalse(DB::collection('users')->where('_id', (string) $userId)->exists());
+    }
+
+    public function testUpdateWithCommit(): void
+    {
+        User::create(['name' => 'klinson', 'age' => 20, 'title' => 'admin']);
+
+        DB::beginTransaction();
+        $updated = DB::collection('users')->where('name', 'klinson')->update(['age' => 21]);
+        DB::commit();
+
+        $this->assertEquals(1, $updated);
+        $this->assertTrue(DB::collection('users')->where('name', 'klinson')->where('age', 21)->exists());
+    }
+
+    public function testUpdateWithRollback(): void
+    {
+        User::create(['name' => 'klinson', 'age' => 20, 'title' => 'admin']);
+
+        DB::beginTransaction();
+        $updated = DB::collection('users')->where('name', 'klinson')->update(['age' => 21]);
+        DB::rollBack();
+
+        $this->assertEquals(1, $updated);
+        $this->assertFalse(DB::collection('users')->where('name', 'klinson')->where('age', 21)->exists());
+    }
+
+    public function testEloquentUpdateWithCommit(): void
+    {
+        /** @var User $klinson */
+        $klinson = User::create(['name' => 'klinson', 'age' => 20, 'title' => 'admin']);
+        /** @var User $alcaeus */
+        $alcaeus = User::create(['name' => 'alcaeus', 'age' => 38, 'title' => 'admin']);
+
+        DB::beginTransaction();
+        $klinson->age = 21;
+        $klinson->update();
+
+        $alcaeus->update(['age' => 39]);
+        DB::commit();
+
+        $this->assertEquals(21, $klinson->age);
+        $this->assertEquals(39, $alcaeus->age);
+
+        $this->assertTrue(User::where('_id', $klinson->_id)->where('age', 21)->exists());
+        $this->assertTrue(User::where('_id', $alcaeus->_id)->where('age', 39)->exists());
+    }
+
+    public function testEloquentUpdateWithRollBack(): void
+    {
+        /** @var User $klinson */
+        $klinson = User::create(['name' => 'klinson', 'age' => 20, 'title' => 'admin']);
+        /** @var User $alcaeus */
+        $alcaeus = User::create(['name' => 'klinson', 'age' => 38, 'title' => 'admin']);
+
+        DB::beginTransaction();
+        $klinson->age = 21;
+        $klinson->update();
+
+        $alcaeus->update(['age' => 39]);
+        DB::rollBack();
+
+        $this->assertEquals(21, $klinson->age);
+        $this->assertEquals(39, $alcaeus->age);
+
+        $this->assertFalse(User::where('_id', $klinson->_id)->where('age', 21)->exists());
+        $this->assertFalse(User::where('_id', $alcaeus->_id)->where('age', 39)->exists());
+    }
+
+    public function testDeleteWithCommit(): void
+    {
+        User::create(['name' => 'klinson', 'age' => 20, 'title' => 'admin']);
+
+        DB::beginTransaction();
+        $deleted = User::where(['name' => 'klinson'])->delete();
+        DB::commit();
+
+        $this->assertEquals(1, $deleted);
+        $this->assertFalse(User::where(['name' => 'klinson'])->exists());
+    }
+
+    public function testDeleteWithRollBack(): void
+    {
+        User::create(['name' => 'klinson', 'age' => 20, 'title' => 'admin']);
+
+        DB::beginTransaction();
+        $deleted = User::where(['name' => 'klinson'])->delete();
+        DB::rollBack();
+
+        $this->assertEquals(1, $deleted);
+        $this->assertTrue(User::where(['name' => 'klinson'])->exists());
+    }
+
+    public function testEloquentDeleteWithCommit(): void
+    {
+        /** @var User $klinson */
+        $klinson = User::create(['name' => 'klinson', 'age' => 20, 'title' => 'admin']);
+
+        DB::beginTransaction();
+        $klinson->delete();
+        DB::commit();
+
+        $this->assertFalse(User::where('_id', $klinson->_id)->exists());
+    }
+
+    public function testEloquentDeleteWithRollBack(): void
+    {
+        /** @var User $klinson */
+        $klinson = User::create(['name' => 'klinson', 'age' => 20, 'title' => 'admin']);
+
+        DB::beginTransaction();
+        $klinson->delete();
+        DB::rollBack();
+
+        $this->assertTrue(User::where('_id', $klinson->_id)->exists());
+    }
+
+    public function testIncrementWithCommit(): void
+    {
+        User::create(['name' => 'klinson', 'age' => 20, 'title' => 'admin']);
+
+        DB::beginTransaction();
+        DB::collection('users')->where('name', 'klinson')->increment('age');
+        DB::commit();
+
+        $this->assertTrue(DB::collection('users')->where('name', 'klinson')->where('age', 21)->exists());
+    }
+
+    public function testIncrementWithRollBack(): void
+    {
+        User::create(['name' => 'klinson', 'age' => 20, 'title' => 'admin']);
+
+        DB::beginTransaction();
+        DB::collection('users')->where('name', 'klinson')->increment('age');
+        DB::rollBack();
+
+        $this->assertTrue(DB::collection('users')->where('name', 'klinson')->where('age', 20)->exists());
+    }
+
+    public function testDecrementWithCommit(): void
+    {
+        User::create(['name' => 'klinson', 'age' => 20, 'title' => 'admin']);
+
+        DB::beginTransaction();
+        DB::collection('users')->where('name', 'klinson')->decrement('age');
+        DB::commit();
+
+        $this->assertTrue(DB::collection('users')->where('name', 'klinson')->where('age', 19)->exists());
+    }
+
+    public function testDecrementWithRollBack(): void
+    {
+        User::create(['name' => 'klinson', 'age' => 20, 'title' => 'admin']);
+
+        DB::beginTransaction();
+        DB::collection('users')->where('name', 'klinson')->decrement('age');
+        DB::rollBack();
+
+        $this->assertTrue(DB::collection('users')->where('name', 'klinson')->where('age', 20)->exists());
+    }
+
+    public function testQuery()
+    {
+        /** rollback test */
+        DB::beginTransaction();
+        $count = DB::collection('users')->count();
+        $this->assertEquals(0, $count);
+        DB::collection('users')->insert(['name' => 'klinson', 'age' => 20, 'title' => 'admin']);
+        $count = DB::collection('users')->count();
+        $this->assertEquals(1, $count);
+        DB::rollBack();
+
+        $count = DB::collection('users')->count();
+        $this->assertEquals(0, $count);
+
+        /** commit test */
+        DB::beginTransaction();
+        $count = DB::collection('users')->count();
+        $this->assertEquals(0, $count);
+        DB::collection('users')->insert(['name' => 'klinson', 'age' => 20, 'title' => 'admin']);
+        $count = DB::collection('users')->count();
+        $this->assertEquals(1, $count);
+        DB::commit();
+
+        $count = DB::collection('users')->count();
+        $this->assertEquals(1, $count);
+    }
+
+    public function testTransaction(): void
+    {
+        User::create(['name' => 'klinson', 'age' => 20, 'title' => 'admin']);
+
+        DB::transaction(function (): void {
+            User::create(['name' => 'alcaeus', 'age' => 38, 'title' => 'admin']);
+            User::where(['name' => 'klinson'])->update(['age' => 21]);
+        });
+
+        $count = User::count();
+        $this->assertEquals(2, $count);
+
+        $this->assertTrue(User::where('alcaeus')->exists());
+        $this->assertTrue(User::where(['name' => 'klinson'])->where('age', 21)->exists());
+    }
+
+    public function testTransactionRepeatsOnTransientFailure(): void
+    {
+        User::create(['name' => 'klinson', 'age' => 20, 'title' => 'admin']);
+
+        $timesRun = 0;
+
+        DB::transaction(function () use (&$timesRun): void {
+            User::where(['name' => 'klinson'])->update(['age' => 21]);
+
+            // Update user during transaction to simulate a simultaneous update
+            if ($timesRun == 0) {
+                DB::getCollection('users')->updateOne(['name' => 'klinson'], ['$set' => ['age' => 22]]);
+            }
+
+            $timesRun++;
+        }, 2);
+
+        $this->assertSame(2, $timesRun);
+        $this->assertTrue(User::where(['name' => 'klinson'])->where('age', 21)->exists());
+    }
+
+    public function testTransactionRespectsRepetitionLimit(): void
+    {
+        $klinson = User::create(['name' => 'klinson', 'age' => 20, 'title' => 'admin']);
+
+        $timesRun = 0;
+
+        DB::transaction(function () use (&$timesRun): void {
+            User::where(['name' => 'klinson'])->update(['age' => 21]);
+
+            // Update user during transaction to simulate a simultaneous update
+            DB::getCollection('users')->updateOne(['name' => 'klinson'], ['$inc' => ['age' => 2]]);
+
+            $timesRun++;
+        }, 2);
+
+        $this->assertSame(2, $timesRun);
+
+        $check = User::find($klinson->_id);
+        $this->assertInstanceOf(User::class, $check);
+
+        // Age is expected to be 24: the callback is executed twice, incrementing age by 2 every time
+        $this->assertSame(24, $check->age);
+    }
+
+    public function testTransactionReturnsCallbackResult(): void
+    {
+        $result = DB::transaction(function (): User {
+            return User::create(['name' => 'klinson', 'age' => 20, 'title' => 'admin']);
+        });
+
+        $this->assertInstanceOf(User::class, $result);
+        $this->assertEquals($result->title, 'admin');
+        $this->assertSame(1, User::count());
+    }
+
+    public function testNestedTransactionsCauseException(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Transaction already in progress');
+
+        DB::beginTransaction();
+        DB::beginTransaction();
+        DB::commit();
+        DB::rollBack();
+    }
+
+    public function testNestingTransactionInManualTransaction()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Transaction already in progress');
+
+        DB::beginTransaction();
+        DB::transaction(function (): void {
+        });
+        DB::rollBack();
+    }
+
+    public function testCommitWithoutSession(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('There is no active session.');
+
+        DB::commit();
+    }
+
+    public function testRollBackWithoutSession(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('There is no active session.');
+
+        DB::rollback();
+    }
+
+    private function getPrimaryServerType(): int
+    {
+        return DB::getMongoClient()->getManager()->selectServer(new ReadPreference(ReadPreference::RP_PRIMARY))->getType();
+    }
+}

--- a/tests/config/database.php
+++ b/tests/config/database.php
@@ -6,7 +6,7 @@ return [
             'name' => 'mongodb',
             'driver' => 'mongodb',
             'dsn' => env('MONGODB_URI', 'mongodb://127.0.0.1/'),
-            'database' => env('MONGO_DATABASE', 'unittest'),
+            'database' => env('MONGODB_DATABASE', 'unittest'),
             'options' => [
                 'connectTimeoutMS'         => 100,
                 'serverSelectionTimeoutMS' => 250,

--- a/tests/config/database.php
+++ b/tests/config/database.php
@@ -7,6 +7,10 @@ return [
             'driver' => 'mongodb',
             'dsn' => env('MONGODB_URI', 'mongodb://127.0.0.1/'),
             'database' => env('MONGO_DATABASE', 'unittest'),
+            'options' => [
+                'connectTimeoutMS'         => 100,
+                'serverSelectionTimeoutMS' => 250,
+            ],
         ],
 
         'mysql' => [

--- a/tests/config/queue.php
+++ b/tests/config/queue.php
@@ -16,7 +16,7 @@ return [
     ],
 
     'failed' => [
-        'database' => env('MONGO_DATABASE'),
+        'database' => env('MONGODB_DATABASE'),
         'driver' => 'mongodb',
         'table' => 'failed_jobs',
     ],


### PR DESCRIPTION
Note: contains changes from #2462 folded into a single commit; I'd prefer merging that PR before taking on this one.

This takes the work started by @klinson in #1904 and addresses some of the feedback left in that PR:

* Transactions can't be nested. This was done as MongoDB itself can't nest transactions. Running transactions in parallel instead of nested changes the outcome of nested operations that are partially rolled back, so this is a can of worms we better not open.
* Session options are no longer hard coded. Users can specify them when calling `DB::beginTransaction` or `DB::transaction` if they need to.
* The `DB::transaction` method will respect the `$attempts` argument and not invoke the callback more often, but may also abort before invoking the callback the specified number of times. This is due to the comparable logic in the MongoDB driver aborting after two minutes. I believe this is preferable to retrying for longer, especially in a web context (where two minutes is already quite long).

Note that I have not touched the docker-compose logic. Transaction tests are skipped unless run against a deployment that supports them, and I don't think it's necessary to set up a local cluster for quick tests. People who need to debug transaction tests locally should set up their own deployment and change the connection URL via the `MONGODB_URI` environment variable when running tests.

This PR was made possible by the contributions of @klinson and @levon80999 who've worked on this in the past. Commits retain co-authorship to reflect this.