### PR TITLE
PHPORM-75 Defer `Model::unset($field)` to the `save()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - Support `%` and `_` in `like` expression [#17](https://github.com/GromNaN/laravel-mongodb/pull/17) by [@GromNaN](https://github.com/GromNaN).
 - Change signature of `Query\Builder::__constructor` to match the parent class [#26](https://github.com/GromNaN/laravel-mongodb-private/pull/26) by [@GromNaN](https://github.com/GromNaN).
 - Fix Query on `whereDate`, `whereDay`, `whereMonth`, `whereYear`, `whereTime` to use MongoDB operators [#2570](https://github.com/jenssegers/laravel-mongodb/pull/2376) by [@Davpyu](https://github.com/Davpyu) and [@GromNaN](https://github.com/GromNaN).
+- `Model::unset()` does not persist the change. Call `Model::save()` to persist the change [#2578](https://github.com/jenssegers/laravel-mongodb/pull/2578) by [@GromNaN](https://github.com/GromNaN).
 
 ## [3.9.2] - 2022-09-01
 

--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -20,9 +20,6 @@ use MongoDB\BSON\ObjectID;
 use MongoDB\BSON\UTCDateTime;
 use function uniqid;
 
-/**
- * @method void unset(string|string[] $columns) Remove one or more fields.
- */
 abstract class Model extends BaseModel
 {
     use HybridRelations, EmbedsRelations;
@@ -341,8 +338,21 @@ abstract class Model extends BaseModel
      *
      * @param  string|string[]  $columns
      * @return void
+     *
+     * @deprecated Use unset() instead.
      */
     public function drop($columns)
+    {
+        $this->unset($columns);
+    }
+
+    /**
+     * Remove one or more fields.
+     *
+     * @param  string|string[]  $columns
+     * @return void
+     */
+    public function unset($columns)
     {
         $columns = Arr::wrap($columns);
 
@@ -558,19 +568,6 @@ abstract class Model extends BaseModel
     protected function isGuardableColumn($key)
     {
         return true;
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function __call($method, $parameters)
-    {
-        // Unset method
-        if ($method == 'unset') {
-            return $this->drop(...$parameters);
-        }
-
-        return parent::__call($method, $parameters);
     }
 
     /**

--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -20,6 +20,9 @@ use MongoDB\BSON\ObjectID;
 use MongoDB\BSON\UTCDateTime;
 use function uniqid;
 
+/**
+ * @method void unset(string|string[] $columns) Remove one or more fields.
+ */
 abstract class Model extends BaseModel
 {
     use HybridRelations, EmbedsRelations;
@@ -51,6 +54,13 @@ abstract class Model extends BaseModel
      * @var Relation
      */
     protected $parentRelation;
+
+    /**
+     * List of field names to unset from the document on save.
+     *
+     * @var array{string, true}
+     */
+    private array $unset = [];
 
     /**
      * Custom accessor for the model's id.
@@ -151,7 +161,12 @@ abstract class Model extends BaseModel
     public function getAttribute($key)
     {
         if (! $key) {
-            return;
+            return null;
+        }
+
+        // An unset attribute is null or throw an exception.
+        if (isset($this->unset[$key])) {
+            return $this->throwMissingAttributeExceptionIfApplicable($key);
         }
 
         // Dot notation support.
@@ -206,6 +221,9 @@ abstract class Model extends BaseModel
             return $this;
         }
 
+        // Setting an attribute cancels the unset operation.
+        unset($this->unset[$key]);
+
         return parent::setAttribute($key, $value);
     }
 
@@ -242,9 +260,29 @@ abstract class Model extends BaseModel
     /**
      * @inheritdoc
      */
+    public function getDirty()
+    {
+        $dirty = parent::getDirty();
+
+        // The specified value in the $unset expression does not impact the operation.
+        if (! empty($this->unset)) {
+            $dirty['$unset'] = $this->unset;
+        }
+
+        return $dirty;
+    }
+
+    /**
+     * @inheritdoc
+     */
     public function originalIsEquivalent($key)
     {
         if (! array_key_exists($key, $this->original)) {
+            return false;
+        }
+
+        // Calling unset on an attribute marks it as "not equivalent".
+        if (isset($this->unset[$key])) {
             return false;
         }
 
@@ -276,10 +314,33 @@ abstract class Model extends BaseModel
     }
 
     /**
+     * @inheritdoc
+     */
+    public function offsetUnset($offset): void
+    {
+        parent::offsetUnset($offset);
+
+        // Force unsetting even if the attribute is not set.
+        // End user can optimize DB calls by checking if the attribute is set before unsetting it.
+        $this->unset[$offset] = true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function offsetSet($offset, $value): void
+    {
+        parent::offsetSet($offset, $value);
+
+        // Setting an attribute cancels the unset operation.
+        unset($this->unset[$offset]);
+    }
+
+    /**
      * Remove one or more fields.
      *
-     * @param  mixed  $columns
-     * @return int
+     * @param  string|string[]  $columns
+     * @return void
      */
     public function drop($columns)
     {
@@ -289,9 +350,6 @@ abstract class Model extends BaseModel
         foreach ($columns as $column) {
             $this->__unset($column);
         }
-
-        // Perform unset only on current document
-        return $this->newQuery()->where($this->getKeyName(), $this->getKey())->unset($columns);
     }
 
     /**

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -607,9 +607,12 @@ class Builder extends BaseBuilder
      */
     public function update(array $values, array $options = [])
     {
-        // Use $set as default operator.
-        if (! str_starts_with(key($values), '$')) {
-            $values = ['$set' => $values];
+        // Use $set as default operator for field names that are not in an operator
+        foreach ($values as $key => $value) {
+            if (! str_starts_with($key, '$')) {
+                $values['$set'][$key] = $value;
+                unset($values[$key]);
+            }
         }
 
         $options = $this->inheritConnectionOptions($options);

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -515,11 +515,13 @@ class ModelTest extends TestCase
         $this->assertFalse(isset($user->note1));
         $this->assertNull($user['note1']);
         $this->assertFalse($user->originalIsEquivalent('note1'));
+        $this->assertTrue($user->isDirty());
         $this->assertSame(['$unset' => ['note1' => true]], $user->getDirty());
 
         // Reset the previous value
         $user->note1 = 'ABC';
         $this->assertTrue($user->originalIsEquivalent('note1'));
+        $this->assertFalse($user->isDirty());
         $this->assertSame([], $user->getDirty());
 
         // Change the value
@@ -527,6 +529,7 @@ class ModelTest extends TestCase
         $this->assertTrue(isset($user->note1));
         $this->assertSame('GHI', $user['note1']);
         $this->assertFalse($user->originalIsEquivalent('note1'));
+        $this->assertTrue($user->isDirty());
         $this->assertSame(['note1' => 'GHI'], $user->getDirty());
 
         // Fetch to be sure the changes are not persisted yet
@@ -542,6 +545,7 @@ class ModelTest extends TestCase
         $this->assertTrue(isset($user->note1));
         $this->assertSame('GHI', $user->note1);
         $this->assertTrue($user->originalIsEquivalent('note1'));
+        $this->assertFalse($user->isDirty());
     }
 
     public function testDates(): void

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -511,7 +511,7 @@ class ModelTest extends TestCase
         $this->assertTrue($user->originalIsEquivalent('note1'));
 
         // Unset the value
-        unset($user['note1']);
+        $user->unset('note1');
         $this->assertFalse(isset($user->note1));
         $this->assertNull($user['note1']);
         $this->assertFalse($user->originalIsEquivalent('note1'));

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -474,6 +474,10 @@ class ModelTest extends TestCase
         $user1->unset('note1');
 
         $this->assertFalse(isset($user1->note1));
+
+        $user1->save();
+
+        $this->assertFalse(isset($user1->note1));
         $this->assertTrue(isset($user1->note2));
         $this->assertTrue(isset($user2->note1));
         $this->assertTrue(isset($user2->note2));
@@ -488,9 +492,56 @@ class ModelTest extends TestCase
         $this->assertTrue(isset($user2->note2));
 
         $user2->unset(['note1', 'note2']);
+        $user2->save();
 
         $this->assertFalse(isset($user2->note1));
         $this->assertFalse(isset($user2->note2));
+
+        // Re-re-fetch to be sure
+        $user2 = User::find($user2->_id);
+
+        $this->assertFalse(isset($user2->note1));
+        $this->assertFalse(isset($user2->note2));
+    }
+
+    public function testUnsetAndSet(): void
+    {
+        $user = User::create(['name' => 'John Doe', 'note1' => 'ABC', 'note2' => 'DEF']);
+
+        $this->assertTrue($user->originalIsEquivalent('note1'));
+
+        // Unset the value
+        unset($user['note1']);
+        $this->assertFalse(isset($user->note1));
+        $this->assertNull($user['note1']);
+        $this->assertFalse($user->originalIsEquivalent('note1'));
+        $this->assertSame(['$unset' => ['note1' => true]], $user->getDirty());
+
+        // Reset the previous value
+        $user->note1 = 'ABC';
+        $this->assertTrue($user->originalIsEquivalent('note1'));
+        $this->assertSame([], $user->getDirty());
+
+        // Change the value
+        $user->note1 = 'GHI';
+        $this->assertTrue(isset($user->note1));
+        $this->assertSame('GHI', $user['note1']);
+        $this->assertFalse($user->originalIsEquivalent('note1'));
+        $this->assertSame(['note1' => 'GHI'], $user->getDirty());
+
+        // Fetch to be sure the changes are not persisted yet
+        $userCheck = User::find($user->_id);
+        $this->assertSame('ABC', $userCheck['note1']);
+
+        // Persist the changes
+        $user->save();
+
+        // Re-fetch to be sure
+        $user = User::find($user->_id);
+
+        $this->assertTrue(isset($user->note1));
+        $this->assertSame('GHI', $user->note1);
+        $this->assertTrue($user->originalIsEquivalent('note1'));
     }
 
     public function testDates(): void

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -203,6 +203,38 @@ class QueryBuilderTest extends TestCase
         $this->assertEquals(20, $jane['age']);
     }
 
+    public function testUpdateOperators()
+    {
+        DB::collection('users')->insert([
+            ['name' => 'Jane Doe', 'age' => 20],
+            ['name' => 'John Doe', 'age' => 19],
+        ]);
+
+        DB::collection('users')->where('name', 'John Doe')->update(
+            [
+                '$unset' => ['age' => 1],
+                'ageless' => true,
+            ]
+        );
+        DB::collection('users')->where('name', 'Jane Doe')->update(
+            [
+                '$inc' => ['age' => 1],
+                '$set' => ['pronoun' => 'she'],
+                'ageless' => false,
+            ]
+        );
+
+        $john = DB::collection('users')->where('name', 'John Doe')->first();
+        $jane = DB::collection('users')->where('name', 'Jane Doe')->first();
+
+        $this->assertArrayNotHasKey('age', $john);
+        $this->assertTrue($john['ageless']);
+
+        $this->assertEquals(21, $jane['age']);
+        $this->assertEquals('she', $jane['pronoun']);
+        $this->assertFalse($jane['ageless']);
+    }
+
     public function testDelete()
     {
         DB::collection('users')->insert([


### PR DESCRIPTION
Fix #2566 and [PHPORM-75](https://jira.mongodb.org/browse/PHPORM-75).

- **Breaking change**: All calls to `$model->unset($field)`, `$model->drop($field)`, `unset($model[$field])`, `unset($model->field)` must be followed by `$model->save()` so they are persisted.
```diff
  $user = User::find($key);
  unset($user->age);
+ $user->save();
```

- Deprecate `Model::drop($field)`, it's a duplicate of `Model::unset($field)`. The native `unset($model->field)` is recommended.

- `Query\Builder::update()` accept a mix of field names and [update operators](https://www.mongodb.com/docs/manual/reference/operator/update/).

```php
DB::collection('users')->where(...)->update([
    '$inc' => ['age' => 1],
    'last_birthday' => new UTCDateTime(),
]);
```

Todo:
- [x] changelog
- [ ] relations
- [ ] nested model / objects