### PR TITLE
Add tests to cover morphTo with hybrid MongoDB and SQL

### DIFF
--- a/tests/Models/Book.php
+++ b/tests/Models/Book.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MongoDB\Laravel\Tests\Models;
 
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphOne;
 use MongoDB\Laravel\Eloquent\Model as Eloquent;
 
 /**
@@ -27,5 +28,10 @@ class Book extends Eloquent
     public function sqlAuthor(): BelongsTo
     {
         return $this->belongsTo(SqlUser::class, 'author_id');
+    }
+
+    public function photo(): MorphOne
+    {
+        return $this->morphOne(SqlPhoto::class, 'has_image');
     }
 }

--- a/tests/Models/SqlBook.php
+++ b/tests/Models/SqlBook.php
@@ -6,6 +6,7 @@ namespace MongoDB\Laravel\Tests\Models;
 
 use Illuminate\Database\Eloquent\Model as EloquentModel;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\SQLiteBuilder;
 use Illuminate\Support\Facades\Schema;
@@ -17,14 +18,21 @@ class SqlBook extends EloquentModel
 {
     use HybridRelations;
 
-    protected $connection       = 'sqlite';
-    protected $table            = 'books';
+    protected $connection = 'sqlite';
+    protected $table = 'book';
     protected static $unguarded = true;
-    protected $primaryKey       = 'title';
+    protected $primaryKey = 'title';
+    public $incrementing = false;
+    protected $casts = ['title' => 'string'];
 
     public function author(): BelongsTo
     {
         return $this->belongsTo(User::class, 'author_id');
+    }
+
+    public function photo(): MorphOne
+    {
+        return $this->morphOne(Photo::class, 'has_image');
     }
 
     /**
@@ -35,8 +43,8 @@ class SqlBook extends EloquentModel
         $schema = Schema::connection('sqlite');
         assert($schema instanceof SQLiteBuilder);
 
-        $schema->dropIfExists('books');
-        $schema->create('books', function (Blueprint $table) {
+        $schema->dropIfExists('book');
+        $schema->create('book', function (Blueprint $table) {
             $table->string('title');
             $table->string('author_id')->nullable();
             $table->integer('sql_user_id')->unsigned()->nullable();

--- a/tests/Models/SqlPhoto.php
+++ b/tests/Models/SqlPhoto.php
@@ -5,30 +5,25 @@ declare(strict_types=1);
 namespace MongoDB\Laravel\Tests\Models;
 
 use Illuminate\Database\Eloquent\Model as EloquentModel;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\SQLiteBuilder;
 use Illuminate\Support\Facades\Schema;
 use MongoDB\Laravel\Eloquent\HybridRelations;
+use MongoDB\Laravel\Relations\MorphTo;
 
 use function assert;
 
-class SqlRole extends EloquentModel
+class SqlPhoto extends EloquentModel
 {
     use HybridRelations;
 
     protected $connection       = 'sqlite';
-    protected $table            = 'role';
-    protected static $unguarded = true;
+    protected $table            = 'photo';
+    protected $fillable = ['url'];
 
-    public function user(): BelongsTo
+    public function hasImage(): MorphTo
     {
-        return $this->belongsTo(User::class);
-    }
-
-    public function sqlUser(): BelongsTo
-    {
-        return $this->belongsTo(SqlUser::class);
+        return $this->morphTo();
     }
 
     /**
@@ -39,10 +34,12 @@ class SqlRole extends EloquentModel
         $schema = Schema::connection('sqlite');
         assert($schema instanceof SQLiteBuilder);
 
-        $schema->dropIfExists('role');
-        $schema->create('role', function (Blueprint $table) {
-            $table->string('type');
-            $table->string('user_id');
+        $schema->dropIfExists('photo');
+        $schema->create('photo', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('url');
+            $table->string('has_image_id')->nullable();
+            $table->string('has_image_type')->nullable();
             $table->timestamps();
         });
     }

--- a/tests/Models/SqlUser.php
+++ b/tests/Models/SqlUser.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\SQLiteBuilder;
 use Illuminate\Support\Facades\Schema;
 use MongoDB\Laravel\Eloquent\HybridRelations;
+use MongoDB\Laravel\Relations\MorphMany;
 
 use function assert;
 
@@ -19,7 +20,7 @@ class SqlUser extends EloquentModel
     use HybridRelations;
 
     protected $connection       = 'sqlite';
-    protected $table            = 'users';
+    protected $table            = 'user';
     protected static $unguarded = true;
 
     public function books(): HasMany
@@ -30,6 +31,11 @@ class SqlUser extends EloquentModel
     public function role(): HasOne
     {
         return $this->hasOne(Role::class);
+    }
+
+    public function photos(): MorphMany
+    {
+        return $this->morphMany(Photo::class, 'has_image');
     }
 
     public function sqlBooks(): HasMany
@@ -45,8 +51,8 @@ class SqlUser extends EloquentModel
         $schema = Schema::connection('sqlite');
         assert($schema instanceof SQLiteBuilder);
 
-        $schema->dropIfExists('users');
-        $schema->create('users', function (Blueprint $table) {
+        $schema->dropIfExists('user');
+        $schema->create('user', function (Blueprint $table) {
             $table->increments('id');
             $table->string('name');
             $table->timestamps();

--- a/tests/Models/User.php
+++ b/tests/Models/User.php
@@ -17,6 +17,8 @@ use MongoDB\Laravel\Eloquent\Builder;
 use MongoDB\Laravel\Eloquent\HybridRelations;
 use MongoDB\Laravel\Eloquent\MassPrunable;
 use MongoDB\Laravel\Eloquent\Model as Eloquent;
+use MongoDB\Laravel\Relations\EmbedsMany;
+use MongoDB\Laravel\Relations\MorphMany;
 
 /**
  * @property string $_id
@@ -91,12 +93,12 @@ class User extends Eloquent implements AuthenticatableContract, CanResetPassword
         return $this->belongsToMany(Group::class, 'groups', 'users', 'groups', '_id', '_id', 'groups');
     }
 
-    public function photos()
+    public function photos(): MorphMany
     {
         return $this->morphMany(Photo::class, 'has_image');
     }
 
-    public function addresses()
+    public function addresses(): EmbedsMany
     {
         return $this->embedsMany(Address::class);
     }


### PR DESCRIPTION
Follow #2669

Add tests for SQL model to MongoDB model morph relation in both directions.

In tests, I rename SQL tables to singular (common practice) to ensure we don't mess with collection name of similar models. It helps when debugging.

