### PR TITLE
DOCSP-35866: update the link to the compatibility table for older ver…

### DIFF
--- a/docs/index.txt
+++ b/docs/index.txt
@@ -37,8 +37,8 @@ Laravel Eloquent and Query Builder syntax to work with your MongoDB data.
    later.
 
    To find versions of the package compatible with older versions of Laravel,
-   see the `Laravel Version Compatibility <https://github.com/mongodb/laravel-mongodb/tree/3.9#laravel-version-compatibility>`__
-   table.
+   see `Laravel Version Compatibility <https://github.com/mongodb/laravel-mongodb/blob/3.9/README.md#installation>`__
+   on GitHub.
 
 Getting Started
 ---------------


### PR DESCRIPTION
…sions

Docs changes:
This PR replaces the landing page link to the compatibility table with the direct file link to the table.

JIRA: https://jira.mongodb.org/browse/DOCSP-35866

Staging: [Landing page](https://preview-mongodbcchomongodb.gatsbyjs.io/laravel/DOCSP-35866-compatible-versions-link/) (link is in the first note)


### Checklist

- [ ] Add tests and ensure they pass
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Update documentation for new features
