### PR TITLE
Fix build error

### DIFF
--- a/docs/index.txt
+++ b/docs/index.txt
@@ -13,7 +13,6 @@ Laravel MongoDB
    :titlesonly:
    :maxdepth: 1
 
-   /install
    /quick-start
    /retrieve
    /eloquent-models


### PR DESCRIPTION
This PR removes a TOC entry that should no longer exist, addressing the following Snooty error:

`ERROR(index.txt:11ish): Could not locate toctree entry install`

Build log (fixed) - https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65e62a8211db7b042769e083

### Checklist

- [ ] Add tests and ensure they pass
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Update documentation for new features
