### PR TITLE
Support renaming columns in migrations

### DIFF
--- a/src/Schema/Blueprint.php
+++ b/src/Schema/Blueprint.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MongoDB\Laravel\Schema;
 
 use Illuminate\Database\Connection;
+use Illuminate\Database\Schema\Blueprint as SchemaBlueprint;
 use MongoDB\Laravel\Collection;
 
 use function array_flip;
@@ -15,7 +16,7 @@ use function is_int;
 use function is_string;
 use function key;
 
-class Blueprint extends \Illuminate\Database\Schema\Blueprint
+class Blueprint extends SchemaBlueprint
 {
     /**
      * The MongoConnection object for this blueprint.
@@ -274,6 +275,14 @@ class Blueprint extends \Illuminate\Database\Schema\Blueprint
     public function drop()
     {
         $this->collection->drop();
+    }
+
+    /** @inheritdoc */
+    public function renameColumn($from, $to)
+    {
+        $this->collection->updateMany([$from => ['$exists' => true]], ['$rename' => [$from => $to]]);
+
+        return $this;
     }
 
     /** @inheritdoc */

--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -343,6 +343,19 @@ class SchemaTest extends TestCase
         DB::connection()->collection('newcollection')->insert(['test' => 'value 2']);
         DB::connection()->collection('newcollection')->insert(['column' => 'column value']);
 
+        $check = DB::connection()->collection('newcollection')->get();
+        $this->assertCount(3, $check);
+
+        $this->assertArrayHasKey('test', $check[0]);
+        $this->assertArrayNotHasKey('newtest', $check[0]);
+
+        $this->assertArrayHasKey('test', $check[1]);
+        $this->assertArrayNotHasKey('newtest', $check[1]);
+
+        $this->assertArrayHasKey('column', $check[2]);
+        $this->assertArrayNotHasKey('test', $check[2]);
+        $this->assertArrayNotHasKey('newtest', $check[2]);
+
         Schema::collection('newcollection', function (Blueprint $collection) {
             $collection->renameColumn('test', 'newtest');
         });

--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -343,19 +343,6 @@ class SchemaTest extends TestCase
         DB::connection()->collection('newcollection')->insert(['test' => 'value 2']);
         DB::connection()->collection('newcollection')->insert(['column' => 'column value']);
 
-        $check = DB::connection()->collection('newcollection')->get();
-        $this->assertCount(3, $check);
-
-        $this->assertArrayHasKey('test', $check[0]);
-        $this->assertArrayNotHasKey('newtest', $check[0]);
-
-        $this->assertArrayHasKey('test', $check[1]);
-        $this->assertArrayNotHasKey('newtest', $check[1]);
-
-        $this->assertArrayHasKey('column', $check[2]);
-        $this->assertArrayNotHasKey('test', $check[2]);
-        $this->assertArrayNotHasKey('newtest', $check[2]);
-
         Schema::collection('newcollection', function (Blueprint $collection) {
             $collection->renameColumn('test', 'newtest');
         });

--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -356,7 +356,7 @@ class SchemaTest extends TestCase
         $this->assertArrayNotHasKey('test', $check[2]);
         $this->assertArrayNotHasKey('newtest', $check[2]);
 
-        Schema::create('newcollection', function (Blueprint $collection) {
+        Schema::collection('newcollection', function (Blueprint $collection) {
             $collection->renameColumn('test', 'newtest');
         });
 

--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -337,6 +337,46 @@ class SchemaTest extends TestCase
         $this->assertEquals(1, $index['unique']);
     }
 
+    public function testRenameColumn(): void
+    {
+        DB::connection()->collection('newcollection')->insert(['test' => 'value']);
+        DB::connection()->collection('newcollection')->insert(['test' => 'value 2']);
+        DB::connection()->collection('newcollection')->insert(['column' => 'column value']);
+
+        $check = DB::connection()->collection('newcollection')->get();
+        $this->assertCount(3, $check);
+
+        $this->assertArrayHasKey('test', $check[0]);
+        $this->assertArrayNotHasKey('newtest', $check[0]);
+
+        $this->assertArrayHasKey('test', $check[1]);
+        $this->assertArrayNotHasKey('newtest', $check[1]);
+
+        $this->assertArrayHasKey('column', $check[2]);
+        $this->assertArrayNotHasKey('test', $check[2]);
+        $this->assertArrayNotHasKey('newtest', $check[2]);
+
+        Schema::create('newcollection', function (Blueprint $collection) {
+            $collection->renameColumn('test', 'newtest');
+        });
+
+        $check2 = DB::connection()->collection('newcollection')->get();
+        $this->assertCount(3, $check2);
+
+        $this->assertArrayHasKey('newtest', $check2[0]);
+        $this->assertArrayNotHasKey('test', $check2[0]);
+        $this->assertSame($check[0]['test'], $check2[0]['newtest']);
+
+        $this->assertArrayHasKey('newtest', $check2[1]);
+        $this->assertArrayNotHasKey('test', $check2[1]);
+        $this->assertSame($check[1]['test'], $check2[1]['newtest']);
+
+        $this->assertArrayHasKey('column', $check2[2]);
+        $this->assertArrayNotHasKey('test', $check2[2]);
+        $this->assertArrayNotHasKey('newtest', $check2[2]);
+        $this->assertSame($check[2]['column'], $check2[2]['column']);
+    }
+
     protected function getIndex(string $collection, string $name)
     {
         $collection = DB::getCollection($collection);


### PR DESCRIPTION
Fix #2391
As mentioned in the linked issue, the `renameColumn` doesn't work. I just override that to fix the method.