### PR TITLE
Change `illuminate support` version to include version ^9.0.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "license": "MIT",
     "require": {
-        "illuminate/support": "^10.0",
+        "illuminate/support": "^9.0|^10.0",
         "illuminate/container": "^10.0",
         "illuminate/database": "^10.0",
         "illuminate/events": "^10.0",


### PR DESCRIPTION
I've made this update to clear the error in the following screenshot.
It has a conflict with [termwind](https://github.com/nunomaduro/termwind) package.

![image](https://github.com/jenssegers/laravel-mongodb/assets/45445067/49c5c50d-71ee-453e-8a51-8bfa4b2601f5)

![image](https://github.com/jenssegers/laravel-mongodb/assets/45445067/879c5484-b280-405b-a3ab-7358f2cd17c6)
