### PR TITLE
feat!: use mongodb function to check for dirtiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ All notable changes to this project will be documented in this file.
 - Change signature of `Query\Builder::__constructor` to match the parent class [#26](https://github.com/GromNaN/laravel-mongodb-private/pull/26) by [@GromNaN](https://github.com/GromNaN).
 - Fix Query on `whereDate`, `whereDay`, `whereMonth`, `whereYear`, `whereTime` to use MongoDB operators [#2570](https://github.com/jenssegers/laravel-mongodb/pull/2376) by [@Davpyu](https://github.com/Davpyu) and [@GromNaN](https://github.com/GromNaN).
 - `Model::unset()` does not persist the change. Call `Model::save()` to persist the change [#2578](https://github.com/jenssegers/laravel-mongodb/pull/2578) by [@GromNaN](https://github.com/GromNaN).
-- Use mongodb function to check for dirtiness [#2515](https://github.com/jenssegers/laravel-mongodb/pull/2515) by [@halaei](https://github.com/halaei) and [@GromNaN](https://github.com/GromNaN).
+- Use `MongoDB\BSON\fromPHP` to detect changes [#2515](https://github.com/jenssegers/laravel-mongodb/pull/2515) by [@halaei](https://github.com/halaei) and [@divine](https://github.com/divine).
 
 ## [3.9.2] - 2022-09-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 - Change signature of `Query\Builder::__constructor` to match the parent class [#26](https://github.com/GromNaN/laravel-mongodb-private/pull/26) by [@GromNaN](https://github.com/GromNaN).
 - Fix Query on `whereDate`, `whereDay`, `whereMonth`, `whereYear`, `whereTime` to use MongoDB operators [#2570](https://github.com/jenssegers/laravel-mongodb/pull/2376) by [@Davpyu](https://github.com/Davpyu) and [@GromNaN](https://github.com/GromNaN).
 - `Model::unset()` does not persist the change. Call `Model::save()` to persist the change [#2578](https://github.com/jenssegers/laravel-mongodb/pull/2578) by [@GromNaN](https://github.com/GromNaN).
+- Use mongodb function to check for dirtiness [#2515](https://github.com/jenssegers/laravel-mongodb/pull/2515) by [@halaei](https://github.com/halaei) and [@GromNaN](https://github.com/GromNaN).
 
 ## [3.9.2] - 2022-09-01
 

--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -16,6 +16,7 @@ use Illuminate\Support\Str;
 use function in_array;
 use Jenssegers\Mongodb\Query\Builder as QueryBuilder;
 use MongoDB\BSON\Binary;
+use function MongoDB\BSON\fromPHP;
 use MongoDB\BSON\ObjectID;
 use MongoDB\BSON\UTCDateTime;
 use function uniqid;
@@ -294,20 +295,11 @@ abstract class Model extends BaseModel
             return false;
         }
 
-        if ($this->isDateAttribute($key)) {
-            $attribute = $attribute instanceof UTCDateTime ? $this->asDateTime($attribute) : $attribute;
-            $original = $original instanceof UTCDateTime ? $this->asDateTime($original) : $original;
-
-            return $attribute == $original;
+        if (is_scalar($attribute) || is_scalar($original)) {
+            return false;
         }
 
-        if ($this->hasCast($key, static::$primitiveCastTypes)) {
-            return $this->castAttribute($key, $attribute) ===
-                $this->castAttribute($key, $original);
-        }
-
-        return is_numeric($attribute) && is_numeric($original)
-            && strcmp((string) $attribute, (string) $original) === 0;
+        return fromPHP([$attribute]) === fromPHP([$original]);
     }
 
     /**

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -876,10 +876,45 @@ class ModelTest extends TestCase
     public function testGetDirtyDates(): void
     {
         $user = new User();
-        $user->setRawAttributes(['name' => 'John Doe', 'birthday' => new DateTime('19 august 1989')], true);
+        $user->name = 'John Doe';
+        $user->birthday = new DateTime('19 august 1989');
+        $user->syncOriginal();
         $this->assertEmpty($user->getDirty());
 
         $user->birthday = new DateTime('19 august 1989');
+        $this->assertEmpty($user->getDirty());
+    }
+
+    public function testGetDirty()
+    {
+        $user = new User([
+            'name' => 'John Doe',
+            'email' => 'john.doe@example.com',
+            'phone' => '123456789',
+        ]);
+
+        $user->save();
+
+        $this->assertFalse($user->isDirty());
+
+        $user->phone = '1234555555';
+        $this->assertTrue($user->isDirty());
+
+        $dirty = $user->getDirty();
+        $this->assertArrayHasKey('phone', $dirty);
+        $this->assertEquals('1234555555', $dirty['phone']);
+
+        $user->email = 'jane.doe@example.com';
+        $this->assertTrue($user->isDirty());
+        $dirty = $user->getDirty();
+        $this->assertArrayHasKey('phone', $dirty);
+        $this->assertArrayHasKey('email', $dirty);
+        $this->assertEquals('1234555555', $dirty['phone']);
+        $this->assertEquals('jane.doe@example.com', $dirty['email']);
+
+        $user->save();
+
+        $this->assertFalse($user->isDirty());
         $this->assertEmpty($user->getDirty());
     }
 


### PR DESCRIPTION
This is rework of test for PR #1990

> To check if a field is dirty we can simply use fromPHP() function of the mongodb driver. Besides, we shouldn't use the SQL-specific logic of Illuminate\Eloquent\Model::originalIsEquivalent() for mongodb. In sql, fields keep their schema data types and changing integer 1 to string '1' actually does nothing. However, in mongodb fields accept their types as they are inserted/updated. Therefore, if we change value of a field from (int)1 to (string)'1' we actually must regard it as dirty. This change is backward incompatible. Don't know if anyone likes the current behaviour more.
> --