### PR TITLE
Explicitly require PHP ^8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
     ],
     "license": "MIT",
     "require": {
+        "php": "^8.1",
         "ext-mongodb": "^1.15",
         "illuminate/support": "^10.0",
         "illuminate/container": "^10.0",


### PR DESCRIPTION
Allows to use PHP 8.1 features without relying on the [transient dependency from Laravel 10](https://github.com/illuminate/support/blob/10.x/composer.json) like `str_contains` in #2571