### PR TITLE
Remove `Eloquent\Builder::chunkById()` already having the correct id field in Laravel

### DIFF
--- a/src/Eloquent/Builder.php
+++ b/src/Eloquent/Builder.php
@@ -156,14 +156,6 @@ class Builder extends EloquentBuilder
     /**
      * @inheritdoc
      */
-    public function chunkById($count, callable $callback, $column = '_id', $alias = null)
-    {
-        return parent::chunkById($count, $callback, $column, $alias);
-    }
-
-    /**
-     * @inheritdoc
-     */
     public function raw($expression = null)
     {
         // Get raw results from the query builder.

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -834,12 +834,12 @@ class ModelTest extends TestCase
         User::create(['name' => 'spork', 'tags' => ['sharp', 'pointy', 'round', 'bowl']]);
         User::create(['name' => 'spoon', 'tags' => ['round', 'bowl']]);
 
-        $count = 0;
-        User::chunkById(2, function (EloquentCollection $items) use (&$count) {
-            $count += count($items);
+        $names = [];
+        User::chunkById(2, function (EloquentCollection $items) use (&$names) {
+            $names = array_merge($names, $items->pluck('name')->all());
         });
 
-        $this->assertEquals(3, $count);
+        $this->assertEquals(['fork', 'spork', 'spoon'], $names);
     }
 
     public function testTruncateModel()


### PR DESCRIPTION
This method was necessary to rename the key name to [`_id` (MongoDB's default)](https://www.mongodb.com/docs/manual/core/document/#field-names).  `chunkById` was refactored in laravel/framework#28065 to allow custom key name.

Reverts #1317