### PR TITLE
[Fix] BelongsToMany sync does't use configured keys

### DIFF
--- a/src/Relations/BelongsToMany.php
+++ b/src/Relations/BelongsToMany.php
@@ -190,10 +190,10 @@ class BelongsToMany extends EloquentBelongsToMany
 
             $query = $this->newRelatedQuery();
 
-            $query->whereIn($this->related->getKeyName(), (array) $id);
+            $query->whereIn($this->relatedKey, (array) $id);
 
             // Attach the new parent id to the related model.
-            $query->push($this->foreignPivotKey, $this->parent->getKey(), true);
+            $query->push($this->foreignPivotKey, $this->parent->{$this->parentKey}, true);
         }
 
         // Attach the new ids to the parent model.

--- a/src/Relations/BelongsToMany.php
+++ b/src/Relations/BelongsToMany.php
@@ -116,7 +116,7 @@ class BelongsToMany extends EloquentBelongsToMany
         ];
 
         if ($ids instanceof Collection) {
-            $ids = $ids->modelKeys();
+            $ids = $this->parseIds($ids);
         } elseif ($ids instanceof Model) {
             $ids = $this->parseIds($ids);
         }

--- a/src/Relations/BelongsToMany.php
+++ b/src/Relations/BelongsToMany.php
@@ -76,7 +76,7 @@ class BelongsToMany extends EloquentBelongsToMany
     {
         $foreign = $this->getForeignKey();
 
-        $this->query->where($foreign, '=', $this->parent->getKey());
+        $this->query->where($foreign, '=', $this->parent->{$this->parentKey});
 
         return $this;
     }

--- a/tests/Models/Experience.php
+++ b/tests/Models/Experience.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Laravel\Tests\Models;
+
+use MongoDB\Laravel\Eloquent\Model as Eloquent;
+
+class Experience extends Eloquent
+{
+    protected $connection       = 'mongodb';
+    protected $collection       = 'experiences';
+    protected static $unguarded = true;
+
+    protected $casts = ['years' => 'int'];
+
+    public function skills()
+    {
+        return $this->belongsToMany(Skill::class, relatedKey: 'cskill_id');
+    }
+}

--- a/tests/Models/Experience.php
+++ b/tests/Models/Experience.php
@@ -18,4 +18,9 @@ class Experience extends Eloquent
     {
         return $this->belongsToMany(Skill::class, relatedKey: 'cskill_id');
     }
+
+    public function skillsWithCustomParentKey()
+    {
+        return $this->belongsToMany(Skill::class, parentKey: 'cexperience_id');
+    }
 }

--- a/tests/Models/Experience.php
+++ b/tests/Models/Experience.php
@@ -14,7 +14,7 @@ class Experience extends Eloquent
 
     protected $casts = ['years' => 'int'];
 
-    public function skills()
+    public function skillsWithCustomRelatedKey()
     {
         return $this->belongsToMany(Skill::class, relatedKey: 'cskill_id');
     }

--- a/tests/Models/Skill.php
+++ b/tests/Models/Skill.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Laravel\Tests\Models;
+
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\MorphOne;
+use MongoDB\BSON\ObjectId;
+use MongoDB\Laravel\Eloquent\Model as Eloquent;
+
+class Skill extends Eloquent
+{
+    protected $connection       = 'mongodb';
+    protected $collection       = 'skills';
+    protected static $unguarded = true;
+    protected $primaryKey = 'custom_id';
+
+    public function getForeignKey()
+    {
+        return 'custom_skill_id';
+    }
+
+    protected static function booted()
+    {
+        static::creating(fn (self $model) => $model->custom_id = (string)(new ObjectId()));
+    }
+
+    public function users(): BelongsToMany
+    {
+        return $this->belongsToMany(User::class);
+    }
+}

--- a/tests/Models/Skill.php
+++ b/tests/Models/Skill.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace MongoDB\Laravel\Tests\Models;
 
-use Illuminate\Database\Eloquent\Relations\BelongsToMany;
-use MongoDB\BSON\ObjectId;
 use MongoDB\Laravel\Eloquent\Model as Eloquent;
 
 class Skill extends Eloquent
@@ -13,20 +11,4 @@ class Skill extends Eloquent
     protected $connection       = 'mongodb';
     protected $collection       = 'skills';
     protected static $unguarded = true;
-    protected $primaryKey = 'custom_id';
-
-    public function getForeignKey()
-    {
-        return 'custom_skill_id';
-    }
-
-    protected static function booted()
-    {
-        static::creating(fn (self $model) => $model->custom_id = (string) (new ObjectId()));
-    }
-
-    public function users(): BelongsToMany
-    {
-        return $this->belongsToMany(User::class);
-    }
 }

