### PR TITLE
fix: morphTo when relation name is in camel case

### DIFF
--- a/src/Eloquent/HybridRelations.php
+++ b/src/Eloquent/HybridRelations.php
@@ -180,10 +180,10 @@ trait HybridRelations
         if ($name === null) {
             [$current, $caller] = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2);
 
-            $name = Str::snake($caller['function']);
+            $name = $caller['function'];
         }
 
-        [$type, $id] = $this->getMorphs($name, $type, $id);
+        [$type, $id] = $this->getMorphs(Str::snake($name), $type, $id);
 
         // If the type value is null it is probably safe to assume we're eager loading
         // the relationship. When that is the case we will pass in a dummy query as

--- a/tests/RelationsTest.php
+++ b/tests/RelationsTest.php
@@ -370,21 +370,21 @@ class RelationsTest extends TestCase
         $this->assertEquals($photo->id, $client->photo->id);
 
         $photo = Photo::first();
-        $this->assertEquals($photo->imageable->name, $user->name);
+        $this->assertEquals($photo->hasImage->name, $user->name);
 
         $user = User::with('photos')->find($user->_id);
         $relations = $user->getRelations();
         $this->assertArrayHasKey('photos', $relations);
         $this->assertEquals(1, $relations['photos']->count());
 
-        $photos = Photo::with('imageable')->get();
+        $photos = Photo::with('hasImage')->get();
         $relations = $photos[0]->getRelations();
-        $this->assertArrayHasKey('imageable', $relations);
-        $this->assertInstanceOf(User::class, $photos[0]->imageable);
+        $this->assertArrayHasKey('hasImage', $relations);
+        $this->assertInstanceOf(User::class, $photos[0]->hasImage);
 
         $relations = $photos[1]->getRelations();
-        $this->assertArrayHasKey('imageable', $relations);
-        $this->assertInstanceOf(Client::class, $photos[1]->imageable);
+        $this->assertArrayHasKey('hasImage', $relations);
+        $this->assertInstanceOf(Client::class, $photos[1]->hasImage);
     }
 
     public function testHasManyHas(): void

--- a/tests/models/Client.php
+++ b/tests/models/Client.php
@@ -20,7 +20,7 @@ class Client extends Eloquent
 
     public function photo(): MorphOne
     {
-        return $this->morphOne('Photo', 'imageable');
+        return $this->morphOne('Photo', 'has_image');
     }
 
     public function addresses(): HasMany

--- a/tests/models/Photo.php
+++ b/tests/models/Photo.php
@@ -11,7 +11,7 @@ class Photo extends Eloquent
     protected $collection = 'photos';
     protected static $unguarded = true;
 
-    public function imageable(): MorphTo
+    public function hasImage(): MorphTo
     {
         return $this->morphTo();
     }

--- a/tests/models/User.php
+++ b/tests/models/User.php
@@ -73,7 +73,7 @@ class User extends Eloquent implements AuthenticatableContract, CanResetPassword
 
     public function photos()
     {
-        return $this->morphMany('Photo', 'imageable');
+        return $this->morphMany('Photo', 'has_image');
     }
 
     public function addresses()


### PR DESCRIPTION
Recreating #2318 as I don't have permission to resolve merge conflicts.