### PR TITLE
PHPORM-151 Update signature of `Query\Builder::dump` to match parent `DumpableTrait`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## [unreleased]
 
-* Fix `Query\Builder::dump` and `dd` methods to dump the MongoDB query by @GromNaN in [#2727](https://github.com/mongodb/laravel-mongodb/pull/2727)
+* Fix `Query\Builder::dump` and `dd` methods to dump the MongoDB query by @GromNaN in [#2727](https://github.com/mongodb/laravel-mongodb/pull/2727) and [#2730](https://github.com/mongodb/laravel-mongodb/pull/2730)
 
 ## [4.1.2]
 

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -267,12 +267,14 @@ class Builder extends BaseBuilder
     /**
      * Dump the current MongoDB query
      *
+     * @param mixed ...$args
+     *
      * @return $this
      */
     #[Override]
-    public function dump()
+    public function dump(mixed ...$args)
     {
-        dump($this->toMql());
+        dump($this->toMql(), ...$args);
 
         return $this;
     }


### PR DESCRIPTION
Fix [PHPORM-151](https://jira.mongodb.org/browse/PHPORM-151)

Laravel 11 breaking change: https://github.com/laravel/framework/commit/4326fc350de2d9e5b1578a0122a8c428895e8391#diff-2ed94a0ea151404a12f3c0d52ae9fb5742348578ec4a8ff79d079fa598ff145dR3878

### Checklist

- [x] Add tests and ensure they pass (no tests)
- [x] Add an entry to the CHANGELOG.md file
- [x] Update documentation for new features (no doc)
