### PR TITLE
PHPORM-148 Fix `null` in `datetime` fields and reset time in `date` field with custom format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## [4.1.3] - 2024-03-01
+## [4.1.3] - 2024-03-04
 
-* Fix the timezone of `datetime` fields when they are read from the database by @GromNaN in [#2739](https://github.com/mongodb/laravel-mongodb/pull/2739)
-* Fix support for null values in `datetime` fields by @GromNaN in [#2741](https://github.com/mongodb/laravel-mongodb/pull/2741)
+* Fix the timezone of `datetime` fields when they are read from the database. By @GromNaN in [#2739](https://github.com/mongodb/laravel-mongodb/pull/2739)
+* Fix support for null values in `datetime` and reset `date` fields with custom format to the start of the day. By @GromNaN in [#2741](https://github.com/mongodb/laravel-mongodb/pull/2741)
 
 ## [4.1.2] - 2024-02-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## [4.1.3] - unreleased
+## [4.1.3] - 2024-03-01
 
 * Fix the timezone of `datetime` fields when they are read from the database by @GromNaN in [#2739](https://github.com/mongodb/laravel-mongodb/pull/2739)
+* Fix support for null values in `datetime` fields by @GromNaN in [#2741](https://github.com/mongodb/laravel-mongodb/pull/2741)
 
 ## [4.1.2] - 2024-02-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## [4.1.3] - 2024-03-04
+## [4.1.3] - 2024-03-05
 
 * Fix the timezone of `datetime` fields when they are read from the database. By @GromNaN in [#2739](https://github.com/mongodb/laravel-mongodb/pull/2739)
 * Fix support for null values in `datetime` and reset `date` fields with custom format to the start of the day. By @GromNaN in [#2741](https://github.com/mongodb/laravel-mongodb/pull/2741)

--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -316,26 +316,6 @@ abstract class Model extends BaseModel
     }
 
     /** @inheritdoc */
-    protected function castAttribute($key, $value)
-    {
-        $castType = $this->getCastType($key);
-
-        if ($castType === 'immutable_custom_datetime' || $castType === 'immutable_datetime') {
-            if ($value === null) {
-                return null;
-            }
-
-            if (str_starts_with($this->getCasts()[$key], 'immutable_date:')) {
-                return $this->asDate($value)->toImmutable();
-            }
-
-            return $this->asDateTime($value)->toImmutable();
-        }
-
-        return parent::castAttribute($key, $value);
-    }
-
-    /** @inheritdoc */
     public function attributesToArray()
     {
         $attributes = parent::attributesToArray();

--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -205,9 +205,10 @@ abstract class Model extends BaseModel
         if ($this->hasCast($key) && $value instanceof CarbonInterface) {
             $value->settings(array_merge($value->getSettings(), ['toStringFormat' => $this->getDateFormat()]));
 
+            // "date" cast resets the time to 00:00:00.
             $castType = $this->getCasts()[$key];
-            if ($this->isCustomDateTimeCast($castType) && str_starts_with($castType, 'date:')) {
-                $value->startOfDay();
+            if (str_starts_with($castType, 'date:') || str_starts_with($castType, 'immutable_date:')) {
+                $value = $value->startOfDay();
             }
         }
 

--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -320,12 +320,19 @@ abstract class Model extends BaseModel
     {
         $castType = $this->getCastType($key);
 
-        return match ($castType) {
-            'immutable_custom_datetime','immutable_datetime' => str_starts_with($this->getCasts()[$key], 'immutable_date:') ?
-                $this->asDate($value)->toImmutable() :
-                $this->asDateTime($value)->toImmutable(),
-            default => parent::castAttribute($key, $value)
-        };
+        if ($castType === 'immutable_custom_datetime' || $castType === 'immutable_datetime') {
+            if ($value === null) {
+                return null;
+            }
+
+            if (str_starts_with($this->getCasts()[$key], 'immutable_date:')) {
+                return $this->asDate($value)->toImmutable();
+            }
+
+            return $this->asDateTime($value)->toImmutable();
+        }
+
+        return parent::castAttribute($key, $value);
     }
 
     /** @inheritdoc */

--- a/tests/Casts/DateTest.php
+++ b/tests/Casts/DateTest.php
@@ -115,10 +115,12 @@ class DateTest extends TestCase
 
     public function testImmutableDateWithCustomFormat(): void
     {
+        // With a custom format, "date" cast behave like "datetime". The time is not reset to the start of the day.
+        // https://github.com/laravel/framework/blob/v10.46.0/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php#L866-L869
         $model = Casting::query()->create(['immutableDateWithFormatField' => new DateTime()]);
 
         self::assertInstanceOf(CarbonImmutable::class, $model->immutableDateWithFormatField);
-        self::assertEquals(now()->startOfDay()->format('j.n.Y H:i'), (string) $model->immutableDateWithFormatField);
+        self::assertEquals(now()->format('j.n.Y H:i'), (string) $model->immutableDateWithFormatField);
 
         $model->update(['immutableDateWithFormatField' => now()->startOfDay()->subDay()]);
 

--- a/tests/Casts/DateTest.php
+++ b/tests/Casts/DateTest.php
@@ -115,12 +115,10 @@ class DateTest extends TestCase
 
     public function testImmutableDateWithCustomFormat(): void
     {
-        // With a custom format, "date" cast behave like "datetime". The time is not reset to the start of the day.
-        // https://github.com/laravel/framework/blob/v10.46.0/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php#L866-L869
         $model = Casting::query()->create(['immutableDateWithFormatField' => new DateTime()]);
 
         self::assertInstanceOf(CarbonImmutable::class, $model->immutableDateWithFormatField);
-        self::assertEquals(now()->format('j.n.Y H:i'), (string) $model->immutableDateWithFormatField);
+        self::assertEquals(now()->startOfDay()->format('j.n.Y H:i'), (string) $model->immutableDateWithFormatField);
 
         $model->update(['immutableDateWithFormatField' => now()->startOfDay()->subDay()]);
 

--- a/tests/Casts/DateTest.php
+++ b/tests/Casts/DateTest.php
@@ -52,6 +52,12 @@ class DateTest extends TestCase
         self::assertInstanceOf(Carbon::class, $refetchedModel->dateField);
         self::assertInstanceOf(UTCDateTime::class, $model->getRawOriginal('dateField'));
         self::assertEquals(now()->subDay()->startOfDay()->format('Y-m-d H:i:s'), (string) $refetchedModel->dateField);
+
+        $model = Casting::query()->create();
+        $this->assertNull($model->dateField);
+
+        $model->update(['dateField' => null]);
+        $this->assertNull($model->dateField);
     }
 
     public function testDateAsString(): void
@@ -126,5 +132,11 @@ class DateTest extends TestCase
             Carbon::createFromTimestamp(1698577443)->subDay()->startOfDay()->format('j.n.Y H:i'),
             (string) $model->immutableDateWithFormatField,
         );
+
+        $model = Casting::query()->create();
+        $this->assertNull($model->immutableDateField);
+
+        $model->update(['immutableDateField' => null]);
+        $this->assertNull($model->immutableDateField);
     }
 }

--- a/tests/Casts/DateTest.php
+++ b/tests/Casts/DateTest.php
@@ -90,6 +90,12 @@ class DateTest extends TestCase
 
         self::assertInstanceOf(Carbon::class, $model->dateWithFormatField);
         self::assertEquals(now()->startOfDay()->subDay()->format('j.n.Y H:i'), (string) $model->dateWithFormatField);
+
+        $model = Casting::query()->create();
+        $this->assertNull($model->dateWithFormatField);
+
+        $model->update(['dateWithFormatField' => null]);
+        $this->assertNull($model->dateWithFormatField);
     }
 
     public function testImmutableDate(): void
@@ -111,6 +117,12 @@ class DateTest extends TestCase
             Carbon::createFromTimestamp(1698577443)->subDay()->startOfDay()->format('Y-m-d H:i:s'),
             (string) $model->immutableDateField,
         );
+
+        $model = Casting::query()->create();
+        $this->assertNull($model->immutableDateField);
+
+        $model->update(['immutableDateField' => null]);
+        $this->assertNull($model->immutableDateField);
     }
 
     public function testImmutableDateWithCustomFormat(): void
@@ -134,9 +146,9 @@ class DateTest extends TestCase
         );
 
         $model = Casting::query()->create();
-        $this->assertNull($model->immutableDateField);
+        $this->assertNull($model->immutableDateWithFormatField);
 
-        $model->update(['immutableDateField' => null]);
-        $this->assertNull($model->immutableDateField);
+        $model->update(['immutableDateWithFormatField' => null]);
+        $this->assertNull($model->immutableDateWithFormatField);
     }
 }

--- a/tests/Casts/DatetimeTest.php
+++ b/tests/Casts/DatetimeTest.php
@@ -36,6 +36,12 @@ class DatetimeTest extends TestCase
         self::assertInstanceOf(Carbon::class, $model->datetimeField);
         self::assertInstanceOf(UTCDateTime::class, $model->getRawOriginal('datetimeField'));
         self::assertEquals(now()->subDay()->format('Y-m-d H:i:s'), (string) $model->datetimeField);
+
+        $model = Casting::query()->create();
+        $this->assertNull($model->datetimeField);
+
+        $model->update(['datetimeField' => null]);
+        $this->assertNull($model->datetimeField);
     }
 
     public function testDatetimeAsString(): void
