### PR TITLE
Added support for Laravel v10.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
         "illuminate/support": "^10.0",
         "illuminate/container": "^10.0",
         "illuminate/database": "^10.0",
-        "illuminate/events": "^10.0",
         "mongodb/mongodb": "^1.15"
     },
     "require-dev": {


### PR DESCRIPTION
As `laravel/framework` replaces `illuminate/events` and thus cannot coexist with it, we need to remove `illuminate/events` from `composer.json` file. Otherwise, it is failing to install the package using `composer require`.

I hope the PR will be approved and will be merged soon.