### PR TITLE
This trait will provide you correct implementation of Laravel/Sanctum…

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,18 @@ class User extends Model
 
 For more information check [Laravel Docs about Soft Deleting](http://laravel.com/docs/eloquent#soft-deleting).
 
+### [Laravel Sanctum](https://laravel.com/docs/9.x/sanctum)
+This trait will provide you correct implementation of Sanctum with this package. If your model is already using the `Laravel\Sanctum\HasApiTokens` trait, you may replace it with this `Jenssegers\Mongodb\Sanctum\HasApiTokens`
+
+```php
+use Jenssegers\Mongodb\Sanctum\HasApiTokens;
+
+class User
+{
+    use HasApiTokens;
+}
+```
+
 ### Guarding attributes
 
 When choosing between guarding attributes or marking some as fillable, Taylor Otwell prefers the fillable route.

--- a/README.md
+++ b/README.md
@@ -270,6 +270,21 @@ class User
     use HasApiTokens;
 }
 ```
+And then you have to set This package PersonalAccessToken as default to Sanctum in `AuthServiceProvider`
+```php
+use Laravel\Sanctum\Sanctum;
+use Jenssegers\Mongodb\Sanctum\PersonalAccessToken;
+//...
+
+class AuthServiceProvider extends ServiceProvider
+{
+    public function boot()
+    {
+        //...
+        Sanctum::usePersonalAccessTokenModel(PersonalAccessToken::class);
+    }
+}
+```
 
 ### Guarding attributes
 

--- a/src/Sanctum/Contracts/HasAbilities.php
+++ b/src/Sanctum/Contracts/HasAbilities.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Jenssegers\Mongodb\Sanctum\Contracts;
+
+interface HasAbilities
+{
+    /**
+     * Determine if the token has a given ability.
+     *
+     * @param string $ability
+     * @return bool
+     */
+    public function can($ability);
+
+    /**
+     * Determine if the token is missing a given ability.
+     *
+     * @param string $ability
+     * @return bool
+     */
+    public function cant($ability);
+}

--- a/src/Sanctum/HasApiTokens.php
+++ b/src/Sanctum/HasApiTokens.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Jenssegers\Mongodb\Sanctum;
+
+use Illuminate\Support\Str;
+use Jenssegers\Mongodb\Sanctum\Contracts\HasAbilities;
+
+trait HasApiTokens
+{
+    /**
+     * The access token the user is using for the current request.
+     *
+     * @var HasAbilities
+     */
+    protected $accessToken;
+
+    /**
+     * Get the access tokens that belong to model.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\MorphMany
+     */
+    public function tokens()
+    {
+        return $this->morphMany(PersonalAccessToken::class, 'tokenable');
+    }
+
+    /**
+     * Determine if the current API token has a given scope.
+     *
+     * @param string $ability
+     * @return bool
+     */
+    public function tokenCan(string $ability)
+    {
+        return $this->accessToken && $this->accessToken->can($ability);
+    }
+
+    /**
+     * Create a new personal access token for the user.
+     *
+     * @param string $name
+     * @param array $abilities
+     * @return NewAccessToken
+     */
+    public function createToken(string $name, array $abilities = ['*'])
+    {
+        $token = $this->tokens()->create([
+            'name' => $name,
+            'token' => hash('sha256', $plainTextToken = Str::random(40)),
+            'abilities' => $abilities,
+        ]);
+
+        return new NewAccessToken($token, $token->getKey() . '|' . $plainTextToken);
+    }
+
+    /**
+     * Get the access token currently associated with the user.
+     *
+     * @return HasAbilities
+     */
+    public function currentAccessToken()
+    {
+        return $this->accessToken;
+    }
+
+    /**
+     * Set the current access token for the user.
+     *
+     * @param HasAbilities $accessToken
+     * @return $this
+     */
+    public function withAccessToken($accessToken)
+    {
+        $this->accessToken = $accessToken;
+
+        return $this;
+    }
+}

--- a/src/Sanctum/NewAccessToken.php
+++ b/src/Sanctum/NewAccessToken.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Jenssegers\Mongodb\Sanctum;
+
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Support\Jsonable;
+
+class NewAccessToken implements Arrayable, Jsonable
+{
+    /**
+     * The access token instance.
+     *
+     * @var PersonalAccessToken
+     */
+    public $accessToken;
+
+    /**
+     * The plain text version of the token.
+     *
+     * @var string
+     */
+    public $plainTextToken;
+
+    /**
+     * Create a new access token result.
+     *
+     * @param PersonalAccessToken $accessToken
+     * @param string $plainTextToken
+     * @return void
+     */
+    public function __construct(PersonalAccessToken $accessToken, string $plainTextToken)
+    {
+        $this->accessToken = $accessToken;
+        $this->plainTextToken = $plainTextToken;
+    }
+
+    /**
+     * Get the instance as an array.
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return [
+            'accessToken' => $this->accessToken,
+            'plainTextToken' => $this->plainTextToken,
+        ];
+    }
+
+    /**
+     * Convert the object to its JSON representation.
+     *
+     * @param int $options
+     * @return string
+     */
+    public function toJson($options = 0)
+    {
+        return json_encode($this->toArray(), $options);
+    }
+}

--- a/src/Sanctum/PersonalAccessToken.php
+++ b/src/Sanctum/PersonalAccessToken.php
@@ -55,6 +55,10 @@ class PersonalAccessToken extends Model implements HasAbilities
      */
     public static function findToken($token)
     {
+        if (stripos($token, 'bearer ') === 0) {
+            $token = trim(substr($token, strlen('bearer ')));
+        }
+
         if (strpos($token, '|') === false) {
             return static::where('token', hash('sha256', $token))->first();
         }

--- a/src/Sanctum/PersonalAccessToken.php
+++ b/src/Sanctum/PersonalAccessToken.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Jenssegers\Mongodb\Sanctum;
+
+use Jenssegers\Mongodb\Eloquent\Model;
+use Jenssegers\Mongodb\Sanctum\Contracts\HasAbilities;
+
+class PersonalAccessToken extends Model implements HasAbilities
+{
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'abilities' => 'json',
+        'last_used_at' => 'datetime',
+    ];
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'name',
+        'token',
+        'abilities',
+    ];
+
+    /**
+     * The attributes that should be hidden for serialization.
+     *
+     * @var array
+     */
+    protected $hidden = [
+        'token',
+    ];
+
+    /**
+     * Get the tokenable model that the access token belongs to.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\MorphTo
+     */
+    public function tokenable()
+    {
+        return $this->morphTo('tokenable');
+    }
+
+    /**
+     * Find the token instance matching the given token.
+     *
+     * @param string $token
+     * @return static|null
+     */
+    public static function findToken($token)
+    {
+        if (strpos($token, '|') === false) {
+            return static::where('token', hash('sha256', $token))->first();
+        }
+
+        [$id, $token] = explode('|', $token, 2);
+
+        if ($instance = static::find($id)) {
+            return hash_equals($instance->token, hash('sha256', $token)) ? $instance : null;
+        }
+    }
+
+    /**
+     * Determine if the token has a given ability.
+     *
+     * @param string $ability
+     * @return bool
+     */
+    public function can($ability)
+    {
+        return in_array('*', $this->abilities) ||
+            array_key_exists($ability, array_flip($this->abilities));
+    }
+
+    /**
+     * Determine if the token is missing a given ability.
+     *
+     * @param string $ability
+     * @return bool
+     */
+    public function cant($ability)
+    {
+        return !$this->can($ability);
+    }
+}


### PR DESCRIPTION
Fix issues #2233

This commit aims to fix: **Call to a member function prepare() on null** when using on [Laravel/Sanctum](https://github.com/Laravel/Sanctum).
Which occurs when calling `createToken` function.

So, to fix the issue, use `Jenssegers\Mongodb\Sanctum\HasApiTokens` rather than `Laravel\Sanctum\HasApiTokens`:
```php
use Jenssegers\Mongodb\Sanctum\HasApiTokens;

class User
{
    use HasApiTokens;
}
```

And then change default personal token to this package by `AuthServiceProvider`:

```php
use Laravel\Sanctum\Sanctum;
use Jenssegers\Mongodb\Sanctum\PersonalAccessToken;
//...

class AuthServiceProvider extends ServiceProvider
{
    public function boot()
    {
        //...
        Sanctum::usePersonalAccessTokenModel(PersonalAccessToken::class);
    }
}
```