### PR TITLE
Fix Call to undefined method compileWhereSub()

### DIFF
--- a/src/Eloquent/Builder.php
+++ b/src/Eloquent/Builder.php
@@ -92,7 +92,7 @@ class Builder extends EloquentBuilder
             return $this->model->getKey();
         }
 
-        return parent::insertGetId($values, $sequence);
+        return $this->toBase()->insertGetId($values, $sequence);
     }
 
     /** @inheritdoc */


### PR DESCRIPTION
It fixes the #2656 issue. I believe some updates in dependencies caused this break.