### PR TITLE
Mutator can not handle array

### DIFF
--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -20,6 +20,7 @@ use MongoDB\Laravel\Query\Builder as QueryBuilder;
 
 use function abs;
 use function array_key_exists;
+use function array_key_first;
 use function array_keys;
 use function array_unique;
 use function array_values;
@@ -254,7 +255,11 @@ abstract class Model extends BaseModel
     /** @inheritdoc */
     protected function normalizeCastClassResponse($key, $value)
     {
-        return [$key => $value];
+        if (! is_array($value) || (count($value) && is_numeric(array_key_first($value)))) {
+            return [$key => $value];
+        }
+
+        return $value;
     }
 
     /** @inheritdoc */

--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -252,37 +252,6 @@ abstract class Model extends BaseModel
     }
 
     /** @inheritdoc */
-    protected function setAttributeMarkedMutatedAttributeValue($key, $value)
-    {
-        $attribute = $this->{Str::camel($key)}();
-
-        $callback = $attribute->set ?: function ($value) use ($key) {
-            $this->attributes[$key] = $value;
-        };
-
-        $normalizeCastClassResponse = $this->normalizeCastClassResponse(
-            $key, $callback($value, $this->attributes)
-        );
-
-        if (count($normalizeCastClassResponse) > 1) {
-            $normalizeCastClassResponse = [$key => $normalizeCastClassResponse];
-        }
-
-        $this->attributes = array_merge(
-            $this->attributes,
-            $normalizeCastClassResponse
-        );
-
-        if ($attribute->withCaching || (is_object($value) && $attribute->withObjectCaching)) {
-            $this->attributeCastCache[$key] = $value;
-        } else {
-            unset($this->attributeCastCache[$key]);
-        }
-
-        return $this;
-    }
-
-    /** @inheritdoc */
     public function getCasts()
     {
         return $this->casts;

--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -252,6 +252,12 @@ abstract class Model extends BaseModel
     }
 
     /** @inheritdoc */
+    protected function normalizeCastClassResponse($key, $value)
+    {
+        return [$key => $value];
+    }
+
+    /** @inheritdoc */
     public function getCasts()
     {
         return $this->casts;

--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -252,6 +252,37 @@ abstract class Model extends BaseModel
     }
 
     /** @inheritdoc */
+    protected function setAttributeMarkedMutatedAttributeValue($key, $value)
+    {
+        $attribute = $this->{Str::camel($key)}();
+
+        $callback = $attribute->set ?: function ($value) use ($key) {
+            $this->attributes[$key] = $value;
+        };
+
+        $normalizeCastClassResponse = $this->normalizeCastClassResponse(
+            $key, $callback($value, $this->attributes)
+        );
+
+        if (count($normalizeCastClassResponse) > 1) {
+            $normalizeCastClassResponse = [$key => $normalizeCastClassResponse];
+        }
+
+        $this->attributes = array_merge(
+            $this->attributes,
+            $normalizeCastClassResponse
+        );
+
+        if ($attribute->withCaching || (is_object($value) && $attribute->withObjectCaching)) {
+            $this->attributeCastCache[$key] = $value;
+        } else {
+            unset($this->attributeCastCache[$key]);
+        }
+
+        return $this;
+    }
+
+    /** @inheritdoc */
     public function getCasts()
     {
         return $this->casts;

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -114,6 +114,19 @@ class ModelTest extends TestCase
 
         $check = User::find($user->_id);
         $this->assertEquals(20, $check->age);
+
+        $check->skills = ['PHP', 'Laravel', 'MongoDB', 'Laravel'];
+        $check->save();
+
+        $check = User::find($user->_id);
+        $this->assertCount(3,$check->skills);
+        $this->assertEquals(['PHP', 'Laravel', 'MongoDB'],$check->skills);
+
+        $check->update(['skills' => ['Git','Github','Unit testing','Github']]);
+
+        $check = User::find($user->_id);
+        $this->assertCount(3,$check->skills);
+        $this->assertEquals(['Git','Github','Unit testing'],$check->skills);
     }
 
     public function testManualStringId(): void

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -112,21 +112,20 @@ class ModelTest extends TestCase
         $raw = $user->getAttributes();
         $this->assertInstanceOf(ObjectID::class, $raw['_id']);
 
-        $check = User::find($user->_id);
-        $this->assertEquals(20, $check->age);
-
         $check->skills = ['PHP', 'Laravel', 'MongoDB', 'Laravel'];
         $check->save();
 
         $check = User::find($user->_id);
-        $this->assertCount(3,$check->skills);
-        $this->assertEquals(['PHP', 'Laravel', 'MongoDB'],$check->skills);
+        $this->assertCount(3, $check->skills);
+        $this->assertEquals(['PHP', 'Laravel', 'MongoDB'], $check->skills);
 
-        $check->update(['skills' => ['Git','Github','Unit testing','Github']]);
+        $check->fullname = ['Hans', 'Thomas'];
+        $check->save();
 
         $check = User::find($user->_id);
-        $this->assertCount(3,$check->skills);
-        $this->assertEquals(['Git','Github','Unit testing'],$check->skills);
+        self::assertEquals('Hans', $check->first_name);
+        self::assertEquals('Thomas', $check->last_name);
+        self::assertEquals('Hans Thomas', $check->fullname);
     }
 
     public function testManualStringId(): void

--- a/tests/Models/User.php
+++ b/tests/Models/User.php
@@ -18,6 +18,8 @@ use MongoDB\Laravel\Eloquent\HybridRelations;
 use MongoDB\Laravel\Eloquent\MassPrunable;
 use MongoDB\Laravel\Eloquent\Model as Eloquent;
 
+use function array_unique;
+
 /**
  * @property string $_id
  * @property string $name
@@ -114,6 +116,14 @@ class User extends Eloquent implements AuthenticatableContract, CanResetPassword
         return Attribute::make(
             get: fn ($value) => $value,
             set: fn ($values) => array_unique($values)
+        );
+    }
+
+    protected function fullname(): Attribute
+    {
+        return Attribute::make(
+            get: fn ($value) => $this->first_name . ' ' . $this->last_name,
+            set: fn ($values) => ['first_name' => $values[0], 'last_name' => $values[1]]
         );
     }
 

--- a/tests/Models/User.php
+++ b/tests/Models/User.php
@@ -109,6 +109,14 @@ class User extends Eloquent implements AuthenticatableContract, CanResetPassword
         );
     }
 
+    protected function skills(): Attribute
+    {
+        return Attribute::make(
+            get: fn ($value) => $value,
+            set: fn ($values) => array_unique($values)
+        );
+    }
+
     public function prunable(): Builder
     {
         return $this->where('age', '>', 18);


### PR DESCRIPTION
Hi,
As mentioned in #2634, creating a mutator for the `array` type attribute will throw an error while setting the value to the attribute. This error will be thrown because of the invalid value prepared for the update action. So I override `normalizeCastClassResponse` method from `Illuminate\Database\Eloquent\Concerns\HasAttributes` trait and force it to add the key name all the time.

So if we have something like this on our model class
```php
protected function skills(): Attribute
{
    return Attribute::make(
        get: fn ($value) => $value,
        set: fn ($values) => array_unique($values)
    );
}
```
we do not get an error anymore.