### PR TITLE
Fix: remove incompatible return type

### DIFF
--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -518,7 +518,7 @@ abstract class Model extends BaseModel
     /**
      * @inheritdoc
      */
-    protected function addCastAttributesToArray(array $attributes, array $mutatedAttributes): array
+    protected function addCastAttributesToArray(array $attributes, array $mutatedAttributes)
     {
         foreach ($this->getCasts() as $key => $castType) {
             if (! Arr::has($attributes, $key) || Arr::has($mutatedAttributes, $key)) {

--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -187,7 +187,7 @@ abstract class Model extends BaseModel
     /**
      * @inheritdoc
      */
-    public function setAttribute($key, $value): static
+    public function setAttribute($key, $value)
     {
         // Convert _id to ObjectID.
         if ($key == '_id' && is_string($value)) {


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/jenssegers/laravel-mongodb/pull/2506

Commit: https://github.com/jenssegers/laravel-mongodb/pull/2506/commits/226a7098c31e282dd33b539d2d9003fc4d40a7cd

`setAttribute` in Laravel has it's return type declared as `mixed`, making this method incompatible: https://github.com/laravel/framework/blob/10.x/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php#L933-L940

This pull request removes return type. A method with no return type is `mixed` by default.