### PR TITLE
PHPORM-100 Support query on numerical field names

### DIFF
--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -209,14 +209,14 @@ abstract class Model extends BaseModel
     /** @inheritdoc */
     public function setAttribute($key, $value)
     {
+        $key = (string) $key;
+
         // Convert _id to ObjectID.
         if ($key === '_id' && is_string($value)) {
             $builder = $this->newBaseQueryBuilder();
 
             $value = $builder->convertKey($value);
         }
-
-        $key = (string) $key;
 
         // Support keys in dot notation.
         if (str_contains($key, '.')) {

--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -169,6 +169,8 @@ abstract class Model extends BaseModel
             return null;
         }
 
+        $key = (string) $key;
+
         // An unset attribute is null or throw an exception.
         if (isset($this->unset[$key])) {
             return $this->throwMissingAttributeExceptionIfApplicable($key);
@@ -194,6 +196,8 @@ abstract class Model extends BaseModel
     /** @inheritdoc */
     protected function getAttributeFromArray($key)
     {
+        $key = (string) $key;
+
         // Support keys in dot notation.
         if (str_contains($key, '.')) {
             return Arr::get($this->attributes, $key);
@@ -211,6 +215,8 @@ abstract class Model extends BaseModel
 
             $value = $builder->convertKey($value);
         }
+
+        $key = (string) $key;
 
         // Support keys in dot notation.
         if (str_contains($key, '.')) {
@@ -314,6 +320,8 @@ abstract class Model extends BaseModel
     /** @inheritdoc */
     public function offsetUnset($offset): void
     {
+        $offset = (string) $offset;
+
         if (str_contains($offset, '.')) {
             // Update the field in the subdocument
             Arr::forget($this->attributes, $offset);

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -953,7 +953,20 @@ class Builder extends BaseBuilder
         return $id;
     }
 
-    /** @inheritdoc */
+    /**
+     * Add a basic where clause to the query.
+     *
+     * If 1 argument, the signature is: where(array|Closure $where)
+     * If 2 arguments, the signature is: where(string $column, mixed $value)
+     * If 3 arguments, the signature is: where(string $colum, string $operator, mixed $value)
+     *
+     * @param  Closure|string|array $column
+     * @param  mixed                $operator
+     * @param  mixed                $value
+     * @param  string               $boolean
+     *
+     * @return $this
+     */
     public function where($column, $operator = null, $value = null, $boolean = 'and')
     {
         $params = func_get_args();

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -45,8 +45,8 @@ use function get_debug_type;
 use function implode;
 use function in_array;
 use function is_array;
+use function is_callable;
 use function is_int;
-use function is_scalar;
 use function is_string;
 use function md5;
 use function preg_match;
@@ -967,8 +967,8 @@ class Builder extends BaseBuilder
             }
         }
 
-        if (func_num_args() === 1 && is_scalar($column)) {
-            throw new ArgumentCountError(sprintf('Too few arguments to function %s(%s), 1 passed and at least 2 expected when the 1st is not an array.', __METHOD__, var_export($column, true)));
+        if (func_num_args() === 1 && ! is_array($column) && ! is_callable($column)) {
+            throw new ArgumentCountError(sprintf('Too few arguments to function %s(%s), 1 passed and at least 2 expected when the 1st is not an array or a callable', __METHOD__, var_export($column, true)));
         }
 
         return parent::where(...$params);

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -971,6 +971,10 @@ class Builder extends BaseBuilder
             throw new ArgumentCountError(sprintf('Too few arguments to function %s(%s), 1 passed and at least 2 expected when the 1st is not an array or a callable', __METHOD__, var_export($column, true)));
         }
 
+        if (! is_int($column) && ! is_string($column)) {
+            throw new InvalidArgumentException(sprintf('First argument of %s must be a column name as "string". Got "%s"', __METHOD__, get_debug_type($column)));
+        }
+
         return parent::where(...$params);
     }
 

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -23,13 +23,11 @@ use MongoDB\BSON\Regex;
 use MongoDB\BSON\UTCDateTime;
 use MongoDB\Driver\Cursor;
 use RuntimeException;
-use Stringable;
 
 use function array_fill_keys;
 use function array_is_list;
 use function array_key_exists;
 use function array_merge;
-use function array_merge_recursive;
 use function array_values;
 use function array_walk_recursive;
 use function assert;
@@ -47,6 +45,7 @@ use function implode;
 use function in_array;
 use function is_array;
 use function is_int;
+use function is_scalar;
 use function is_string;
 use function md5;
 use function preg_match;
@@ -60,6 +59,7 @@ use function str_starts_with;
 use function strlen;
 use function strtolower;
 use function substr;
+use function var_export;
 
 class Builder extends BaseBuilder
 {
@@ -665,7 +665,7 @@ class Builder extends BaseBuilder
     {
         // Use $set as default operator for field names that are not in an operator
         foreach ($values as $key => $value) {
-            if (str_starts_with($key, '$')) {
+            if (is_string($key) && str_starts_with($key, '$')) {
                 continue;
             }
 
@@ -966,8 +966,8 @@ class Builder extends BaseBuilder
             }
         }
 
-        if (func_num_args() === 1 && is_string($column)) {
-            throw new ArgumentCountError(sprintf('Too few arguments to function %s("%s"), 1 passed and at least 2 expected when the 1st is a string.', __METHOD__, $column));
+        if (func_num_args() === 1 && is_scalar($column)) {
+            throw new ArgumentCountError(sprintf('Too few arguments to function %s(%s), 1 passed and at least 2 expected when the 1st is a scalar.', __METHOD__, var_export($column, true)));
         }
 
         return parent::where(...$params);
@@ -998,7 +998,7 @@ class Builder extends BaseBuilder
             }
 
             // Convert column name to string to use as array key
-            if (isset($where['column']) && $where['column'] instanceof Stringable) {
+            if (isset($where['column'])) {
                 $where['column'] = (string) $where['column'];
             }
 
@@ -1076,7 +1076,14 @@ class Builder extends BaseBuilder
             }
 
             // Merge the compiled where with the others.
-            $compiled = array_merge_recursive($compiled, $result);
+            // array_merge_recursive can't be used here because it converts int keys to sequential int.
+            foreach ($result as $key => $value) {
+                if (in_array($key, ['$and', '$or', '$nor'])) {
+                    $compiled[$key] = array_merge($compiled[$key] ?? [], $value);
+                } else {
+                    $compiled[$key] = $value;
+                }
+            }
         }
 
         return $compiled;

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -968,7 +968,7 @@ class Builder extends BaseBuilder
         }
 
         if (func_num_args() === 1 && is_scalar($column)) {
-            throw new ArgumentCountError(sprintf('Too few arguments to function %s(%s), 1 passed and at least 2 expected when the 1st is a scalar.', __METHOD__, var_export($column, true)));
+            throw new ArgumentCountError(sprintf('Too few arguments to function %s(%s), 1 passed and at least 2 expected when the 1st is not an array.', __METHOD__, var_export($column, true)));
         }
 
         return parent::where(...$params);

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -45,8 +45,11 @@ use function get_debug_type;
 use function implode;
 use function in_array;
 use function is_array;
+use function is_bool;
 use function is_callable;
+use function is_float;
 use function is_int;
+use function is_null;
 use function is_string;
 use function md5;
 use function preg_match;
@@ -984,8 +987,8 @@ class Builder extends BaseBuilder
             throw new ArgumentCountError(sprintf('Too few arguments to function %s(%s), 1 passed and at least 2 expected when the 1st is not an array or a callable', __METHOD__, var_export($column, true)));
         }
 
-        if (! is_int($column) && ! is_string($column)) {
-            throw new InvalidArgumentException(sprintf('First argument of %s must be a column name as "string". Got "%s"', __METHOD__, get_debug_type($column)));
+        if (is_float($column) || is_bool($column) || is_null($column)) {
+            throw new InvalidArgumentException(sprintf('First argument of %s must be a field path as "string". Got "%s"', __METHOD__, get_debug_type($column)));
         }
 
         return parent::where(...$params);

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -27,6 +27,7 @@ use RuntimeException;
 use function array_fill_keys;
 use function array_is_list;
 use function array_key_exists;
+use function array_map;
 use function array_merge;
 use function array_values;
 use function array_walk_recursive;
@@ -1006,9 +1007,7 @@ class Builder extends BaseBuilder
             if (isset($where['column']) && ($where['column'] === '_id' || str_ends_with($where['column'], '._id'))) {
                 if (isset($where['values'])) {
                     // Multiple values.
-                    foreach ($where['values'] as &$value) {
-                        $value = $this->convertKey($value);
-                    }
+                    $where['values'] = array_map($this->convertKey(...), $where['values']);
                 } elseif (isset($where['value'])) {
                     // Single value.
                     $where['value'] = $this->convertKey($where['value']);

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -976,15 +976,19 @@ class ModelTest extends TestCase
     {
         $user      = new User();
         $user->{1} = 'one';
-        $user->{2} = ['2' => 'two.two'];
+        $user->{2} = ['3' => 'two.three'];
         $user->save();
 
         $found = User::where(1, 'one')->first();
         $this->assertInstanceOf(User::class, $found);
         $this->assertEquals('one', $found[1]);
 
-        $found = User::where('2.2', 'two.two')->first();
+        $found = User::where('2.3', 'two.three')->first();
         $this->assertInstanceOf(User::class, $found);
-        $this->assertEquals([2 => 'two.two'], $found[2]);
+        $this->assertEquals([3 => 'two.three'], $found[2]);
+
+        $found = User::where(2.3, 'two.three')->first();
+        $this->assertInstanceOf(User::class, $found);
+        $this->assertEquals([3 => 'two.three'], $found[2]);
     }
 }

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -971,4 +971,20 @@ class ModelTest extends TestCase
         $this->assertSame(MemberStatus::Member->value, $check->getRawOriginal('member_status'));
         $this->assertSame(MemberStatus::Member, $check->member_status);
     }
+
+    public function testNumericFieldName(): void
+    {
+        $user      = new User();
+        $user->{1} = 'one';
+        $user->{2} = ['2' => 'two.two'];
+        $user->save();
+
+        $found = User::where(1, 'one')->first();
+        $this->assertInstanceOf(User::class, $found);
+        $this->assertEquals('one', $found[1]);
+
+        $found = User::where('2.2', 'two.two')->first();
+        $this->assertInstanceOf(User::class, $found);
+        $this->assertEquals([2 => 'two.two'], $found[2]);
+    }
 }

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -986,9 +986,5 @@ class ModelTest extends TestCase
         $found = User::where('2.3', 'two.three')->first();
         $this->assertInstanceOf(User::class, $found);
         $this->assertEquals([3 => 'two.three'], $found[2]);
-
-        $found = User::where(2.3, 'two.three')->first();
-        $this->assertInstanceOf(User::class, $found);
-        $this->assertEquals([3 => 'two.three'], $found[2]);
     }
 }

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -1180,13 +1180,13 @@ class BuilderTest extends TestCase
 
         yield 'find with single string argument' => [
             ArgumentCountError::class,
-            'Too few arguments to function MongoDB\Laravel\Query\Builder::where(\'foo\'), 1 passed and at least 2 expected when the 1st is a scalar',
+            'Too few arguments to function MongoDB\Laravel\Query\Builder::where(\'foo\'), 1 passed and at least 2 expected when the 1st is not an array',
             fn (Builder $builder) => $builder->where('foo'),
         ];
 
         yield 'find with single numeric argument' => [
             ArgumentCountError::class,
-            'Too few arguments to function MongoDB\Laravel\Query\Builder::where(123), 1 passed and at least 2 expected when the 1st is a scalar',
+            'Too few arguments to function MongoDB\Laravel\Query\Builder::where(123), 1 passed and at least 2 expected when the 1st is not an array',
             fn (Builder $builder) => $builder->where(123),
         ];
 

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -1222,7 +1222,7 @@ class BuilderTest extends TestCase
 
         yield 'where invalid column type' => [
             InvalidArgumentException::class,
-            'First argument of MongoDB\Laravel\Query\Builder::where must be a column name as "string". Got "float"',
+            'First argument of MongoDB\Laravel\Query\Builder::where must be a field path as "string". Got "float"',
             fn (Builder $builder) => $builder->where(2.3, '>', 1),
         ];
     }

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -1219,6 +1219,12 @@ class BuilderTest extends TestCase
             'Invalid time format, expected HH:MM:SS, HH:MM or HH, got "stdClass"',
             fn (Builder $builder) => $builder->whereTime('created_at', new stdClass()),
         ];
