### PR TITLE
fix Enums not being cast when calling `Model::toArray()`

### DIFF
--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -556,7 +556,7 @@ abstract class Model extends BaseModel
             }
 
             if ($this->isEnumCastable($key) && (! $castValue instanceof Arrayable)) {
-                $castValue = $castValue !== null ? $this->getStorableEnumValue($attributes[$key]) : null;
+                $castValue = $castValue !== null ? $this->getStorableEnumValue($castValue) : null;
             }
 
             if ($castValue instanceof Arrayable) {

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -786,4 +786,19 @@ class ModelTest extends TestCase
         $check = User::where('name', $name)->first();
         $this->assertEquals($user->_id, $check->_id);
     }
+
+    public function testEnumCast(): void
+    {
+        $name = 'John Member';
+
+        $user = new User();
+        $user->name = $name;
+        $user->member_status = MemberStatus::Member;
+        $user->save();
+
+        /** @var User $check */
+        $check = User::where('name', $name)->first();
+        $this->assertSame(MemberStatus::Member->value, $check->getRawOriginal('member_status'));
+        $this->assertSame(MemberStatus::Member, $check->member_status);
+    }
 }

--- a/tests/models/MemberStatus.php
+++ b/tests/models/MemberStatus.php
@@ -1,0 +1,6 @@
+<?php
+
+enum MemberStatus: string
+{
+    case Member = 'MEMBER';
+}

--- a/tests/models/User.php
+++ b/tests/models/User.php
@@ -24,6 +24,7 @@ use Jenssegers\Mongodb\Eloquent\Model as Eloquent;
  * @property \Carbon\Carbon $created_at
  * @property \Carbon\Carbon $updated_at
  * @property string $username
+ * @property MemberStatus member_status
  */
 class User extends Eloquent implements AuthenticatableContract, CanResetPasswordContract
 {
@@ -36,6 +37,7 @@ class User extends Eloquent implements AuthenticatableContract, CanResetPassword
     protected $casts = [
         'birthday' => 'datetime',
         'entry.date' => 'datetime',
+        'member_status' => MemberStatus::class,
     ];
     protected static $unguarded = true;
 


### PR DESCRIPTION
Hey there 👋,

while testing the migration of a project to Laravel 10, calling `toArray()` on a model caused a warning when attributes are defined to be cast as Enums.

```
Attempt to read property "my_property" on string in vendor/laravel/framework/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php on line 1181
```

(and it didn't work). After diving a bit into the code, I noticed that the previously created `$castValue` was not used when converting the Enum to a string in the `addCastAttributesToArray()` method.

I didn't know where to put the Enum for the test, so I just added it to the `models` directory although it felt wrong 😅.

~~The changed order in the `use` statements is due to StyleCI complaining.~~

Let me know if you'd like me to change the Enum location or anything else! 🙏🏻

:octocat: 