### PR TITLE
Add tests on Adding New Fields and fetch relationships withThrashed

### DIFF
--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -115,14 +115,13 @@ class ModelTest extends TestCase
         $check = User::find($user->_id);
         $this->assertEquals(20, $check->age);
 
-        $check->age = 24;
+        $check->age      = 24;
         $check->fullname = 'Hans Thomas'; // new field
         $check->save();
 
         $check = User::find($user->_id);
         $this->assertEquals(24, $check->age);
         $this->assertEquals('Hans Thomas', $check->fullname);
-
     }
 
     public function testManualStringId(): void

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -83,6 +83,10 @@ class ModelTest extends TestCase
         $this->assertEquals(35, $user->age);
     }
 
+    /**
+     * @return void
+     * @group hans
+     */
     public function testUpdate(): void
     {
         $user        = new User();
@@ -114,6 +118,15 @@ class ModelTest extends TestCase
 
         $check = User::find($user->_id);
         $this->assertEquals(20, $check->age);
+
+        $check->age = 24;
+        $check->fullname = 'Hans Thomas'; // new field
+        $check->save();
+
+        $check = User::find($user->_id);
+        $this->assertEquals(24, $check->age);
+        $this->assertEquals('Hans Thomas', $check->fullname);
+
     }
 
     public function testManualStringId(): void

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -83,10 +83,6 @@ class ModelTest extends TestCase
         $this->assertEquals(35, $user->age);
     }
 
-    /**
-     * @return void
-     * @group hans
-     */
     public function testUpdate(): void
     {
         $user        = new User();

--- a/tests/Models/Soft.php
+++ b/tests/Models/Soft.php
@@ -25,4 +25,10 @@ class Soft extends Eloquent
     {
         return $this->newQuery();
     }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
 }

--- a/tests/Models/Soft.php
+++ b/tests/Models/Soft.php
@@ -30,5 +30,4 @@ class Soft extends Eloquent
     {
         return $this->belongsTo(User::class);
     }
-
 }

--- a/tests/Models/User.php
+++ b/tests/Models/User.php
@@ -51,6 +51,16 @@ class User extends Eloquent implements AuthenticatableContract, CanResetPassword
         return $this->hasMany(Book::class, 'author_id');
     }
 
+    public function softs()
+    {
+        return $this->hasMany(Soft::class);
+    }
+
+    public function softsWithTrashed()
+    {
+        return $this->hasMany(Soft::class)->withTrashed();
+    }
+
     public function sqlBooks()
     {
         return $this->hasMany(SqlBook::class, 'author_id');

--- a/tests/RelationsTest.php
+++ b/tests/RelationsTest.php
@@ -13,6 +13,7 @@ use MongoDB\Laravel\Tests\Models\Group;
 use MongoDB\Laravel\Tests\Models\Item;
 use MongoDB\Laravel\Tests\Models\Photo;
 use MongoDB\Laravel\Tests\Models\Role;
+use MongoDB\Laravel\Tests\Models\Soft;
 use MongoDB\Laravel\Tests\Models\User;
 
 class RelationsTest extends TestCase
@@ -48,6 +49,24 @@ class RelationsTest extends TestCase
 
         $items = $user->items;
         $this->assertCount(3, $items);
+    }
+    
+    public function testHasManyWithTrashed(): void
+    {
+        $user = User::create(['name' => 'George R. R. Martin']);
+        $first = Soft::create(['title' => 'A Game of Thrones', 'user_id' => $user->_id]);
+        $second = Soft::create(['title' => 'The Witcher', 'user_id' => $user->_id]);
+
+        self::assertNull($first->deleted_at);
+        self::assertEquals($user->_id,$first->user->_id);
+        self::assertEquals([$first->_id,$second->_id],$user->softs->pluck('_id')->toArray());
+
+        $first->delete();
+        $user->refresh();
+
+        self::assertNotNull($first->deleted_at);
+        self::assertEquals([$second->_id],$user->softs->pluck('_id')->toArray());
+        self::assertEquals([$first->_id,$second->_id],$user->softsWithTrashed->pluck('_id')->toArray());
     }
 
     public function testBelongsTo(): void

--- a/tests/RelationsTest.php
+++ b/tests/RelationsTest.php
@@ -50,23 +50,23 @@ class RelationsTest extends TestCase
         $items = $user->items;
         $this->assertCount(3, $items);
     }
-    
+
     public function testHasManyWithTrashed(): void
     {
-        $user = User::create(['name' => 'George R. R. Martin']);
-        $first = Soft::create(['title' => 'A Game of Thrones', 'user_id' => $user->_id]);
+        $user   = User::create(['name' => 'George R. R. Martin']);
+        $first  = Soft::create(['title' => 'A Game of Thrones', 'user_id' => $user->_id]);
         $second = Soft::create(['title' => 'The Witcher', 'user_id' => $user->_id]);
 
         self::assertNull($first->deleted_at);
-        self::assertEquals($user->_id,$first->user->_id);
-        self::assertEquals([$first->_id,$second->_id],$user->softs->pluck('_id')->toArray());
+        self::assertEquals($user->_id, $first->user->_id);
+        self::assertEquals([$first->_id, $second->_id], $user->softs->pluck('_id')->toArray());
 
         $first->delete();
         $user->refresh();
 
         self::assertNotNull($first->deleted_at);
-        self::assertEquals([$second->_id],$user->softs->pluck('_id')->toArray());
-        self::assertEquals([$first->_id,$second->_id],$user->softsWithTrashed->pluck('_id')->toArray());
+        self::assertEquals([$second->_id], $user->softs->pluck('_id')->toArray());
+        self::assertEquals([$first->_id, $second->_id], $user->softsWithTrashed->pluck('_id')->toArray());
     }
 
     public function testBelongsTo(): void


### PR DESCRIPTION
Hi, I write tests for some issues to ensure they are fixed.
- #2468: Ensure it is possible to add a new field on updating an existing document
- #2423: Ensure it is possible to retrieve `OneToMany` relationship's data with and without trashed

You can close them now.