### PR TITLE
PHPORM-145 Fix `Query\Builder::dump` and `dd` methods to dump MongoDB query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [unreleased]
+
+* Fix `Query\Builder::dump` and `dd` methods to dump the MongoDB query by @GromNaN in [#2727](https://github.com/mongodb/laravel-mongodb/pull/2727)
+
 ## [4.1.2]
 
 * Fix support for subqueries using the query builder by @GromNaN in [#2717](https://github.com/mongodb/laravel-mongodb/pull/2717)

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -22,6 +22,7 @@ use MongoDB\BSON\ObjectID;
 use MongoDB\BSON\Regex;
 use MongoDB\BSON\UTCDateTime;
 use MongoDB\Driver\Cursor;
+use Override;
 use RuntimeException;
 
 use function array_fill_keys;
@@ -37,6 +38,8 @@ use function call_user_func;
 use function call_user_func_array;
 use function count;
 use function ctype_xdigit;
+use function dd;
+use function dump;
 use function end;
 use function explode;
 use function func_get_args;
@@ -248,6 +251,30 @@ class Builder extends BaseBuilder
         }
 
         throw new RuntimeException('Query not compatible with cursor');
+    }
+
+    /**
+     * Die and dump the current MongoDB query
+     *
+     * @return never-return
+     */
+    #[Override]
+    public function dd()
+    {
+        dd($this->toMql());
+    }
+
+    /**
+     * Dump the current MongoDB query
+     *
+     * @return $this
+     */
+    #[Override]
+    public function dump()
+    {
+        dump($this->toMql());
+
+        return $this;
     }
 
     /**

--- a/tests/Eloquent/CallBuilderTest.php
+++ b/tests/Eloquent/CallBuilderTest.php
@@ -89,19 +89,5 @@ final class CallBuilderTest extends TestCase
             'This method is not supported by MongoDB. Try "toMql()" instead',
             [[['name' => 'Jane']], fn (QueryBuilder $builder) => $builder],
         ];
-
-        yield 'dd' => [
-            'dd',
-            BadMethodCallException::class,
-            'This method is not supported by MongoDB. Try "toMql()" instead',
-            [[['name' => 'Jane']], fn (QueryBuilder $builder) => $builder],
-        ];
-
-        yield 'dump' => [
-            'dump',
-            BadMethodCallException::class,
-            'This method is not supported by MongoDB. Try "toMql()" instead',
-            [[['name' => 'Jane']], fn (QueryBuilder $builder) => $builder],
-        ];
     }
 }


### PR DESCRIPTION
Fix [PHPORM-145](https://jira.mongodb.org/browse/PHPORM-145)

Can't be tested in a simple way. The code is trivial.

### Checklist

- [x] Add tests and ensure they pass
- [x] Add an entry to the CHANGELOG.md file
- [x] Update documentation for new features
