### PR TITLE
PHPORM-101 Allow empty insert batch for consistency with Eloquent SQL

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -613,6 +613,11 @@ class Builder extends BaseBuilder
     /** @inheritdoc */
     public function insert(array $values)
     {
+        // Allow empty insert batch for consistency with Eloquent SQL
+        if ($values === []) {
+            return true;
+        }
+
         // Since every insert gets treated like a batch insert, we will have to detect
         // if the user is inserting a single document or an array of documents.
         $batch = true;

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -225,6 +225,12 @@ class ModelTest extends TestCase
         $this->assertEquals(35, $check->age);
     }
 
+    public function testInsertEmpty(): void
+    {
+        $success = User::insert([]);
+        $this->assertTrue($success);
+    }
+
     public function testGet(): void
     {
         User::insert([


### PR DESCRIPTION
Fix [PHPORM-101](https://jira.mongodb.org/browse/PHPORM-101)
Fix https://github.com/mongodb/laravel-mongodb/issues/1704

Eloquent SQL allows empty inserts and shortcuts the call to the database. Do the same for consistency.

https://github.com/laravel/framework/blob/a47df681bf4b72cb11e38f7ee7c285406ca934e0/src/Illuminate/Database/Query/Builder.php#L3307-L3314