@@ -70,6 +76,12 @@ class DatetimeTest extends TestCase
 
         self::assertInstanceOf(Carbon::class, $model->datetimeWithFormatField);
         self::assertEquals(now()->subDay()->format('j.n.Y H:i'), (string) $model->datetimeWithFormatField);
+
+        $model = Casting::query()->create();
+        $this->assertNull($model->datetimeWithFormatField);
+
+        $model->update(['datetimeWithFormatField' => null]);
+        $this->assertNull($model->datetimeWithFormatField);
     }
 
     public function testImmutableDatetime(): void
@@ -92,6 +104,12 @@ class DatetimeTest extends TestCase
             Carbon::createFromTimestamp(1698577443)->subDay()->format('Y-m-d H:i:s'),
             (string) $model->immutableDatetimeField,
         );
+
+        $model = Casting::query()->create();
+        $this->assertNull($model->immutableDatetimeField);
+
+        $model->update(['immutableDatetimeField' => null]);
+        $this->assertNull($model->immutableDatetimeField);
     }
 
     public function testImmutableDatetimeWithCustomFormat(): void
@@ -113,5 +131,11 @@ class DatetimeTest extends TestCase
             Carbon::createFromTimestamp(1698577443)->subDay()->format('j.n.Y H:i'),
             (string) $model->immutableDatetimeWithFormatField,
         );
+
+        $model = Casting::query()->create();
+        $this->assertNull($model->immutableDatetimeWithFormatField);
+
+        $model->update(['immutableDatetimeWithFormatField' => null]);
+        $this->assertNull($model->immutableDatetimeWithFormatField);
     }
 }


### PR DESCRIPTION
Fix PHPORM-148
Fix #2729

- Fix #2729 by removing the method `Model::castAttribute()` that was introduced by #2658 in 4.1.0. Tests added to ensure `null` is allowed in `date`, `datetime`, `immutable_date`, `immutable_datetime` and the variants with custom formats.
- Change the behavior of `immutable_date:j.n.Y H:i` (with custom format), to reset the time. This behave differently than [Laravel 10.46 that treats it like a `immutable_datetime`](https://github.com/laravel/framework/blob/v10.46.0/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php#L866-L869).

### Checklist

- [x] Add tests and ensure they pass
- [x] Add an entry to the CHANGELOG.md file
- [ ] Update documentation for new features
