### PR TITLE
Use bot access token for merge-up pull requests

### DIFF
--- a/.github/workflows/merge-up.yml
+++ b/.github/workflows/merge-up.yml
@@ -5,12 +5,8 @@ on:
     branches:
       - "[0-9]+.[0-9]+"
 
-permissions:
-  contents: write
-  pull-requests: write
-
 env:
-  GH_TOKEN: ${{ github.token }}
+  GH_TOKEN: ${{ secrets.MERGE_UP_TOKEN }}
 
 jobs:
   merge-up:
@@ -24,6 +20,7 @@ jobs:
         with:
           # fetch-depth 0 is required to fetch all branches, not just the branch being built
           fetch-depth: 0
+          token: ${{ secrets.MERGE_UP_TOKEN }}
 
       - name: Create pull request
         id: create-pull-request


### PR DESCRIPTION
This changes the merge-up action to use a personal access token of the PHP bot, which will ensure that pull requests generated through the actions dispatch pull request workflows.