### PR TITLE
Test Laravel 10 and 11

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -24,16 +24,17 @@ jobs:
                     - "8.2"
                     - "8.3"
                 laravel:
-                  - "10.*"
+                    - "10.*"
+                    - "11.*"
                 include:
                     - php: "8.1"
                       laravel: "10.*"
                       mongodb: "5.0"
                       mode: "low-deps"
-                    # Laravel 11
-                    - php: "8.3"
-                      mongodb: "7.0"
-                      mode: "dev"
+                exclude:
+                    - php: "8.1"
+                      laravel: "11.*"
+
         steps:
             -   uses: "actions/checkout@v4"
 
@@ -79,10 +80,7 @@ jobs:
                     restore-keys: "${{ matrix.os }}-composer-"
 
             -   name: "Install dependencies"
-                run: |
-                  composer update --no-interaction \
-                  $([[ "${{ matrix.mode }}" == low-deps ]] && echo ' --prefer-lowest') \
-                  $([[ "${{ matrix.mode }}" != dev ]] && echo ' --prefer-stable')
+                run: composer update --no-interaction $([[ "${{ matrix.mode }}" == low-deps ]] && echo ' --prefer-lowest')
             -   name: "Run tests"
                 run: "./vendor/bin/phpunit --coverage-clover coverage.xml"
                 env:


### PR DESCRIPTION
Follow-up https://github.com/mongodb/laravel-mongodb/pull/2735

In order to keep testing Laravel 10 when Laravel 11 will be released, I'm using a variable in the CI that specifies the version of `laravel/framework`, which is a meta package containing all `illuminate` packages.

### Checklist

- [ ] ~Add tests and ensure they pass~
- [ ] ~Add an entry to the CHANGELOG.md file~
- [ ] ~Update documentation for new features~
