### PR TITLE
chore: improve docker tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,11 @@ COPY --from=composer:${COMPOSER_VERSION} /usr/bin/composer /usr/local/bin/compos
 
 WORKDIR /code
 
-COPY . .
+COPY composer.* ./
+
+RUN composer install
+
+COPY ./ ./
 
 RUN composer install
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 ARG PHP_VERSION=8.1
 ARG COMPOSER_VERSION=2.5.4
 
-FROM composer:${COMPOSER_VERSION}
 FROM php:${PHP_VERSION}-cli
 
 RUN apt-get update && \
@@ -10,7 +9,7 @@ RUN apt-get update && \
     pecl install xdebug && docker-php-ext-enable xdebug && \
     docker-php-ext-install -j$(nproc) pdo_mysql zip
 
-COPY --from=composer /usr/bin/composer /usr/local/bin/composer
+COPY --from=composer:${COMPOSER_VERSION} /usr/bin/composer /usr/local/bin/composer
 
 WORKDIR /code
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-ARG PHP_VERSION=8.0
-ARG COMPOSER_VERSION=2.0
+ARG PHP_VERSION=8.1
+ARG COMPOSER_VERSION=2.5.4
 
 FROM composer:${COMPOSER_VERSION}
 FROM php:${PHP_VERSION}-cli
@@ -13,3 +13,9 @@ RUN apt-get update && \
 COPY --from=composer /usr/bin/composer /usr/local/bin/composer
 
 WORKDIR /code
+
+COPY . .
+
+RUN composer install
+
+CMD ["./vendor/bin/phpunit"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
-FROM composer:2.5.4
-FROM php:8.1-cli
+ARG PHP_VERSION=8.1
+ARG COMPOSER_VERSION=2.5.4
+
+FROM composer:${COMPOSER_VERSION}
+FROM php:${PHP_VERSION}-cli
 
 RUN apt-get update && \
     apt-get install -y autoconf pkg-config libssl-dev git libzip-dev zlib1g-dev && \
@@ -11,10 +14,8 @@ COPY --from=composer /usr/bin/composer /usr/local/bin/composer
 
 WORKDIR /code
 
-COPY composer.* ./
+COPY . .
 
 RUN composer install
-
-COPY ./ ./
 
 CMD ["./vendor/bin/phpunit"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
-ARG PHP_VERSION=8.1
-ARG COMPOSER_VERSION=2.5.4
-
-FROM composer:${COMPOSER_VERSION}
-FROM php:${PHP_VERSION}-cli
+FROM composer:2.5.4
+FROM php:8.1-cli
 
 RUN apt-get update && \
     apt-get install -y autoconf pkg-config libssl-dev git libzip-dev zlib1g-dev && \
@@ -14,8 +11,10 @@ COPY --from=composer /usr/bin/composer /usr/local/bin/composer
 
 WORKDIR /code
 
-COPY . .
+COPY composer.* ./
 
 RUN composer install
+
+COPY ./ ./
 
 CMD ["./vendor/bin/phpunit"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,8 +25,6 @@ services:
             MYSQL_ROOT_PASSWORD:
             MYSQL_DATABASE: unittest
             MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
-        logging:
-            driver: none
 
     mongodb:
         container_name: mongodb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ version: '3'
 services:
     tests:
         container_name: tests
+        #platform: linux/arm64
+        tty: true
         build:
             context: .
             dockerfile: Dockerfile
@@ -15,9 +17,10 @@ services:
 
     mysql:
         container_name: mysql
-        image: mysql:5.7
+        #platform: linux/arm64
+        image: mysql:8.0
         ports:
-            - 3306:3306
+            - "3306:3306"
         environment:
             MYSQL_ROOT_PASSWORD:
             MYSQL_DATABASE: unittest
@@ -27,8 +30,7 @@ services:
 
     mongodb:
         container_name: mongodb
-        image: mongo
+        #platform: linux/arm64
+        image: mongo:latest
         ports:
-            - 27017:27017
-        logging:
-            driver: none
+            - "27017:27017"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,6 @@ version: '3'
 services:
     tests:
         container_name: tests
-        #platform: linux/arm64
         tty: true
         build:
             context: .
@@ -17,7 +16,6 @@ services:
 
     mysql:
         container_name: mysql
-        #platform: linux/arm64
         image: mysql:8.0
         ports:
             - "3306:3306"
@@ -28,7 +26,6 @@ services:
 
     mongodb:
         container_name: mongodb
-        #platform: linux/arm64
         image: mongo:latest
         ports:
             - "27017:27017"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -38,7 +38,7 @@
         </testsuite>
     </testsuites>
     <php>
-        <env name="MONGODB_URI" value="mongodb://127.0.0.1/" />
+        <env name="MONGODB_URI" value="mongodb://mongodb/" />
         <env name="MONGODB_DATABASE" value="unittest"/>
         <env name="MYSQL_HOST" value="mysql"/>
         <env name="MYSQL_PORT" value="3306"/>


### PR DESCRIPTION
Currently it's not possible to run test when running `docker-compose up` as the test container just stops silently and it's possible to run it again.

After this merge it would be possible to run tests just by starting up the container and it'll just work.