### PR TITLE
PHPORM-6 Fix doc Builder::timeout applies to find query, not the cursor

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -80,7 +80,7 @@ class Builder extends BaseBuilder
     public $projections;
 
     /**
-     * The cursor timeout value.
+     * The maximum amount of seconds to allow the query to run.
      *
      * @var int
      */
@@ -189,7 +189,7 @@ class Builder extends BaseBuilder
     }
 
     /**
-     * Set the cursor timeout in seconds.
+     * The maximum amount of seconds to allow the query to run.
      *
      * @param  int $seconds
      *


### PR DESCRIPTION
Fix [PHPORM-6](https://jira.mongodb.org/browse/PHPORM-6)

Took the description from [`maxTimeMS` option](https://github.com/mongodb/mongo-php-library/blob/9f8eac1400fdb11d9a427d636689943a48447167/src/Operation/Find.php#L109-L111). We don't use [tailable cursor](https://github.com/mongodb/specifications/blob/022fbf64fb36c80b9295ba93acec150c94362767/source/find_getmore_killcursors_commands.rst#semantics-of-maxtimems-for-a-driver).