### PR TITLE
PHPORM-159 Add tests on `whereAny` and `whereAll`

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -1154,11 +1154,6 @@ class Builder extends BaseBuilder
         return $compiled;
     }
 
-    /**
-     * @param  array $where
-     *
-     * @return array
-     */
     protected function compileWhereBasic(array $where): array
     {
         $column   = $where['column'];

--- a/tests/Models/User.php
+++ b/tests/Models/User.php
@@ -130,7 +130,7 @@ class User extends Eloquent implements AuthenticatableContract, CanResetPassword
     {
         return Attribute::make(
             get: fn ($value) => $value,
-            set: fn ($value) => Str::slug($value)
+            set: fn ($value) => Str::slug($value),
         );
     }
 

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -1157,6 +1157,138 @@ class BuilderTest extends TestCase
                 },
             ),
         ];
+
+        /** @see DatabaseQueryBuilderTest::testWhereAll */
+        yield 'whereAll' => [
+            [
+                'find' => [
+                    ['$and' => [['last_name' => 'Doe'], ['email' => 'Doe']]],
+                    [], // options
+                ],
+            ],
+            fn (Builder $builder) => $builder->whereAll(['last_name', 'email'], 'Doe'),
+        ];
+
+        yield 'whereAll operator' => [
+            [
+                'find' => [
+                    [
+                        '$and' => [
+                            ['last_name' => ['$not' => new Regex('^.*Doe.*$', 'i')]],
+                            ['email' => ['$not' => new Regex('^.*Doe.*$', 'i')]],
+                        ],
+                    ],
+                    [], // options
+                ],
+            ],
+            fn (Builder $builder) => $builder->whereAll(['last_name', 'email'], 'not like', '%Doe%'),
+        ];
+
+        /** @see DatabaseQueryBuilderTest::testOrWhereAll */
+        yield 'orWhereAll' => [
+            [
+                'find' => [
+                    [
+                        '$or' => [
+                            ['first_name' => 'John'],
+                            ['$and' => [['last_name' => 'Doe'], ['email' => 'Doe']]],
+                        ],
+                    ],
+                    [], // options
+                ],
+            ],
+            fn (Builder $builder) => $builder
+                ->where('first_name', 'John')
+                ->orWhereAll(['last_name', 'email'], 'Doe'),
+        ];
+
+        yield 'orWhereAll operator' => [
+            [
+                'find' => [
+                    [
+                        '$or' => [
+                            ['first_name' => new Regex('^.*John.*$', 'i')],
+                            [
+                                '$and' => [
+                                    ['last_name' => ['$not' => new Regex('^.*Doe.*$', 'i')]],
+                                    ['email' => ['$not' => new Regex('^.*Doe.*$', 'i')]],
+                                ],
+                            ],
+                        ],
+                    ],
+                    [], // options
+                ],
+            ],
+            fn (Builder $builder) => $builder
+                ->where('first_name', 'like', '%John%')
+                ->orWhereAll(['last_name', 'email'], 'not like', '%Doe%'),
+        ];
+
+        /** @see DatabaseQueryBuilderTest::testWhereAny */
+        yield 'whereAny' => [
+            [
+                'find' => [
+                    ['$or' => [['last_name' => 'Doe'], ['email' => 'Doe']]],
+                    [], // options
+                ],
+            ],
+            fn (Builder $builder) => $builder->whereAny(['last_name', 'email'], 'Doe'),
+        ];
+
+        yield 'whereAny operator' => [
+            [
+                'find' => [
+                    [
+                        '$or' => [
+                            ['last_name' => ['$not' => new Regex('^.*Doe.*$', 'i')]],
+                            ['email' => ['$not' => new Regex('^.*Doe.*$', 'i')]],
+                        ],
+                    ],
+                    [], // options
+                ],
+            ],
+            fn (Builder $builder) => $builder->whereAny(['last_name', 'email'], 'not like', '%Doe%'),
+        ];
+
+        /** @see DatabaseQueryBuilderTest::testOrWhereAny */
+        yield 'orWhereAny' => [
+            [
+                'find' => [
+                    [
+                        '$or' => [
+                            ['first_name' => 'John'],
+                            ['$or' => [['last_name' => 'Doe'], ['email' => 'Doe']]],
+                        ],
+                    ],
+                    [], // options
+                ],
+            ],
+            fn (Builder $builder) => $builder
+                ->where('first_name', 'John')
+                ->orWhereAny(['last_name', 'email'], 'Doe'),
+        ];
+
+        yield 'orWhereAny operator' => [
+            [
+                'find' => [
+                    [
+                        '$or' => [
+                            ['first_name' => new Regex('^.*John.*$', 'i')],
+                            [
+                                '$or' => [
+                                    ['last_name' => ['$not' => new Regex('^.*Doe.*$', 'i')]],
+                                    ['email' => ['$not' => new Regex('^.*Doe.*$', 'i')]],
+                                ],
+                            ],
+                        ],
+                    ],
+                    [], // options
+                ],
+            ],
+            fn (Builder $builder) => $builder
+                ->where('first_name', 'like', '%John%')
+                ->orWhereAny(['last_name', 'email'], 'not like', '%Doe%'),
+        ];
     }
 
     /** @dataProvider provideExceptions */

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -23,6 +23,7 @@ use PHPUnit\Framework\TestCase;
 use stdClass;
 
 use function collect;
