### PR TITLE
PHPORM-139 Improve `Model::createOrFirst()` tests and error checking

### DIFF
--- a/src/Eloquent/Builder.php
+++ b/src/Eloquent/Builder.php
@@ -6,6 +6,7 @@ namespace MongoDB\Laravel\Eloquent;
 
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use InvalidArgumentException;
 use MongoDB\Driver\Cursor;
 use MongoDB\Laravel\Collection;
 use MongoDB\Laravel\Helpers\QueriesRelationships;
@@ -195,6 +196,10 @@ class Builder extends EloquentBuilder
      */
     public function createOrFirst(array $attributes = [], array $values = []): Model
     {
+        if ($attributes === []) {
+            throw new InvalidArgumentException('You must provide attributes to check for duplicates');
+        }
+
         // Apply casting and default values to the attributes
         $instance = $this->newModelInstance($values + $attributes);
         $values = $instance->getAttributes();

--- a/src/Eloquent/Builder.php
+++ b/src/Eloquent/Builder.php
@@ -214,6 +214,8 @@ class Builder extends EloquentBuilder
             try {
                 $document = $collection->findOneAndUpdate(
                     $attributes,
+                    // Before MongoDB 5.0, the $setOnInsert does support empty document,
+                    // so the filter value are added to avoid an error.
                     ['$setOnInsert' => (object) $values],
                     [
                         'upsert' => true,

--- a/src/Eloquent/Builder.php
+++ b/src/Eloquent/Builder.php
@@ -214,8 +214,8 @@ class Builder extends EloquentBuilder
             try {
                 $document = $collection->findOneAndUpdate(
                     $attributes,
-                    // Before MongoDB 5.0, the $setOnInsert does support empty document,
-                    // so the filter value are added to avoid an error.
+                    // Before MongoDB 5.0, $setOnInsert requires a non-empty document.
+                    // This is should not be an issue as $values includes the query filter.
                     ['$setOnInsert' => (object) $values],
                     [
                         'upsert' => true,

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Str;
+use InvalidArgumentException;
 use MongoDB\BSON\Binary;
 use MongoDB\BSON\ObjectID;
 use MongoDB\BSON\UTCDateTime;
@@ -1047,40 +1048,47 @@ class ModelTest extends TestCase
 
     public function testCreateOrFirst()
     {
-        $user1 = User::createOrFirst(['email' => 'taylorotwell@gmail.com']);
+        $user1 = User::createOrFirst(['email' => 'john.doe@example.com']);
 
-        $this->assertSame('taylorotwell@gmail.com', $user1->email);
+        $this->assertSame('john.doe@example.com', $user1->email);
         $this->assertNull($user1->name);
         $this->assertTrue($user1->wasRecentlyCreated);
 
         $user2 = User::createOrFirst(
-            ['email' => 'taylorotwell@gmail.com'],
-            ['name' => 'Taylor Otwell', 'birthday' => new DateTime('1987-05-28')],
+            ['email' => 'john.doe@example.com'],
+            ['name' => 'John Doe', 'birthday' => new DateTime('1987-05-28')],
         );
 
         $this->assertEquals($user1->id, $user2->id);
-        $this->assertSame('taylorotwell@gmail.com', $user2->email);
+        $this->assertSame('john.doe@example.com', $user2->email);
         $this->assertNull($user2->name);
         $this->assertNull($user2->birthday);
         $this->assertFalse($user2->wasRecentlyCreated);
 
         $user3 = User::createOrFirst(
-            ['email' => 'abigailotwell@gmail.com'],
-            ['name' => 'Abigail Otwell', 'birthday' => new DateTime('1987-05-28')],
+            ['email' => 'jane.doe@example.com'],
+            ['name' => 'Jane Doe', 'birthday' => new DateTime('1987-05-28')],
         );
 
         $this->assertNotEquals($user3->id, $user1->id);
-        $this->assertSame('abigailotwell@gmail.com', $user3->email);
-        $this->assertSame('Abigail Otwell', $user3->name);
+        $this->assertSame('jane.doe@example.com', $user3->email);
+        $this->assertSame('Jane Doe', $user3->name);
         $this->assertEquals(new DateTime('1987-05-28'), $user3->birthday);
         $this->assertTrue($user3->wasRecentlyCreated);
 
         $user4 = User::createOrFirst(
-            ['name' => 'Dries Vints'],
-            ['name' => 'Nuno Maduro', 'email' => 'nuno@laravel.com'],
+            ['name' => 'Robert Doe'],
+            ['name' => 'Maria Doe', 'email' => 'maria.doe@example.com'],
         );
 
-        $this->assertSame('Nuno Maduro', $user4->name);
+        $this->assertSame('Maria Doe', $user4->name);
         $this->assertTrue($user4->wasRecentlyCreated);
+    }
+
+    public function testCreateOrFirstRequiresFilter()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('You must provide attributes to check for duplicates');
+        User::createOrFirst([]);
     }
 }


### PR DESCRIPTION
Applies @jmikola's review on https://github.com/mongodb/laravel-mongodb/pull/2742
Fix PHPORM-139