--- a/tests/Models/Skill.php
+++ b/tests/Models/Skill.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace MongoDB\Laravel\Tests\Models;
 
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
-use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Database\Eloquent\Relations\MorphOne;
 use MongoDB\BSON\ObjectId;
 use MongoDB\Laravel\Eloquent\Model as Eloquent;
 
@@ -24,7 +22,7 @@ class Skill extends Eloquent
 
     protected static function booted()
     {
-        static::creating(fn (self $model) => $model->custom_id = (string)(new ObjectId()));
+        static::creating(fn (self $model) => $model->custom_id = (string) (new ObjectId()));
     }
 
     public function users(): BelongsToMany

--- a/tests/Models/User.php
+++ b/tests/Models/User.php
@@ -86,11 +86,6 @@ class User extends Eloquent implements AuthenticatableContract, CanResetPassword
         return $this->belongsToMany(Client::class);
     }
 
-    public function skills()
-    {
-        return $this->belongsToMany(Skill::class);
-    }
-
     public function groups()
     {
         return $this->belongsToMany(Group::class, 'groups', 'users', 'groups', '_id', '_id', 'groups');

--- a/tests/Models/User.php
+++ b/tests/Models/User.php
@@ -86,6 +86,11 @@ class User extends Eloquent implements AuthenticatableContract, CanResetPassword
         return $this->belongsToMany(Client::class);
     }
 
+    public function skills()
+    {
+        return $this->belongsToMany(Skill::class);
+    }
+
     public function groups()
     {
         return $this->belongsToMany(Group::class, 'groups', 'users', 'groups', '_id', '_id', 'groups');

--- a/tests/RelationsTest.php
+++ b/tests/RelationsTest.php
@@ -6,9 +6,11 @@ namespace MongoDB\Laravel\Tests;
 
 use Illuminate\Database\Eloquent\Collection;
 use Mockery;
+use MongoDB\BSON\ObjectId;
 use MongoDB\Laravel\Tests\Models\Address;
 use MongoDB\Laravel\Tests\Models\Book;
 use MongoDB\Laravel\Tests\Models\Client;
+use MongoDB\Laravel\Tests\Models\Experience;
 use MongoDB\Laravel\Tests\Models\Group;
 use MongoDB\Laravel\Tests\Models\Item;
 use MongoDB\Laravel\Tests\Models\Photo;
@@ -32,6 +34,7 @@ class RelationsTest extends TestCase
         Group::truncate();
         Photo::truncate();
         Skill::truncate();
+        Experience::truncate();
     }
 
     public function testHasMany(): void
@@ -345,30 +348,30 @@ class RelationsTest extends TestCase
         $this->assertCount(2, $user->clients);
     }
 
-    public function testBelongsToManySyncEloquentCollection(): void
+    public function testBelongsToManySyncEloquentCollectionWithCustomRelatedKey(): void
     {
-        $user = User::create(['name' => 'Hans Thomas']);
-        $skill1    = Skill::create(['name' => 'PHP 1']);
-        $skill2    = Skill::create(['name' => 'Laravel 2']);
+        $experience = Experience::create(['years' => '5']);
+        $skill1    = Skill::create(['cskill_id' => (string) (new ObjectId()),'name' => 'PHP']);
+        $skill2    = Skill::create(['cskill_id' => (string) (new ObjectId()),'name' => 'Laravel']);
         $collection = new Collection([$skill1, $skill2]);
 
-        $user = User::query()->find($user->_id);
-        $user->skills()->sync($collection);
-        $this->assertCount(2, $user->skills);
+        $experience = Experience::query()->find($experience->id);
+        $experience->skills()->sync($collection);
+        $this->assertCount(2, $experience->skills);
 
-        self::assertIsString($skill1->custom_id);
-        self::assertContains($skill1->custom_id, $user->custom_skill_ids);
+        self::assertIsString($skill1->cskill_id);
+        self::assertContains($skill1->cskill_id, $experience->skill_ids);
 
-        self::assertIsString($skill2->custom_id);
-        self::assertContains($skill2->custom_id, $user->custom_skill_ids);
+        self::assertIsString($skill2->cskill_id);
+        self::assertContains($skill2->cskill_id, $experience->skill_ids);
 
         $skill1->refresh();
         self::assertIsString($skill1->_id);
-        self::assertNotContains($skill1->_id, $user->custom_skill_ids);
+        self::assertNotContains($skill1->_id, $experience->skill_ids);
 
         $skill2->refresh();
         self::assertIsString($skill2->_id);
-        self::assertNotContains($skill2->_id, $user->custom_skill_ids);
+        self::assertNotContains($skill2->_id, $experience->skill_ids);
     }
 
     public function testBelongsToManySyncAlreadyPresent(): void

--- a/tests/RelationsTest.php
+++ b/tests/RelationsTest.php
@@ -356,22 +356,22 @@ class RelationsTest extends TestCase
         $collection = new Collection([$skill1, $skill2]);
 
         $experience = Experience::query()->find($experience->id);
