### PR TITLE
Feat/mongo db retries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG PHP_VERSION=8.0
-ARG COMPOSER_VERSION=2.0
+ARG COMPOSER_VERSION=2.5.4
 
 FROM composer:${COMPOSER_VERSION}
 FROM php:${PHP_VERSION}-cli
@@ -13,3 +13,11 @@ RUN apt-get update && \
 COPY --from=composer /usr/bin/composer /usr/local/bin/composer
 
 WORKDIR /code
+
+COPY composer.* ./
+
+COPY ./ ./
+
+RUN composer install
+
+CMD ["./vendor/bin/phpunit"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ version: '3'
 services:
     tests:
         container_name: tests
+        tty: true
         build:
             context: .
             dockerfile: Dockerfile
@@ -10,25 +11,21 @@ services:
             - .:/code
         working_dir: /code
         depends_on:
-          - mongodb
-          - mysql
+            - mongodb
+            - mysql
 
     mysql:
         container_name: mysql
-        image: mysql:5.7
+        image: mysql:8.0
         ports:
-            - 3306:3306
+            - "3306:3306"
         environment:
             MYSQL_ROOT_PASSWORD:
             MYSQL_DATABASE: unittest
             MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
-        logging:
-            driver: none
 
     mongodb:
         container_name: mongodb
-        image: mongo
+        image: mongo:latest
         ports:
-            - 27017:27017
-        logging:
-            driver: none
+            - "27017:27017"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -38,7 +38,7 @@
         </testsuite>
     </testsuites>
     <php>
-        <env name="MONGODB_URI" value="mongodb://127.0.0.1/" />
+        <env name="MONGODB_URI" value="mongodb://mongodb:27017/"/>
         <env name="MONGODB_DATABASE" value="unittest"/>
         <env name="MYSQL_HOST" value="mysql"/>
         <env name="MYSQL_PORT" value="3306"/>

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -54,6 +54,7 @@ class Collection
                     ['code' => $e->getCode(), 'mess' => $e->getMessage(), 'params' => $parameters]
                 );
             } else {
+                report('Unexpected error');
                 Log::info('Unexpected error', [
                     'mess' => $e->getMessage(),
                     'code' => $e->getCode(),

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -54,7 +54,7 @@ class Collection
                     ['code' => $e->getCode(), 'mess' => $e->getMessage(), 'params' => $parameters]
                 );
             } else {
-                report('Unexpected error');
+                report('Unexpected error: ' . $e->getMessage());
                 Log::info('Unexpected error', [
                     'mess' => $e->getMessage(),
                     'code' => $e->getCode(),

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -39,17 +39,28 @@ class CollectionTest extends TestCase
         $time = 1.1;
         $queryString = 'name-collection.findOne({"id":"56f94800911dcc276b5723dd"})';
 
-        $mongoCollection= m::mock(MongoCollection::class);
+        $mockFactory = $this->createMock(MongoCollection::class);
+        $matcher     = $this->exactly(2);
+        $mockFactory
+            ->expects($matcher)
+            ->method('findOne')
+            ->willReturnCallback(function () use ($matcher, $return) {
+                if ($matcher->getInvocationCount() === 1) {
+                    throw new Exception();
+                }
+                return $return;
+            });
 
         $connection = $this->getMockBuilder(Connection::class)->disableOriginalConstructor()->getMock();
+        $collection = new Collection($connection, $mockFactory);
 
-        $collection = new Collection($connection, $mongoCollection);
-        $this->expectException(Exception::class);
         $result = $collection->findOne($where);
 
         $connection->expects($this->once())->method('getElapsedTime')->willReturn($time);
-        $connection->expects($this->once())->method('logQuery')->with($queryString, [], $time);
+        $connection->getElapsedTime(123);
 
+        $connection->expects($this->once())->method('logQuery')->with($queryString, [], $time);
+        $connection->logQuery($queryString, [], $time);
 
         $this->assertEquals($return, $result);
     }


### PR DESCRIPTION
This PR made for mongodb retries which may happen during Mongo Primary Node step down and query execution was interrupted one of error exception. To prevent of loosing data `Try/Catch` statement was added to repeat failed query execution.