### PR TITLE
Remove calls to `Str::contains` and `Arr::get` when not necessary

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -5,7 +5,6 @@ namespace Jenssegers\Mongodb;
 use function class_exists;
 use Composer\InstalledVersions;
 use Illuminate\Database\Connection as BaseConnection;
-use Illuminate\Support\Arr;
 use InvalidArgumentException;
 use Jenssegers\Mongodb\Concerns\ManagesTransactions;
 use MongoDB\Client;
@@ -48,7 +47,7 @@ class Connection extends BaseConnection
         $dsn = $this->getDsn($config);
 
         // You can pass options directly to the MongoDB constructor
-        $options = Arr::get($config, 'options', []);
+        $options = $config['options'] ?? [];
 
         // Create the connection
         $this->connection = $this->createConnection($dsn, $config, $options);

--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -155,7 +155,7 @@ abstract class Model extends BaseModel
         }
 
         // Dot notation support.
-        if (Str::contains($key, '.') && Arr::has($this->attributes, $key)) {
+        if (str_contains($key, '.') && Arr::has($this->attributes, $key)) {
             return $this->getAttributeValue($key);
         }
 
@@ -177,7 +177,7 @@ abstract class Model extends BaseModel
     protected function getAttributeFromArray($key)
     {
         // Support keys in dot notation.
-        if (Str::contains($key, '.')) {
+        if (str_contains($key, '.')) {
             return Arr::get($this->attributes, $key);
         }
 
@@ -195,7 +195,7 @@ abstract class Model extends BaseModel
 
             $value = $builder->convertKey($value);
         } // Support keys in dot notation.
-        elseif (Str::contains($key, '.')) {
+        elseif (str_contains($key, '.')) {
             // Store to a temporary key, then move data to the actual key
             $uniqueKey = uniqid($key);
             parent::setAttribute($uniqueKey, $value);

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -617,7 +617,7 @@ class Builder extends BaseBuilder
     public function update(array $values, array $options = [])
     {
         // Use $set as default operator.
-        if (! Str::startsWith(key($values), '$')) {
+        if (! str_starts_with(key($values), '$')) {
             $values = ['$set' => $values];
         }
 
@@ -951,7 +951,7 @@ class Builder extends BaseBuilder
             }
 
             // Convert id's.
-            if (isset($where['column']) && ($where['column'] == '_id' || Str::endsWith($where['column'], '._id'))) {
+            if (isset($where['column']) && ($where['column'] == '_id' || str_ends_with($where['column'], '._id'))) {
                 // Multiple values.
                 if (isset($where['values'])) {
                     foreach ($where['values'] as &$value) {

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -10,7 +10,6 @@ use Illuminate\Database\Query\Expression;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\LazyCollection;
-use Illuminate\Support\Str;
 use Jenssegers\Mongodb\Connection;
 use MongoDB\BSON\Binary;
 use MongoDB\BSON\ObjectID;

--- a/src/Queue/MongoConnector.php
+++ b/src/Queue/MongoConnector.php
@@ -4,7 +4,6 @@ namespace Jenssegers\Mongodb\Queue;
 
 use Illuminate\Database\ConnectionResolverInterface;
 use Illuminate\Queue\Connectors\ConnectorInterface;
-use Illuminate\Support\Arr;
 
 class MongoConnector implements ConnectorInterface
 {
@@ -34,10 +33,10 @@ class MongoConnector implements ConnectorInterface
     public function connect(array $config)
     {
         return new MongoQueue(
-            $this->connections->connection(Arr::get($config, 'connection')),
+            $this->connections->connection($config['connection'] ?? null),
             $config['table'],
             $config['queue'],
-            Arr::get($config, 'expire', 60)
+            $config['expire'] ?? 60
         );
     }
 }


### PR DESCRIPTION
- [`Str::contains`](https://laravel.com/docs/10.x/helpers#method-str-contains) is identical to `str_contains` but support `array`. This is not necessary in several places.
- [`Arr::get`](https://laravel.com/docs/10.x/helpers#method-array-get) is identical to `$array[$key] ?? $default` but accept dot notation for nested arrays. This is not necessary when the key does not contain a dot.

Replacing this method calls with native functions improve performance (less method calls) and simplifies step-by-step debugging.