### PR TITLE
PHPORM-143 Ensure date are read using local timezone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [4.1.3] - unreleased
+
+* Fix the timezone of `datetime` fields when they are read from the database by @GromNaN in [#2739](https://github.com/mongodb/laravel-mongodb/pull/2739)
+
 ## [4.1.2] - 2024-02-22
 
 * Fix support for subqueries using the query builder by @GromNaN in [#2717](https://github.com/mongodb/laravel-mongodb/pull/2717)

--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -6,6 +6,7 @@ namespace MongoDB\Laravel\Eloquent;
 
 use Carbon\CarbonInterface;
 use DateTimeInterface;
+use DateTimeZone;
 use Illuminate\Contracts\Queue\QueueableCollection;
 use Illuminate\Contracts\Queue\QueueableEntity;
 use Illuminate\Contracts\Support\Arrayable;
@@ -30,6 +31,7 @@ use function array_unique;
 use function array_values;
 use function class_basename;
 use function count;
+use function date_default_timezone_get;
 use function explode;
 use function func_get_args;
 use function in_array;
@@ -137,7 +139,8 @@ abstract class Model extends BaseModel
     {
         // Convert UTCDateTime instances to Carbon.
         if ($value instanceof UTCDateTime) {
-            return Date::instance($value->toDateTime());
+            return Date::instance($value->toDateTime())
+                ->setTimezone(new DateTimeZone(date_default_timezone_get()));
         }
 
         return parent::asDateTime($value);


### PR DESCRIPTION
Fix PHPORM-143
Fix #2719

In #2705 ([a5cf5cb](https://github.com/mongodb/laravel-mongodb/commit/a5cf5cba823f5a1d79fb23ce8c9a55e2f27f0ce7#diff-284e164f76aeb13f424d154f9208d91fdbb0112b0a50ad8b1dfa237176f03cf2L144-R140)), the conversion from `MongoDB\BSON\UTCDateTime` to `Carbon\Date` was modified in a way that no longer change use the local timezone. `UTCDateTime::asDateTime` always return a `DateTime` instance with `UTC` timezone, while le previous `Date::createFromTimestampMs($timestampMs)` was using the local timezone.

### Checklist

- [x] Add tests and ensure they pass
- [x] Add an entry to the CHANGELOG.md file
- [x] ~Update documentation for new features~
