### PR TITLE
PHPORM-119 Fix integration with Spatie Query Builder - Don't qualify field names in document models

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
         "phpunit/phpunit": "^10.3",
         "orchestra/testbench": "^8.0",
         "mockery/mockery": "^1.4.4",
-        "doctrine/coding-standard": "12.0.x-dev"
+        "doctrine/coding-standard": "12.0.x-dev",
+        "spatie/laravel-query-builder": "^5.6"
     },
     "replace": {
         "jenssegers/mongodb": "self.version"

--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -578,6 +578,12 @@ abstract class Model extends BaseModel
     }
 
     /** @inheritdoc */
+    public function qualifyColumn($column)
+    {
+        return $column;
+    }
+
+    /** @inheritdoc */
     protected function newBaseQueryBuilder()
     {
         $connection = $this->getConnection();

--- a/tests/ExternalPackageTest.php
+++ b/tests/ExternalPackageTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Laravel\Tests;
+
+use Composer\InstalledVersions;
+use Illuminate\Http\Request;
+use MongoDB\Laravel\Tests\Models\User;
+use Spatie\QueryBuilder\AllowedFilter;
+use Spatie\QueryBuilder\AllowedSort;
+use Spatie\QueryBuilder\QueryBuilder;
+
+/**
+ * Test integration with external packages.
+ */
+class ExternalPackageTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        User::truncate();
+    }
+
+    public function testSpacieQueryBuilder(): void
+    {
+        if (! InstalledVersions::isInstalled('spatie/laravel-query-builder')) {
+            $this->markTestSkipped('spatie/laravel-query-builder is not installed.');
+        }
+
+        User::insert([
+            ['name' => 'Jane Doe', 'birthday' => '1983-09-10', 'role' => 'admin'],
+            ['name' => 'John Doe', 'birthday' => '1980-07-08', 'role' => 'admin'],
+            ['name' => 'Jimmy Doe', 'birthday' => '2012-11-12', 'role' => 'user'],
+        ]);
+
+        $request = Request::create('/users', 'GET', ['filter' => ['role' => 'admin'], 'sort' => '-birthday']);
+        $result = QueryBuilder::for(User::class, $request)
+            ->allowedFilters([
+                AllowedFilter::exact('role'),
+            ])
+            ->allowedSorts([
+                AllowedSort::field('birthday'),
+            ])
+            ->get();
+
+        $this->assertCount(2, $result);
+        $this->assertSame('Jane Doe', $result[0]->name);
+    }
+}

--- a/tests/ExternalPackageTest.php
+++ b/tests/ExternalPackageTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace MongoDB\Laravel\Tests;
 
-use Composer\InstalledVersions;
 use Illuminate\Http\Request;
 use MongoDB\Laravel\Tests\Models\User;
 use Spatie\QueryBuilder\AllowedFilter;
@@ -23,16 +22,16 @@ class ExternalPackageTest extends TestCase
         User::truncate();
     }
 
+    /**
+     * Integration test with spatie/laravel-query-builder.
+     */
     public function testSpacieQueryBuilder(): void
     {
-        if (! InstalledVersions::isInstalled('spatie/laravel-query-builder')) {
-            $this->markTestSkipped('spatie/laravel-query-builder is not installed.');
-        }
-
         User::insert([
-            ['name' => 'Jane Doe', 'birthday' => '1983-09-10', 'role' => 'admin'],
-            ['name' => 'John Doe', 'birthday' => '1980-07-08', 'role' => 'admin'],
             ['name' => 'Jimmy Doe', 'birthday' => '2012-11-12', 'role' => 'user'],
+            ['name' => 'John Doe', 'birthday' => '1980-07-08', 'role' => 'admin'],
+            ['name' => 'Jane Doe', 'birthday' => '1983-09-10', 'role' => 'admin'],
+            ['name' => 'Jess Doe', 'birthday' => '2014-05-06', 'role' => 'user'],
         ]);
 
         $request = Request::create('/users', 'GET', ['filter' => ['role' => 'admin'], 'sort' => '-birthday']);

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -25,6 +25,7 @@ use MongoDB\Laravel\Tests\Models\IdIsString;
 use MongoDB\Laravel\Tests\Models\Item;
 use MongoDB\Laravel\Tests\Models\MemberStatus;
 use MongoDB\Laravel\Tests\Models\Soft;
+use MongoDB\Laravel\Tests\Models\SqlUser;
 use MongoDB\Laravel\Tests\Models\User;
 
 use function abs;
@@ -56,6 +57,17 @@ class ModelTest extends TestCase
         $this->assertFalse($user->exists);
         $this->assertEquals('users', $user->getTable());
         $this->assertEquals('_id', $user->getKeyName());
+    }
+
+    public function testQualifyColumn(): void
+    {
+        // Don't qualify field names in document models
+        $user = new User();
+        $this->assertEquals('name', $user->qualifyColumn('name'));
+
+        // Qualify column names in hybrid SQL models
+        $sqlUser = new SqlUser();
+        $this->assertEquals('users.name', $sqlUser->qualifyColumn('name'));
     }
 
     public function testInsert(): void


### PR DESCRIPTION
Fix #2409 PHPORM-119

As far as I know, there are no cases where you would want to prefix the field name with the collection name. Except in `$lookup` aggregation pipeline, but that's out of scope of the query builder.

Note that I'm adding the package [`spatie/laravel-query-builder`](https://packagist.org/packages/spatie/laravel-query-builder) as a dev dependency to ensure we will always support it. It's a very popular package that looks stable.
