### PR TITLE
PHPORM-127 Fix priority of embeds vs attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -805,6 +805,7 @@ class User extends Model
     }
 }
 ```
+**Warning:** naming the foreign key same as the relation name will prevent the relation for being called on dynamic property, i.e. in the example above if you replaced `group_ids` with `groups` calling `$user->groups` will return the column instead of the relation.
 
 ### EmbedsMany Relationship
 
@@ -812,12 +813,15 @@ If you want to embed models, rather than referencing them, you can use the `embe
 
 **REMEMBER**: These relations return Eloquent collections, they don't return query builder objects!
 
+**Breaking changes** starting from v4.0 you need to define the return type of EmbedsOne and EmbedsMany relation for it to work
+
 ```php
 use MongoDB\Laravel\Eloquent\Model;
+use MongoDB\Laravel\Relations\EmbedsMany;
 
 class User extends Model
 {
-    public function books()
+    public function books(): EmbedsMany
     {
         return $this->embedsMany(Book::class);
     }
@@ -886,10 +890,11 @@ Like other relations, embedsMany assumes the local key of the relationship based
 
 ```php
 use MongoDB\Laravel\Eloquent\Model;
+use MongoDB\Laravel\Relations\EmbedsMany;
 
 class User extends Model
 {
-    public function books()
+    public function books(): EmbedsMany
     {
         return $this->embedsMany(Book::class, 'local_key');
     }
@@ -902,12 +907,15 @@ Embedded relations will return a Collection of embedded items instead of a query
 
 The embedsOne relation is similar to the embedsMany relation, but only embeds a single model.
 
+**Breaking changes** starting from v4.0 you need to define the return type of EmbedsOne and EmbedsMany relation for it to work
+
 ```php
 use MongoDB\Laravel\Eloquent\Model;
+use MongoDB\Laravel\Relations\EmbedsOne;
 
 class Book extends Model
 {
-    public function author()
+    public function author(): EmbedsOne
     {
         return $this->embedsOne(Author::class);
     }

--- a/src/Eloquent/HybridRelations.php
+++ b/src/Eloquent/HybridRelations.php
@@ -272,6 +272,10 @@ trait HybridRelations
 
         $instance = new $related;
 
+        if ($relatedPivotKey === $relation) {
+            throw new \LogicException(sprintf('In %s::%s(), the key cannot be identical to the relation name "%s". The default key is "%s".', static::class, $relation, $relation, $instance->getForeignKey().'s'));
+        }
+
         $relatedPivotKey = $relatedPivotKey ?: $instance->getForeignKey().'s';
 
         // If no table name was provided, we can guess it by concatenating the two

--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -18,6 +18,7 @@ use MongoDB\BSON\Binary;
 use MongoDB\BSON\ObjectID;
 use MongoDB\BSON\UTCDateTime;
 use MongoDB\Laravel\Query\Builder as QueryBuilder;
+use ReflectionException;
 use function uniqid;
 
 abstract class Model extends BaseModel
@@ -154,6 +155,7 @@ abstract class Model extends BaseModel
 
     /**
      * @inheritdoc
+     * @throws ReflectionException
      */
     public function getAttribute($key)
     {
@@ -172,11 +174,7 @@ abstract class Model extends BaseModel
         }
 
         // This checks for embedded relation support.
-        if (
-            method_exists($this, $key)
-            && ! method_exists(self::class, $key)
-            && ! $this->hasAttributeGetMutator($key)
-        ) {
+        if ($this->hasEmbeddedRelation($key)) {
             return $this->getRelationValue($key);
         }
 
@@ -474,7 +472,7 @@ abstract class Model extends BaseModel
     /**
      * Set the parent relation.
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\Relation  $relation
+     * @param Relation $relation
      */
     public function setParentRelation(Relation $relation)
     {
@@ -484,7 +482,7 @@ abstract class Model extends BaseModel
     /**
      * Get the parent relation.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\Relation
+     * @return Relation
      */
     public function getParentRelation()
     {

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -1035,4 +1035,11 @@ class ModelTest extends TestCase
         $this->assertSame(MemberStatus::Member->value, $check->getRawOriginal('member_status'));
         $this->assertSame(MemberStatus::Member, $check->member_status);
     }
+
+    public function testGetFooAttributeAccessor()
+    {
+        $user = new User();
+
+        $this->assertSame('normal attribute', $user->foo);
+    }
 }

--- a/tests/Models/Group.php
+++ b/tests/Models/Group.php
@@ -15,6 +15,6 @@ class Group extends Eloquent
 
     public function users(): BelongsToMany
     {
-        return $this->belongsToMany(User::class, 'users', 'groups', 'users', '_id', '_id', 'users');
+        return $this->belongsToMany(User::class, 'users', 'groupIds', 'userIds', '_id', '_id', 'users');
     }
 }

--- a/tests/Models/User.php
+++ b/tests/Models/User.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Laravel\Tests\Models;
 
+use Carbon\Carbon;
 use DateTimeInterface;
 use Illuminate\Auth\Authenticatable;
 use Illuminate\Auth\Passwords\CanResetPassword;
@@ -14,6 +15,8 @@ use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Str;
 use MongoDB\Laravel\Eloquent\HybridRelations;
 use MongoDB\Laravel\Eloquent\Model as Eloquent;
+use MongoDB\Laravel\Relations\EmbedsMany;
+use MongoDB\Laravel\Relations\EmbedsOne;
 
 /**
  * Class User.
@@ -23,9 +26,9 @@ use MongoDB\Laravel\Eloquent\Model as Eloquent;
  * @property string $email
  * @property string $title
  * @property int $age
- * @property \Carbon\Carbon $birthday
- * @property \Carbon\Carbon $created_at
- * @property \Carbon\Carbon $updated_at
+ * @property Carbon $birthday
+ * @property Carbon $created_at
+ * @property Carbon $updated_at
  * @property string $username
  * @property MemberStatus member_status
  */
@@ -76,7 +79,7 @@ class User extends Eloquent implements AuthenticatableContract, CanResetPassword
 
     public function groups()
     {
-        return $this->belongsToMany(Group::class, 'groups', 'users', 'groups', '_id', '_id', 'groups');
+        return $this->belongsToMany(Group::class, 'groups', 'userIds', 'groupIds', '_id', '_id', 'groups');
     }
 
     public function photos()
@@ -84,12 +87,12 @@ class User extends Eloquent implements AuthenticatableContract, CanResetPassword
         return $this->morphMany(Photo::class, 'has_image');
     }
 
-    public function addresses()
+    public function addresses(): EmbedsMany
     {
         return $this->embedsMany(Address::class);
     }
 
-    public function father()
+    public function father(): EmbedsOne
     {
         return $this->embedsOne(self::class);
     }
@@ -105,5 +108,15 @@ class User extends Eloquent implements AuthenticatableContract, CanResetPassword
             get: fn ($value) => $value,
             set: fn ($value) => Str::slug($value)
         );
+    }
+
+    public function getFooAttribute()
+    {
+        return 'normal attribute';
+    }
+
+    public function foo()
+    {
+        return 'normal function';
     }
 }

--- a/tests/RelationsTest.php
+++ b/tests/RelationsTest.php
@@ -344,8 +344,8 @@ class RelationsTest extends TestCase
         $group = Group::find($group->_id);
 
         // Check for custom relation attributes
-        $this->assertArrayHasKey('users', $group->getAttributes());
-        $this->assertArrayHasKey('groups', $user->getAttributes());
+        $this->assertArrayHasKey('userIds', $group->getAttributes());
+        $this->assertArrayHasKey('groupIds', $user->getAttributes());
 
         // Assert they are attached
         $this->assertContains($group->_id, $user->groups->pluck('_id')->toArray());


### PR DESCRIPTION
Fix #2577 (continuing)
Fix PHPORM-127

Moving the code from the `Model` class to the `EmbedsRelations` trait.