### PR TITLE
Fix tests for MongoDB 7.0

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -36,16 +36,16 @@ jobs:
                 os:
                     - ubuntu-latest
                 mongodb:
-                    - '4.0'
-                    - '4.2'
                     - '4.4'
                     - '5.0'
+                    - '6.0'
+                    - '7.0'
                 php:
                     - '8.1'
                     - '8.2'
         services:
             mysql:
-                image: mysql:5.7
+                image: mysql:8.0
                 ports:
                     - 3307:3306
                 env:
@@ -58,13 +58,16 @@ jobs:
             -   name: Create MongoDB Replica Set
                 run: |
                     docker run --name mongodb -p 27017:27017 -e MONGO_INITDB_DATABASE=unittest --detach mongo:${{ matrix.mongodb }} mongod --replSet rs --setParameter transactionLifetimeLimitSeconds=5
-                    until docker exec --tty mongodb mongo 127.0.0.1:27017 --eval "db.runCommand({ ping: 1 })"; do
+
+                    if [ "${{ matrix.mongodb }}" = "4.4" ]; then MONGOSH_BIN="mongo"; else MONGOSH_BIN="mongosh"; fi
+                    until docker exec --tty mongodb $MONGOSH_BIN 127.0.0.1:27017 --eval "db.runCommand({ ping: 1 })"; do
                     sleep 1
                     done
-                    sudo docker exec --tty mongodb mongo 127.0.0.1:27017 --eval "rs.initiate({\"_id\":\"rs\",\"members\":[{\"_id\":0,\"host\":\"127.0.0.1:27017\" }]})"
+                    sudo docker exec --tty mongodb $MONGOSH_BIN 127.0.0.1:27017 --eval "rs.initiate({\"_id\":\"rs\",\"members\":[{\"_id\":0,\"host\":\"127.0.0.1:27017\" }]})"
             -   name: Show MongoDB server status
                 run: |
-                    docker exec --tty mongodb mongo 127.0.0.1:27017 --eval "db.runCommand({ serverStatus: 1 })"
+                    if [ "${{ matrix.mongodb }}" = "4.4" ]; then MONGOSH_BIN="mongo"; else MONGOSH_BIN="mongosh"; fi
+                    docker exec --tty mongodb $MONGOSH_BIN 127.0.0.1:27017 --eval "db.runCommand({ serverStatus: 1 })"
             -   name: "Installing php"
                 uses: shivammathur/setup-php@v2
                 with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,21 @@
 ARG PHP_VERSION=8.1
-ARG COMPOSER_VERSION=2.5.4
 
 FROM php:${PHP_VERSION}-cli
 
 RUN apt-get update && \
-    apt-get install -y autoconf pkg-config libssl-dev git libzip-dev zlib1g-dev && \
+    apt-get install -y autoconf pkg-config libssl-dev git unzip libzip-dev zlib1g-dev && \
     pecl install mongodb && docker-php-ext-enable mongodb && \
     pecl install xdebug && docker-php-ext-enable xdebug && \
     docker-php-ext-install -j$(nproc) pdo_mysql zip
 
-COPY --from=composer:${COMPOSER_VERSION} /usr/bin/composer /usr/local/bin/composer
+COPY --from=composer:2.5.8 /usr/bin/composer /usr/local/bin/composer
 
 WORKDIR /code
 
-COPY composer.* ./
-
-RUN composer install
-
 COPY ./ ./
 
+ENV COMPOSER_ALLOW_SUPERUSER=1
+
 RUN composer install
 
-CMD ["./vendor/bin/phpunit"]
+CMD ["./vendor/bin/phpunit", "--testdox"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.5'
 
 services:
     tests:
@@ -10,9 +10,14 @@ services:
         volumes:
             - .:/code
         working_dir: /code
+        environment:
+            MONGODB_URI: 'mongodb://mongodb/'
+            MYSQL_HOST: 'mysql'
         depends_on:
-          - mongodb
-          - mysql
+            mongodb:
+                condition: service_healthy
+            mysql:
+                condition: service_started
 
     mysql:
         container_name: mysql
@@ -29,3 +34,8 @@ services:
         image: mongo:latest
         ports:
             - "27017:27017"
+        healthcheck:
+            test: echo 'db.runCommand("ping").ok' | mongosh mongodb:27017 --quiet
+            interval: 10s
+            timeout: 10s
+            retries: 5

--- a/tests/TransactionTest.php
+++ b/tests/TransactionTest.php
@@ -384,7 +384,6 @@ class TransactionTest extends TestCase
             $this->fail('Expected exception during transaction');
         } catch (BulkWriteException $e) {
             $this->assertInstanceOf(BulkWriteException::class, $e);
-            $this->assertStringContainsString('WriteConflict', $e->getMessage());
         }
 
         $this->assertSame(2, $timesRun);


### PR DESCRIPTION
- Add MongoDB server 6.0 and 7.0 in CI.
- Remote [unmaintained MongoDB versions < 4.4](https://www.mongodb.com/support-policy/lifecycles)
- Upgrade CI to MySQL 8.0

Error message have changed. We don't need to assert on the error message as we already assert there is a `BulkWriteException`.

```
Caused by :: Write conflict during plan execution and yielding is disabled. :: Please retry your operation or multi-document transaction.
```