### PR TITLE
PHPORM-139 Implement `Model::createOrFirst()` using `findOneAndUpdate` operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [unreleased]
 
 * Add support for Laravel 11 by @GromNaN in [#2735](https://github.com/mongodb/laravel-mongodb/pull/2735)
+* Implement Model::createOrFirst() using findOneAndUpdate operation by @GromNaN in [#2742](https://github.com/mongodb/laravel-mongodb/pull/2742)
 
 ## [4.1.3] - 2024-03-05
 

--- a/src/Eloquent/Builder.php
+++ b/src/Eloquent/Builder.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use MongoDB\Driver\Cursor;
 use MongoDB\Laravel\Collection;
 use MongoDB\Laravel\Helpers\QueriesRelationships;
+use MongoDB\Laravel\Internal\FindAndModifyCommandSubscriber;
 use MongoDB\Model\BSONDocument;
 
 use function array_intersect_key;
@@ -185,7 +186,14 @@ class Builder extends EloquentBuilder
         return $results;
     }
 
-    public function createOrFirst(array $attributes = [], array $values = [])
+    /**
+     * Attempt to create the record if it does not exist with the matching attributes.
+     * If the record exists, it will be returned.
+     *
+     * @param  array $attributes The attributes to check for duplicate records
+     * @param  array $values     The attributes to insert if no matching record is found
+     */
+    public function createOrFirst(array $attributes = [], array $values = []): Model
     {
         // Apply casting and default values to the attributes
         $instance = $this->newModelInstance($values + $attributes);
@@ -193,11 +201,23 @@ class Builder extends EloquentBuilder
         $attributes = array_intersect_key($attributes, $values);
 
         return $this->raw(function (Collection $collection) use ($attributes, $values) {
-            return $collection->findOneAndUpdate(
-                $attributes,
-                ['$setOnInsert' => $values],
-                ['upsert' => true, 'new' => true],
-            );
+            $listener = new FindAndModifyCommandSubscriber();
+            $collection->getManager()->addSubscriber($listener);
+
+            try {
+                $document = $collection->findOneAndUpdate(
+                    $attributes,
+                    ['$setOnInsert' => $values],
+                    ['upsert' => true, 'new' => true, 'typeMap' => ['root' => 'array', 'document' => 'array']],
+                );
+            } finally {
+                $collection->getManager()->removeSubscriber($listener);
+            }
+
+            $model = $this->model->newFromBuilder($document);
+            $model->wasRecentlyCreated = $listener->created;
+
+            return $model;
         });
     }
 

--- a/src/Internal/FindAndModifyCommandSubscriber.php
+++ b/src/Internal/FindAndModifyCommandSubscriber.php
@@ -15,7 +15,7 @@ use MongoDB\Driver\Monitoring\CommandSucceededEvent;
  *
  * @internal
  */
-class FindAndModifyCommandSubscriber implements CommandSubscriber
+final class FindAndModifyCommandSubscriber implements CommandSubscriber
 {
     public bool $created;
 

--- a/src/Internal/FindAndModifyCommandSubscriber.php
+++ b/src/Internal/FindAndModifyCommandSubscriber.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Laravel\Internal;
+
+use MongoDB\Driver\Monitoring\CommandFailedEvent;
+use MongoDB\Driver\Monitoring\CommandStartedEvent;
+use MongoDB\Driver\Monitoring\CommandSubscriber;
+use MongoDB\Driver\Monitoring\CommandSucceededEvent;
+
+/**
+ * Track findAndModify command events to detect when a document is inserted or
+ * updated.
+ *
+ * @internal
+ */
+class FindAndModifyCommandSubscriber implements CommandSubscriber
+{
+    public bool $created;
+
+    public function commandFailed(CommandFailedEvent $event)
+    {
+    }
+
+    public function commandStarted(CommandStartedEvent $event)
+    {
+    }
+
+    public function commandSucceeded(CommandSucceededEvent $event)
+    {
+        $this->created = ! $event->getReply()->lastErrorObject->updatedExisting;
+    }
+}

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -1055,6 +1055,7 @@ class ModelTest extends TestCase
 
         $this->assertSame('taylorotwell@gmail.com', $user1->email);
         $this->assertNull($user1->name);
+        $this->assertTrue($user1->wasRecentlyCreated);
 
         $user2 = User::createOrFirst(
             ['email' => 'taylorotwell@gmail.com'],
@@ -1065,6 +1066,7 @@ class ModelTest extends TestCase
         $this->assertSame('taylorotwell@gmail.com', $user2->email);
         $this->assertNull($user2->name);
         $this->assertNull($user2->birthday);
+        $this->assertFalse($user2->wasRecentlyCreated);
 
         $user3 = User::createOrFirst(
             ['email' => 'abigailotwell@gmail.com'],
@@ -1075,6 +1077,7 @@ class ModelTest extends TestCase
         $this->assertSame('abigailotwell@gmail.com', $user3->email);
         $this->assertSame('Abigail Otwell', $user3->name);
         $this->assertEquals(new DateTime('1987-05-28'), $user3->birthday);
+        $this->assertTrue($user3->wasRecentlyCreated);
 
         $user4 = User::createOrFirst(
             ['name' => 'Dries Vints'],
@@ -1082,5 +1085,6 @@ class ModelTest extends TestCase
         );
 
         $this->assertSame('Nuno Maduro', $user4->name);
+        $this->assertTrue($user4->wasRecentlyCreated);
     }
 }

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -45,7 +45,7 @@ class ModelTest extends TestCase
 {
     public function tearDown(): void
     {
-        User::raw(fn(Collection $collection) => $collection->drop());
+        User::truncate();
         Soft::truncate();
         Book::truncate();
         Item::truncate();
@@ -1047,10 +1047,6 @@ class ModelTest extends TestCase
 
     public function testCreateOrFirst()
     {
-        // Create index unique on "email" and "name"
-        User::raw(fn (Collection $collection) => $collection->createIndex(['email' => 1], ['unique' => true]));
-        User::raw(fn (Collection $collection) => $collection->createIndex(['name' => 1], ['unique' => true]));
-
         $user1 = User::createOrFirst(['email' => 'taylorotwell@gmail.com']);
 
         $this->assertSame('taylorotwell@gmail.com', $user1->email);


### PR DESCRIPTION
Fix [PHPORM-139](https://jira.mongodb.org/browse/PHPORM-139)
Fix #2720

This may be considered as a new feature and merged into 4.2 instead of 4.1

> [Laravel v10.20](https://laravel-news.com/laravel-10-20-0) came out with a brand-new method called `createOrFirst()`. 
Learn more about this method https://github.com/laravel/framework/discussions/48567: https://laravel-news.com/firstorcreate-vs-createorfirst 

The `createOfFirst` algorithm is:
```
try {
    // insert the new document
} catch (UniqueException) {
    // find the document from criteria
}
```

This is precisely what we can do in a single command with `findOneAndUpdate`.

Unlike Eloquent's implementation, we don't rely on the "unique" index constraint, and just use the `$attribute` array as criteria. 


### Checklist

- [x] Add tests and ensure they pass
- [x] Add an entry to the CHANGELOG.md file
- [ ] Update documentation for new features
