### PR TITLE
fix CI workflow

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -54,10 +54,6 @@ jobs:
                     coverage: "xdebug"
                     tools: "composer"
 
-            -   name: "Show PHP version"
-                if: ${{ runner.debug }}
-                run: "php -v && composer -V"
-
             -   name: "Show Docker version"
                 if: ${{ runner.debug }}
                 run: "docker version && env"

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -55,11 +55,11 @@ jobs:
                     tools: "composer"
 
             -   name: "Show PHP version"
-                if: ${{ secrets.DEBUG == 'true' }}
+                if: ${{ runner.debug }}
                 run: "php -v && composer -V"
 
             -   name: "Show Docker version"
-                if: ${{ secrets.DEBUG == 'true' }}
+                if: ${{ runner.debug }}
                 run: "docker version && env"
 
             -   name: "Download Composer cache dependencies from cache"


### PR DESCRIPTION
I noticed that the CI workflow stopped working because it didn't know about secrets somehow.

I've updated the workflow by only showing debug info when the action is re-run with debugging enabled