+
+        yield 'where invalid column type' => [
+            InvalidArgumentException::class,
+            'First argument of MongoDB\Laravel\Query\Builder::where must be a column name as "string". Got "float"',
+            fn (Builder $builder) => $builder->where(2.3, '>', 1),
+        ];
     }
 
     /** @dataProvider getEloquentMethodsNotSupported */

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -90,6 +90,11 @@ class BuilderTest extends TestCase
             fn (Builder $builder) => $builder->where('foo', 'bar'),
         ];
 
+        yield 'find with numeric field name' => [
+            ['find' => [['123' => 'bar'], []]],
+            fn (Builder $builder) => $builder->where(123, 'bar'),
+        ];
+
         yield 'where with single array of conditions' => [
             [
                 'find' => [
@@ -1175,8 +1180,14 @@ class BuilderTest extends TestCase
 
         yield 'find with single string argument' => [
             ArgumentCountError::class,
-            'Too few arguments to function MongoDB\Laravel\Query\Builder::where("foo"), 1 passed and at least 2 expected when the 1st is a string',
+            'Too few arguments to function MongoDB\Laravel\Query\Builder::where(\'foo\'), 1 passed and at least 2 expected when the 1st is a scalar',
             fn (Builder $builder) => $builder->where('foo'),
+        ];
+
+        yield 'find with single numeric argument' => [
+            ArgumentCountError::class,
+            'Too few arguments to function MongoDB\Laravel\Query\Builder::where(123), 1 passed and at least 2 expected when the 1st is a scalar',
+            fn (Builder $builder) => $builder->where(123),
         ];
 
         yield 'where regex not starting with /' => [


### PR DESCRIPTION
Fix PHPORM-100
Fix #2639
Related to #2634

- Fix filter on numeric field names.
- Expand the "Too few arguments" exception in `Query::where()` to all scalar values instead of only string as column.
- Cast to field name to string when calling `str_*` functions.

This bug was existing before 4.0.0, this change could be considered a new feature for 4.1 or merged as a bugfix in 4.0