### PR TITLE
Handling single model in sync method

### DIFF
--- a/src/Relations/BelongsToMany.php
+++ b/src/Relations/BelongsToMany.php
@@ -117,6 +117,8 @@ class BelongsToMany extends EloquentBelongsToMany
 
         if ($ids instanceof Collection) {
             $ids = $ids->modelKeys();
+        } elseif ($ids instanceof Model) {
+            $ids = $this->parseIds($ids);
         }
 
         // First we need to attach any of the associated models that are not currently

--- a/tests/RelationsTest.php
+++ b/tests/RelationsTest.php
@@ -255,6 +255,36 @@ class RelationsTest extends TestCase
         $this->assertCount(1, $client->users);
     }
 
+    public function testSyncBelongsToMany()
+    {
+        $user = User::create(['name' => 'John Doe']);
+
+        $first  = Client::query()->create(['name' => 'Hans']);
+        $second = Client::query()->create(['name' => 'Thomas']);
+
+        $user->load('clients');
+        self::assertEmpty($user->clients);
+
+        $user->clients()->sync($first);
+
+        $user->load('clients');
+        self::assertCount(1, $user->clients);
+        self::assertTrue($user->clients->first()->is($first));
+
+        $user->clients()->sync($second);
+
+        $user->load('clients');
+        self::assertCount(1, $user->clients);
+        self::assertTrue($user->clients->first()->is($second));
+
+        $user->clients()->syncWithoutDetaching($first);
+
+        $user->load('clients');
+        self::assertCount(2, $user->clients);
+        self::assertTrue($user->clients->first()->is($first));
+        self::assertTrue($user->clients->last()->is($second));
+    }
+
     public function testBelongsToManyAttachesExistingModels(): void
     {
         $user = User::create(['name' => 'John Doe', 'client_ids' => ['1234523']]);


### PR DESCRIPTION
Hi, `sync` and `syncWithoutDetaching` methods now accept a single model as an argument.
Related issue (fix #2395) and PR (fix #2396).