### PR TITLE
Support for search query to have \ as the last character in a LIKE clause

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -1043,7 +1043,7 @@ class Builder extends BaseBuilder
             }
 
             // Convert to regular expression.
-            $regex = preg_replace('#(^|[^\\\])%#', '$1.*', preg_quote($value));
+            $regex = preg_replace('#(^|[^\\\]|.(?=(%$)))%#', '$1.*', preg_quote($value));
 
             // Convert like to regular expression.
             if (! Str::startsWith($value, '%')) {


### PR DESCRIPTION
updated regex on query builder to support a search query with \ as last characters inside LIKE clause where search query is wrapped with %

Understood the alternator used here is to avoid replacing escaped %. So added another alternator that replaces any character that is immediately followed by a % and end of string. so the backslashes in the middle of the search query is left untouched as before.

Fixes https://github.com/jenssegers/laravel-mongodb/issues/2458 and https://github.com/jenssegers/laravel-mongodb/issues/2475