-        $experience->skills()->sync($collection);
-        $this->assertCount(2, $experience->skills);
+        $experience->skillsWithCustomRelatedKey()->sync($collection);
+        $this->assertCount(2, $experience->skillsWithCustomRelatedKey);
 
         self::assertIsString($skill1->cskill_id);
-        self::assertContains($skill1->cskill_id, $experience->skill_ids);
+        self::assertContains($skill1->cskill_id, $experience->skillsWithCustomRelatedKey->pluck('cskill_id'));
 
         self::assertIsString($skill2->cskill_id);
-        self::assertContains($skill2->cskill_id, $experience->skill_ids);
+        self::assertContains($skill2->cskill_id, $experience->skillsWithCustomRelatedKey->pluck('cskill_id'));
 
         $skill1->refresh();
         self::assertIsString($skill1->_id);
-        self::assertNotContains($skill1->_id, $experience->skill_ids);
+        self::assertNotContains($skill1->_id, $experience->skillsWithCustomRelatedKey->pluck('cskill_id'));
 
         $skill2->refresh();
         self::assertIsString($skill2->_id);
-        self::assertNotContains($skill2->_id, $experience->skill_ids);
+        self::assertNotContains($skill2->_id, $experience->skillsWithCustomRelatedKey->pluck('cskill_id'));
     }
 
     public function testBelongsToManySyncEloquentCollectionWithCustomParentKey(): void

--- a/tests/RelationsTest.php
+++ b/tests/RelationsTest.php
@@ -6,7 +6,6 @@ namespace MongoDB\Laravel\Tests;
 
 use Illuminate\Database\Eloquent\Collection;
 use Mockery;
-use MongoDB\BSON\ObjectId;
 use MongoDB\Laravel\Tests\Models\Address;
 use MongoDB\Laravel\Tests\Models\Book;
 use MongoDB\Laravel\Tests\Models\Client;
@@ -358,18 +357,18 @@ class RelationsTest extends TestCase
         $this->assertCount(2, $user->skills);
 
         self::assertIsString($skill1->custom_id);
-        self::assertContains($skill1->custom_id,$user->custom_skill_ids);
+        self::assertContains($skill1->custom_id, $user->custom_skill_ids);
 
         self::assertIsString($skill2->custom_id);
-        self::assertContains($skill2->custom_id,$user->custom_skill_ids);
+        self::assertContains($skill2->custom_id, $user->custom_skill_ids);
 
         $skill1->refresh();
         self::assertIsString($skill1->_id);
-        self::assertNotContains($skill1->_id,$user->custom_skill_ids);
+        self::assertNotContains($skill1->_id, $user->custom_skill_ids);
 
         $skill2->refresh();
         self::assertIsString($skill2->_id);
-        self::assertNotContains($skill2->_id,$user->custom_skill_ids);
+        self::assertNotContains($skill2->_id, $user->custom_skill_ids);
     }
 
     public function testBelongsToManySyncAlreadyPresent(): void

--- a/tests/RelationsTest.php
+++ b/tests/RelationsTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace MongoDB\Laravel\Tests;
 
 use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Support\Facades\DB;
 use Mockery;
 use MongoDB\BSON\ObjectId;
 use MongoDB\Laravel\Tests\Models\Address;
@@ -352,8 +351,8 @@ class RelationsTest extends TestCase
     public function testBelongsToManySyncEloquentCollectionWithCustomRelatedKey(): void
     {
         $experience = Experience::create(['years' => '5']);
-        $skill1    = Skill::create(['cskill_id' => (string) (new ObjectId()),'name' => 'PHP']);
-        $skill2    = Skill::create(['cskill_id' => (string) (new ObjectId()),'name' => 'Laravel']);
+        $skill1    = Skill::create(['cskill_id' => (string) (new ObjectId()), 'name' => 'PHP']);
+        $skill2    = Skill::create(['cskill_id' => (string) (new ObjectId()), 'name' => 'Laravel']);
         $collection = new Collection([$skill1, $skill2]);
 
         $experience = Experience::query()->find($experience->id);
@@ -377,7 +376,7 @@ class RelationsTest extends TestCase
 
     public function testBelongsToManySyncEloquentCollectionWithCustomParentKey(): void
     {
-        $experience = Experience::create(['cexperience_id' => (string) (new ObjectId()),'years' => '5']);
+        $experience = Experience::create(['cexperience_id' => (string) (new ObjectId()), 'years' => '5']);
         $skill1    = Skill::create(['name' => 'PHP']);
         $skill2    = Skill::create(['name' => 'Laravel']);
         $collection = new Collection([$skill1, $skill2]);


### PR DESCRIPTION
Hi there,
In this PR, I fix #2666 issue. There were other bugs in using a `BelongsToMany` relationship with custom `relatedKey` or `parentKey` that I will explain in the comments.