+use function method_exists;
 use function now;
 use function var_export;
 
@@ -1158,137 +1159,143 @@ class BuilderTest extends TestCase
             ),
         ];
 
-        /** @see DatabaseQueryBuilderTest::testWhereAll */
-        yield 'whereAll' => [
-            [
-                'find' => [
-                    ['$and' => [['last_name' => 'Doe'], ['email' => 'Doe']]],
-                    [], // options
-                ],
-            ],
-            fn (Builder $builder) => $builder->whereAll(['last_name', 'email'], 'Doe'),
-        ];
-
-        yield 'whereAll operator' => [
-            [
-                'find' => [
-                    [
-                        '$and' => [
-                            ['last_name' => ['$not' => new Regex('^.*Doe.*$', 'i')]],
-                            ['email' => ['$not' => new Regex('^.*Doe.*$', 'i')]],
-                        ],
+        // Method added in Laravel v10.47.0
+        if (method_exists(Builder::class, 'whereAll')) {
+            /** @see DatabaseQueryBuilderTest::testWhereAll */
+            yield 'whereAll' => [
+                [
+                    'find' => [
+                        ['$and' => [['last_name' => 'Doe'], ['email' => 'Doe']]],
+                        [], // options
                     ],
-                    [], // options
                 ],
-            ],
-            fn (Builder $builder) => $builder->whereAll(['last_name', 'email'], 'not like', '%Doe%'),
-        ];
+                fn(Builder $builder) => $builder->whereAll(['last_name', 'email'], 'Doe'),
+            ];
 
-        /** @see DatabaseQueryBuilderTest::testOrWhereAll */
-        yield 'orWhereAll' => [
-            [
-                'find' => [
-                    [
-                        '$or' => [
-                            ['first_name' => 'John'],
-                            ['$and' => [['last_name' => 'Doe'], ['email' => 'Doe']]],
+            yield 'whereAll operator' => [
+                [
+                    'find' => [
+                        [
+                            '$and' => [
+                                ['last_name' => ['$not' => new Regex('^.*Doe.*$', 'i')]],
+                                ['email' => ['$not' => new Regex('^.*Doe.*$', 'i')]],
+                            ],
                         ],
+                        [], // options
                     ],
-                    [], // options
                 ],
-            ],
-            fn (Builder $builder) => $builder
-                ->where('first_name', 'John')
-                ->orWhereAll(['last_name', 'email'], 'Doe'),
-        ];
+                fn(Builder $builder) => $builder->whereAll(['last_name', 'email'], 'not like', '%Doe%'),
+            ];
 
-        yield 'orWhereAll operator' => [
-            [
-                'find' => [
-                    [
-                        '$or' => [
-                            ['first_name' => new Regex('^.*John.*$', 'i')],
-                            [
-                                '$and' => [
-                                    ['last_name' => ['$not' => new Regex('^.*Doe.*$', 'i')]],
-                                    ['email' => ['$not' => new Regex('^.*Doe.*$', 'i')]],
+            /** @see DatabaseQueryBuilderTest::testOrWhereAll */
+            yield 'orWhereAll' => [
+                [
+                    'find' => [
+                        [
+                            '$or' => [
+                                ['first_name' => 'John'],
+                                ['$and' => [['last_name' => 'Doe'], ['email' => 'Doe']]],
+                            ],
+                        ],
+                        [], // options
+                    ],
+                ],
+                fn(Builder $builder) => $builder
+                    ->where('first_name', 'John')
+                    ->orWhereAll(['last_name', 'email'], 'Doe'),
+            ];
+
+            yield 'orWhereAll operator' => [
+                [
+                    'find' => [
+                        [
+                            '$or' => [
+                                ['first_name' => new Regex('^.*John.*$', 'i')],
+                                [
+                                    '$and' => [
+                                        ['last_name' => ['$not' => new Regex('^.*Doe.*$', 'i')]],
+                                        ['email' => ['$not' => new Regex('^.*Doe.*$', 'i')]],
+                                    ],
                                 ],
                             ],
                         ],
+                        [], // options
                     ],
-                    [], // options
                 ],
-            ],
-            fn (Builder $builder) => $builder
-                ->where('first_name', 'like', '%John%')
-                ->orWhereAll(['last_name', 'email'], 'not like', '%Doe%'),
-        ];
+                fn(Builder $builder) => $builder
+                    ->where('first_name', 'like', '%John%')
+                    ->orWhereAll(['last_name', 'email'], 'not like', '%Doe%'),
+            ];
+        }
 
-        /** @see DatabaseQueryBuilderTest::testWhereAny */
-        yield 'whereAny' => [
-            [
-                'find' => [
-                    ['$or' => [['last_name' => 'Doe'], ['email' => 'Doe']]],
-                    [], // options
+        // Method added in Laravel v10.47.0
+        if (method_exists(Builder::class, 'whereAny')) {
+            /** @see DatabaseQueryBuilderTest::testWhereAny */
+            yield 'whereAny' => [
+                [
+                    'find' => [
+                        ['$or' => [['last_name' => 'Doe'], ['email' => 'Doe']]],
+                        [], // options
+                    ],
                 ],
-            ],
-            fn (Builder $builder) => $builder->whereAny(['last_name', 'email'], 'Doe'),
-        ];
+                fn(Builder $builder) => $builder->whereAny(['last_name', 'email'], 'Doe'),
+            ];
 
-        yield 'whereAny operator' => [
-            [
-                'find' => [
-                    [
-                        '$or' => [
-                            ['last_name' => ['$not' => new Regex('^.*Doe.*$', 'i')]],
-                            ['email' => ['$not' => new Regex('^.*Doe.*$', 'i')]],
+            yield 'whereAny operator' => [
+                [
+                    'find' => [
+                        [
+                            '$or' => [
+                                ['last_name' => ['$not' => new Regex('^.*Doe.*$', 'i')]],
+                                ['email' => ['$not' => new Regex('^.*Doe.*$', 'i')]],
+                            ],
                         ],
+                        [], // options
                     ],
-                    [], // options
                 ],
-            ],
-            fn (Builder $builder) => $builder->whereAny(['last_name', 'email'], 'not like', '%Doe%'),
-        ];
+                fn(Builder $builder) => $builder->whereAny(['last_name', 'email'], 'not like', '%Doe%'),
+            ];
 
-        /** @see DatabaseQueryBuilderTest::testOrWhereAny */
-        yield 'orWhereAny' => [
-            [
-                'find' => [
-                    [
-                        '$or' => [
-                            ['first_name' => 'John'],
-                            ['$or' => [['last_name' => 'Doe'], ['email' => 'Doe']]],
+            /** @see DatabaseQueryBuilderTest::testOrWhereAny */
+            yield 'orWhereAny' => [
+                [
+                    'find' => [
+                        [
+                            '$or' => [
+                                ['first_name' => 'John'],
+                                ['$or' => [['last_name' => 'Doe'], ['email' => 'Doe']]],
+                            ],
                         ],
+                        [], // options
                     ],
-                    [], // options
                 ],
-            ],
-            fn (Builder $builder) => $builder
-                ->where('first_name', 'John')
-                ->orWhereAny(['last_name', 'email'], 'Doe'),
-        ];
+                fn(Builder $builder) => $builder
+                    ->where('first_name', 'John')
+                    ->orWhereAny(['last_name', 'email'], 'Doe'),
+            ];
 
-        yield 'orWhereAny operator' => [
-            [
-                'find' => [
-                    [
-                        '$or' => [
-                            ['first_name' => new Regex('^.*John.*$', 'i')],
-                            [
-                                '$or' => [
-                                    ['last_name' => ['$not' => new Regex('^.*Doe.*$', 'i')]],
-                                    ['email' => ['$not' => new Regex('^.*Doe.*$', 'i')]],
+            yield 'orWhereAny operator' => [
+                [
+                    'find' => [
+                        [
+                            '$or' => [
+                                ['first_name' => new Regex('^.*John.*$', 'i')],
+                                [
+                                    '$or' => [
+                                        ['last_name' => ['$not' => new Regex('^.*Doe.*$', 'i')]],
+                                        ['email' => ['$not' => new Regex('^.*Doe.*$', 'i')]],
+                                    ],
                                 ],
                             ],
                         ],
+                        [], // options
                     ],
-                    [], // options
                 ],
-            ],
-            fn (Builder $builder) => $builder
-                ->where('first_name', 'like', '%John%')
-                ->orWhereAny(['last_name', 'email'], 'not like', '%Doe%'),
-        ];
+                fn(Builder $builder) => $builder
+                    ->where('first_name', 'like', '%John%')
+                    ->orWhereAny(['last_name', 'email'], 'not like', '%Doe%'),
+            ];
+        }
     }
 
     /** @dataProvider provideExceptions */


### PR DESCRIPTION
Fix PHPORM-159

I could not reproduce the error described in #2757. This new tests ensure the correct query is generated.

### Checklist

- [x] Add tests and ensure they pass
- [ ] ~Add an entry to the CHANGELOG.md file~
- [ ] ~Update documentation for new features~
