### PR TITLE
PHPORM-152 Fix tests for Carbon 3

### DIFF
--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -564,7 +564,12 @@ class BuilderTest extends TestCase
         yield 'whereBetween CarbonPeriod' => [
             [
                 'find' => [
-                    ['created_at' => ['$gte' => new UTCDateTime($period->start), '$lte' => new UTCDateTime($period->end)]],
+                    [
+                        'created_at' => [
+                            '$gte' => new UTCDateTime($period->getStartDate()),
+                            '$lte' => new UTCDateTime($period->getEndDate()),
+                        ],
+                    ],
                     [], // options
                 ],
             ],


### PR DESCRIPTION
Fix [PHPORM-152](https://jira.mongodb.org/browse/PHPORM-152)

The virtual properties from Carbon 2.x have been removed in 3.x
https://github.com/briannesbitt/Carbon/blob/57fbbf88ce332f6da4e5aa1ea7524ef1caebb9e4/src/Carbon/CarbonPeriod.php#L49-L51

### Checklist

- [x] Add tests and ensure they pass
- [x] ~Add an entry to the CHANGELOG.md file~
- [x] ~Update documentation for new features~
