### PR TITLE
Avoid unnecessary data fetch for exists method

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -545,7 +545,7 @@ class Builder extends BaseBuilder
     /** @inheritdoc */
     public function exists()
     {
-        return $this->first() !== null;
+        return $this->first(['_id']) !== null;
     }
 
     /** @inheritdoc */


### PR DESCRIPTION
### The issue
The `exists()` method is fetching all document properties unnecessarily since we only want to know if a record exists.

### The solution
Changed behaviour so it only fetches the `_id` property.