### PR TITLE
Test with lowest dependencies in CI

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
     build:
         runs-on: ${{ matrix.os }}
-        name: PHP v${{ matrix.php }} with MongoDB ${{ matrix.mongodb }}
+        name: PHP v${{ matrix.php }} with MongoDB ${{ matrix.mongodb }} ${{ matrix.mode }}
         strategy:
             matrix:
                 os:
@@ -23,6 +23,10 @@ jobs:
                     - '8.1'
                     - '8.2'
                     - '8.3'
+                include:
+                    - php: '8.1'
+                      mongodb: '5.0'
+                      mode: 'low-deps'
 
         steps:
             -   uses: actions/checkout@v4
@@ -63,7 +67,7 @@ jobs:
                     restore-keys: ${{ matrix.os }}-composer-
             -   name: Install dependencies
                 run: |
-                    composer install --no-interaction
+                    composer update --no-interaction $([[ "${{ matrix.mode }}" == low-deps ]] && echo ' --prefer-lowest --prefer-stable')
             -   name: Run tests
                 run: |
                     ./vendor/bin/phpunit --coverage-clover coverage.xml


### PR DESCRIPTION
As seen with the [recent breaking change in Laravel 10.30](https://github.com/mongodb/laravel-mongodb/pull/2661#issuecomment-1790830940), we need to test for highest and lowest dependencies.

