### PR TITLE
Laravel 10 compatibility

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -41,7 +41,6 @@ jobs:
                     - '4.4'
                     - '5.0'
                 php:
-                    - '8.0'
                     - '8.1'
         services:
             mysql:

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -14,10 +14,10 @@ jobs:
         strategy:
             matrix:
                 php:
-                    - '8.0'
+                    - '8.1'
         steps:
             -   name: Checkout
-                uses: actions/checkout@v2
+                uses: actions/checkout@v3
             -   name: Setup PHP
                 uses: shivammathur/setup-php@v2
                 with:
@@ -42,6 +42,7 @@ jobs:
                     - '5.0'
                 php:
                     - '8.1'
+                    - '8.2'
         services:
             mysql:
                 image: mysql:5.7
@@ -53,7 +54,7 @@ jobs:
                     MYSQL_ROOT_PASSWORD:
 
         steps:
-            -   uses: actions/checkout@v2
+            -   uses: actions/checkout@v3
             -   name: Create MongoDB Replica Set
                 run: |
                     docker run --name mongodb -p 27017:27017 -e MONGO_INITDB_DATABASE=unittest --detach mongo:${{ matrix.mongodb }} mongod --replSet rs --setParameter transactionLifetimeLimitSeconds=5

--- a/README.md
+++ b/README.md
@@ -256,8 +256,6 @@ use Jenssegers\Mongodb\Eloquent\SoftDeletes;
 class User extends Model
 {
     use SoftDeletes;
-
-    protected $dates = ['deleted_at'];
 }
 ```
 
@@ -279,7 +277,7 @@ use Jenssegers\Mongodb\Eloquent\Model;
 
 class User extends Model
 {
-    protected $dates = ['birthday'];
+    protected $casts = ['birthday' => 'datetime'];
 }
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -19,17 +19,17 @@
     ],
     "license": "MIT",
     "require": {
-        "illuminate/support": "^9.0",
-        "illuminate/container": "^9.0",
-        "illuminate/database": "^9.0",
-        "illuminate/events": "^9.0",
-        "mongodb/mongodb": "^1.11"
+        "illuminate/support": "^10.0",
+        "illuminate/container": "^10.0",
+        "illuminate/database": "^10.0",
+        "illuminate/events": "^10.0",
+        "mongodb/mongodb": "^1.15"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5.8",
-        "orchestra/testbench": "^7.0",
-        "mockery/mockery": "^1.3.1",
-        "doctrine/dbal": "^2.13.3|^3.1.4"
+        "phpunit/phpunit": "^9.5.10",
+        "orchestra/testbench": "^8.0",
+        "mockery/mockery": "^1.4.4",
+        "doctrine/dbal": "^3.5"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -54,5 +54,6 @@
                 "Jenssegers\\Mongodb\\MongodbQueueServiceProvider"
             ]
         }
-    }
+    },
+    "minimum-stability": "dev"
 }

--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,7 @@
     "require-dev": {
         "phpunit/phpunit": "^9.5.10",
         "orchestra/testbench": "^8.0",
-        "mockery/mockery": "^1.4.4",
-        "doctrine/dbal": "^3.5"
+        "mockery/mockery": "^1.4.4"
     },
     "autoload": {
         "psr-4": {

--- a/src/Auth/PasswordBrokerManager.php
+++ b/src/Auth/PasswordBrokerManager.php
@@ -16,7 +16,8 @@ class PasswordBrokerManager extends BasePasswordBrokerManager
             $this->app['hash'],
             $config['table'],
             $this->app['config']['app.key'],
-            $config['expire']
+            $config['expire'],
+            $config['throttle'] ?? 0
         );
     }
 }

--- a/src/Auth/PasswordResetServiceProvider.php
+++ b/src/Auth/PasswordResetServiceProvider.php
@@ -7,29 +7,6 @@ use Illuminate\Auth\Passwords\PasswordResetServiceProvider as BasePasswordResetS
 class PasswordResetServiceProvider extends BasePasswordResetServiceProvider
 {
     /**
-     * Register the token repository implementation.
-     *
-     * @return void
-     */
-    protected function registerTokenRepository()
-    {
-        $this->app->singleton('auth.password.tokens', function ($app) {
-            $connection = $app['db']->connection();
-
-            // The database token repository is an implementation of the token repository
-            // interface, and is responsible for the actual storing of auth tokens and
-            // their e-mail addresses. We will inject this table and hash key to it.
-            $table = $app['config']['auth.password.table'];
-
-            $key = $app['config']['app.key'];
-
-            $expire = $app['config']->get('auth.password.expire', 60);
-
-            return new DatabaseTokenRepository($connection, $table, $key, $expire);
-        });
-    }
-
-    /**
      * @inheritdoc
      */
     protected function registerPasswordBroker()

--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -187,7 +187,7 @@ abstract class Model extends BaseModel
     /**
      * @inheritdoc
      */
-    public function setAttribute($key, $value)
+    public function setAttribute($key, $value): static
     {
         // Convert _id to ObjectID.
         if ($key == '_id' && is_string($value)) {
@@ -516,13 +516,9 @@ abstract class Model extends BaseModel
     }
 
     /**
-     * Add the casted attributes to the attributes array.
-     *
-     * @param  array  $attributes
-     * @param  array  $mutatedAttributes
-     * @return array
+     * @inheritdoc
      */
-    protected function addCastAttributesToArray(array $attributes, array $mutatedAttributes)
+    protected function addCastAttributesToArray(array $attributes, array $mutatedAttributes): array
     {
         foreach ($this->getCasts() as $key => $castType) {
             if (! Arr::has($attributes, $key) || Arr::has($mutatedAttributes, $key)) {

--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -2,18 +2,23 @@
 
 namespace Jenssegers\Mongodb\Eloquent;
 
+use function array_key_exists;
 use DateTimeInterface;
+use function explode;
 use Illuminate\Contracts\Queue\QueueableCollection;
 use Illuminate\Contracts\Queue\QueueableEntity;
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Model as BaseModel;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Str;
+use function in_array;
 use Jenssegers\Mongodb\Query\Builder as QueryBuilder;
 use MongoDB\BSON\Binary;
 use MongoDB\BSON\ObjectID;
 use MongoDB\BSON\UTCDateTime;
+use function uniqid;
 
 abstract class Model extends BaseModel
 {
@@ -94,7 +99,7 @@ abstract class Model extends BaseModel
             $value = parent::asDateTime($value);
         }
 
-        return new UTCDateTime($value->format('Uv'));
+        return new UTCDateTime($value);
     }
 
     /**
@@ -191,13 +196,14 @@ abstract class Model extends BaseModel
             $value = $builder->convertKey($value);
         } // Support keys in dot notation.
         elseif (Str::contains($key, '.')) {
-            if (in_array($key, $this->getDates()) && $value) {
-                $value = $this->fromDateTime($value);
-            }
+            // Store to a temporary key, then move data to the actual key
+            $uniqueKey = uniqid($key);
+            parent::setAttribute($uniqueKey, $value);
 
-            Arr::set($this->attributes, $key, $value);
+            Arr::set($this->attributes, $key, $this->attributes[$uniqueKey] ?? null);
+            unset($this->attributes[$uniqueKey]);
 
-            return;
+            return $this;
         }
 
         return parent::setAttribute($key, $value);
@@ -219,13 +225,6 @@ abstract class Model extends BaseModel
                 $value = (string) $value;
             } elseif ($value instanceof Binary) {
                 $value = (string) $value->getData();
-            }
-        }
-
-        // Convert dot-notation dates.
-        foreach ($this->getDates() as $key) {
-            if (Str::contains($key, '.') && Arr::has($attributes, $key)) {
-                Arr::set($attributes, $key, (string) $this->asDateTime(Arr::get($attributes, $key)));
             }
         }
 
@@ -514,5 +513,63 @@ abstract class Model extends BaseModel
         }
 
         return parent::__call($method, $parameters);
+    }
+
+    /**
+     * Add the casted attributes to the attributes array.
+     *
+     * @param  array  $attributes
+     * @param  array  $mutatedAttributes
+     * @return array
+     */
+    protected function addCastAttributesToArray(array $attributes, array $mutatedAttributes)
+    {
+        foreach ($this->getCasts() as $key => $castType) {
+            if (! Arr::has($attributes, $key) || Arr::has($mutatedAttributes, $key)) {
+                continue;
+            }
+
+            $originalValue = Arr::get($attributes, $key);
+
+            // Here we will cast the attribute. Then, if the cast is a date or datetime cast
+            // then we will serialize the date for the array. This will convert the dates
+            // to strings based on the date format specified for these Eloquent models.
+            $castValue = $this->castAttribute(
+                $key, $originalValue
+            );
+
+            // If the attribute cast was a date or a datetime, we will serialize the date as
+            // a string. This allows the developers to customize how dates are serialized
+            // into an array without affecting how they are persisted into the storage.
+            if ($castValue !== null && in_array($castType, ['date', 'datetime', 'immutable_date', 'immutable_datetime'])) {
+                $castValue = $this->serializeDate($castValue);
+            }
+
+            if ($castValue !== null && ($this->isCustomDateTimeCast($castType) ||
+                    $this->isImmutableCustomDateTimeCast($castType))) {
+                $castValue = $castValue->format(explode(':', $castType, 2)[1]);
+            }
+
+            if ($castValue instanceof DateTimeInterface &&
+                $this->isClassCastable($key)) {
+                $castValue = $this->serializeDate($castValue);
+            }
+
+            if ($castValue !== null && $this->isClassSerializable($key)) {
+                $castValue = $this->serializeClassCastableAttribute($key, $castValue);
+            }
+
+            if ($this->isEnumCastable($key) && (! $castValue instanceof Arrayable)) {
+                $castValue = $castValue !== null ? $this->getStorableEnumValue($attributes[$key]) : null;
+            }
+
+            if ($castValue instanceof Arrayable) {
+                $castValue = $castValue->toArray();
+            }
+
+            Arr::set($attributes, $key, $castValue);
+        }
+
+        return $attributes;
     }
 }

--- a/src/Relations/EmbedsMany.php
+++ b/src/Relations/EmbedsMany.php
@@ -52,7 +52,7 @@ class EmbedsMany extends EmbedsOneOrMany
         }
 
         // Push the new model to the database.
-        $result = $this->getBaseQuery()->push($this->localKey, $model->getAttributes(), true);
+        $result = $this->toBase()->push($this->localKey, $model->getAttributes(), true);
 
         // Attach the model to its parent.
         if ($result) {
@@ -83,7 +83,7 @@ class EmbedsMany extends EmbedsOneOrMany
         $values = $this->getUpdateValues($model->getDirty(), $this->localKey.'.$.');
 
         // Update document in database.
-        $result = $this->getBaseQuery()->where($this->localKey.'.'.$model->getKeyName(), $foreignKey)
+        $result = $this->toBase()->where($this->localKey.'.'.$model->getKeyName(), $foreignKey)
             ->update($values);
 
         // Attach the model to its parent.
@@ -112,7 +112,7 @@ class EmbedsMany extends EmbedsOneOrMany
         // Get the correct foreign key value.
         $foreignKey = $this->getForeignKeyValue($model);
 
-        $result = $this->getBaseQuery()->pull($this->localKey, [$model->getKeyName() => $foreignKey]);
+        $result = $this->toBase()->pull($this->localKey, [$model->getKeyName() => $foreignKey]);
 
         if ($result) {
             $this->dissociate($model);

--- a/src/Relations/EmbedsOne.php
+++ b/src/Relations/EmbedsOne.php
@@ -33,7 +33,7 @@ class EmbedsOne extends EmbedsOneOrMany
     /**
      * Save a new model and attach it to the parent model.
      *
-     * @param Model $model
+     * @param  Model  $model
      * @return Model|bool
      */
     public function performInsert(Model $model)
@@ -63,7 +63,7 @@ class EmbedsOne extends EmbedsOneOrMany
     /**
      * Save an existing model and attach it to the parent model.
      *
-     * @param Model $model
+     * @param  Model  $model
      * @return Model|bool
      */
     public function performUpdate(Model $model)
@@ -114,7 +114,7 @@ class EmbedsOne extends EmbedsOneOrMany
     /**
      * Attach the model to its parent.
      *
-     * @param Model $model
+     * @param  Model  $model
      * @return Model
      */
     public function associate(Model $model)
@@ -145,8 +145,8 @@ class EmbedsOne extends EmbedsOneOrMany
     /**
      * Get the name of the "where in" method for eager loading.
      *
-     * @param \Illuminate\Database\Eloquent\Model $model
-     * @param string $key
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
      * @return string
      */
     protected function whereInMethod(EloquentModel $model, $key)

--- a/src/Relations/EmbedsOne.php
+++ b/src/Relations/EmbedsOne.php
@@ -50,7 +50,7 @@ class EmbedsOne extends EmbedsOneOrMany
             return $this->parent->save() ? $model : false;
         }
 
-        $result = $this->getBaseQuery()->update([$this->localKey => $model->getAttributes()]);
+        $result = $this->toBase()->update([$this->localKey => $model->getAttributes()]);
 
         // Attach the model to its parent.
         if ($result) {
@@ -76,7 +76,7 @@ class EmbedsOne extends EmbedsOneOrMany
 
         $values = $this->getUpdateValues($model->getDirty(), $this->localKey.'.');
 
-        $result = $this->getBaseQuery()->update($values);
+        $result = $this->toBase()->update($values);
 
         // Attach the model to its parent.
         if ($result) {
@@ -101,7 +101,7 @@ class EmbedsOne extends EmbedsOneOrMany
         }
 
         // Overwrite the local key with an empty array.
-        $result = $this->getBaseQuery()->update([$this->localKey => null]);
+        $result = $this->toBase()->update([$this->localKey => null]);
 
         // Detach the model from its parent.
         if ($result) {

--- a/src/Relations/EmbedsOneOrMany.php
+++ b/src/Relations/EmbedsOneOrMany.php
@@ -34,12 +34,12 @@ abstract class EmbedsOneOrMany extends Relation
     /**
      * Create a new embeds many relationship instance.
      *
-     * @param Builder $query
-     * @param Model $parent
-     * @param Model $related
-     * @param string $localKey
-     * @param string $foreignKey
-     * @param string $relation
+     * @param  Builder  $query
+     * @param  Model  $parent
+     * @param  Model  $related
+     * @param  string  $localKey
+     * @param  string  $foreignKey
+     * @param  string  $relation
      */
     public function __construct(Builder $query, Model $parent, Model $related, $localKey, $foreignKey, $relation)
     {
@@ -95,7 +95,7 @@ abstract class EmbedsOneOrMany extends Relation
     /**
      * Shorthand to get the results of the relationship.
      *
-     * @param array $columns
+     * @param  array  $columns
      * @return Collection
      */
     public function get($columns = ['*'])
@@ -116,7 +116,7 @@ abstract class EmbedsOneOrMany extends Relation
     /**
      * Attach a model instance to the parent model.
      *
-     * @param Model $model
+     * @param  Model  $model
      * @return Model|bool
      */
     public function save(Model $model)
@@ -129,7 +129,7 @@ abstract class EmbedsOneOrMany extends Relation
     /**
      * Attach a collection of models to the parent instance.
      *
-     * @param Collection|array $models
+     * @param  Collection|array  $models
      * @return Collection|array
      */
     public function saveMany($models)
@@ -144,7 +144,7 @@ abstract class EmbedsOneOrMany extends Relation
     /**
      * Create a new instance of the related model.
      *
-     * @param array $attributes
+     * @param  array  $attributes
      * @return Model
      */
     public function create(array $attributes = [])
@@ -164,7 +164,7 @@ abstract class EmbedsOneOrMany extends Relation
     /**
      * Create an array of new instances of the related model.
      *
-     * @param array $records
+     * @param  array  $records
      * @return array
      */
     public function createMany(array $records)
@@ -181,7 +181,7 @@ abstract class EmbedsOneOrMany extends Relation
     /**
      * Transform single ID, single Model or array of Models into an array of IDs.
      *
-     * @param mixed $ids
+     * @param  mixed  $ids
      * @return array
      */
     protected function getIdsArrayFrom($ids)
@@ -236,7 +236,7 @@ abstract class EmbedsOneOrMany extends Relation
     /**
      * Get the foreign key value for the relation.
      *
-     * @param mixed $id
+     * @param  mixed  $id
      * @return mixed
      */
     protected function getForeignKeyValue($id)
@@ -252,7 +252,7 @@ abstract class EmbedsOneOrMany extends Relation
     /**
      * Convert an array of records to a Collection.
      *
-     * @param array $records
+     * @param  array  $records
      * @return Collection
      */
     protected function toCollection(array $records = [])
@@ -273,7 +273,7 @@ abstract class EmbedsOneOrMany extends Relation
     /**
      * Create a related model instanced.
      *
-     * @param array $attributes
+     * @param  array  $attributes
      * @return Model
      */
     protected function toModel($attributes = [])
@@ -342,7 +342,7 @@ abstract class EmbedsOneOrMany extends Relation
     /**
      * Get the fully qualified local key name.
      *
-     * @param string $glue
+     * @param  string  $glue
      * @return string
      */
     protected function getPathHierarchy($glue = '.')
@@ -380,7 +380,7 @@ abstract class EmbedsOneOrMany extends Relation
      * Return update values.
      *
      * @param $array
-     * @param string $prepend
+     * @param  string  $prepend
      * @return array
      */
     public static function getUpdateValues($array, $prepend = '')
@@ -407,8 +407,8 @@ abstract class EmbedsOneOrMany extends Relation
     /**
      * Get the name of the "where in" method for eager loading.
      *
-     * @param \Illuminate\Database\Eloquent\Model $model
-     * @param string $key
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
      * @return string
      */
     protected function whereInMethod(EloquentModel $model, $key)

--- a/src/Relations/EmbedsOneOrMany.php
+++ b/src/Relations/EmbedsOneOrMany.php
@@ -246,7 +246,7 @@ abstract class EmbedsOneOrMany extends Relation
         }
 
         // Convert the id to MongoId if necessary.
-        return $this->getBaseQuery()->convertKey($id);
+        return $this->toBase()->convertKey($id);
     }
 
     /**
@@ -322,7 +322,7 @@ abstract class EmbedsOneOrMany extends Relation
     /**
      * @inheritdoc
      */
-    public function getBaseQuery()
+    public function toBase()
     {
         // Because we are sharing this relation instance to models, we need
         // to make sure we use separate query instances.

--- a/tests/AuthTest.php
+++ b/tests/AuthTest.php
@@ -1,7 +1,6 @@
 <?php
 
 use Illuminate\Auth\Passwords\PasswordBroker;
-use Illuminate\Foundation\Application;
 use MongoDB\BSON\UTCDateTime;
 
 class AuthTest extends TestCase
@@ -10,55 +9,56 @@ class AuthTest extends TestCase
     {
         parent::setUp();
         User::truncate();
-        DB::collection('password_reminders')->truncate();
+        DB::collection('password_reset_tokens')->truncate();
     }
 
     public function testAuthAttempt()
     {
         User::create([
             'name' => 'John Doe',
-            'email' => 'john@doe.com',
+            'email' => 'john.doe@example.com',
             'password' => Hash::make('foobar'),
         ]);
 
-        $this->assertTrue(Auth::attempt(['email' => 'john@doe.com', 'password' => 'foobar'], true));
+        $this->assertTrue(Auth::attempt(['email' => 'john.doe@example.com', 'password' => 'foobar'], true));
         $this->assertTrue(Auth::check());
     }
 
     public function testRemindOld()
     {
-        if (Application::VERSION >= '5.2') {
-            $this->expectNotToPerformAssertions();
-
-            return;
-        }
-
-        $mailer = Mockery::mock('Illuminate\Mail\Mailer');
-        $tokens = $this->app->make('auth.password.tokens');
-        $users = $this->app['auth']->driver()->getProvider();
-
-        $broker = new PasswordBroker($tokens, $users, $mailer, '');
+        $broker = $this->app->make('auth.password.broker');
 
         $user = User::create([
             'name' => 'John Doe',
-            'email' => 'john@doe.com',
+            'email' => 'john.doe@example.com',
             'password' => Hash::make('foobar'),
         ]);
 
-        $mailer->shouldReceive('send')->once();
-        $broker->sendResetLink(['email' => 'john@doe.com']);
+        $token = null;
 
-        $this->assertEquals(1, DB::collection('password_resets')->count());
-        $reminder = DB::collection('password_resets')->first();
-        $this->assertEquals('john@doe.com', $reminder['email']);
+        $this->assertSame(
+            PasswordBroker::RESET_LINK_SENT,
+            $broker->sendResetLink(
+                ['email' => 'john.doe@example.com'],
+                function ($actualUser, $actualToken) use ($user, &$token) {
+                    $this->assertEquals($user->_id, $actualUser->_id);
+                    // Store token for later use
+                    $token = $actualToken;
+                }
+            )
+        );
+
+        $this->assertEquals(1, DB::collection('password_reset_tokens')->count());
+        $reminder = DB::collection('password_reset_tokens')->first();
+        $this->assertEquals('john.doe@example.com', $reminder['email']);
         $this->assertNotNull($reminder['token']);
         $this->assertInstanceOf(UTCDateTime::class, $reminder['created_at']);
 
         $credentials = [
-            'email' => 'john@doe.com',
+            'email' => 'john.doe@example.com',
             'password' => 'foobar',
             'password_confirmation' => 'foobar',
-            'token' => $reminder['token'],
+            'token' => $token,
         ];
 
         $response = $broker->reset($credentials, function ($user, $password) {

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -577,8 +577,7 @@ class ModelTest extends TestCase
         $this->assertInstanceOf(Carbon::class, $user->getAttribute('entry.date'));
 
         $data = $user->toArray();
-        $this->assertNotInstanceOf(UTCDateTime::class, $data['entry']['date']);
-        $this->assertEquals((string) $user->getAttribute('entry.date')->format('Y-m-d H:i:s'), $data['entry']['date']);
+        $this->assertIsString($data['entry']['date']);
     }
 
     public function testCarbonDateMockingWorks()

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -146,8 +146,6 @@ class QueryBuilderTest extends TestCase
                     return;
                 }
 
-                Assert::assertObjectHasAttribute('maxTimeMS', $event->getCommand());
-
                 // Expect the timeout to be converted to milliseconds
                 Assert::assertSame(1000, $event->getCommand()->maxTimeMS);
             }

--- a/tests/models/Soft.php
+++ b/tests/models/Soft.php
@@ -17,5 +17,5 @@ class Soft extends Eloquent
     protected $connection = 'mongodb';
     protected $collection = 'soft';
     protected static $unguarded = true;
-    protected $dates = ['deleted_at'];
+    protected $casts = ['deleted_at' => 'datetime'];
 }

--- a/tests/models/User.php
+++ b/tests/models/User.php
@@ -33,7 +33,10 @@ class User extends Eloquent implements AuthenticatableContract, CanResetPassword
     use Notifiable;
 
     protected $connection = 'mongodb';
-    protected $dates = ['birthday', 'entry.date'];
+    protected $casts = [
+        'birthday' => 'datetime',
+        'entry.date' => 'datetime',
+    ];
     protected static $unguarded = true;
 
     public function books()


### PR DESCRIPTION
This PR replaces #2501 and adapts the library to accommodate the BC breaks introduced in Laravel 10.

The most impactful change is the handling of dates, which requires people to update their models to no longer use the `$dates` property, but instead define a cast for date fields in the `$casts` property (except for the `created_at` and `updated_at` fields).

Note that we will use this BC break as an opportunity to remove auto-casting for `ObjectId` and `Binary` instances, which has been previously planned for version 4.0 of this library. This will require people that want to use auto-casting for identifiers and binary fields to update the `$casts` property accordingly. Since this is a significant BC break (along with other BC breaks introduced by Laravel), we may decide to release Laravel 10 support in a new major version. This will not necessarily all of the changes previously prepared for 4.0 to accelerate the timeline for Laravel 10 support.

Any testing users can do with Laravel 10 to alert us to potential problems with this library are highly appreciated; we value your feedback to let us know what we need to fix or can improve.