### PR TITLE
Add workflow to create merge-up pull request

### DIFF
--- a/.github/workflows/merge-up.yml
+++ b/.github/workflows/merge-up.yml
@@ -1,0 +1,33 @@
+name: Merge up
+
+on:
+  push:
+    branches:
+      - "[0-9]+.[0-9]+"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  GH_TOKEN: ${{ github.token }}
+
+jobs:
+  merge-up:
+    name: Create merge up pull request
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        id: checkout
+        uses: actions/checkout@v4
+        with:
+          # fetch-depth 0 is required to fetch all branches, not just the branch being built
+          fetch-depth: 0
+
+      - name: Create pull request
+        id: create-pull-request
+        uses: alcaeus/automatic-merge-up-action@main
+        with:
+          ref: ${{ github.ref_name }}
+          branchNamePattern: '<major>.<minor>'


### PR DESCRIPTION
The new workflow ensures that changes merged to an older branch efficiently find their way upstream. When a push is made to a matching branch, the action finds the next applicable branch. Example, when pushing to 4.1, it will find 4.2 and create a PR to that branch. When pushing to 4.2, it will first look for 4.3 (which currently doesn't exist), then for 5.0 (which also doesn't exist), and then abort since no fallback branch was specified.