### PR TITLE
PHPORM-162 Drop support for Composer 1.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@ All notable changes to this project will be documented in this file.
 
 ## [unreleased]
 
+* Drop support for Composer 1.x by @GromNaN in [#2784](https://github.com/mongodb/laravel-mongodb/pull/2784)
 
-## [4.2.0] - 2024-12-14
+## [4.2.0] - 2024-03-14
 
 * Add support for Laravel 11 by @GromNaN in [#2735](https://github.com/mongodb/laravel-mongodb/pull/2735)
 * Implement Model::createOrFirst() using findOneAndUpdate operation by @GromNaN in [#2742](https://github.com/mongodb/laravel-mongodb/pull/2742)

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
     "require": {
         "php": "^8.1",
         "ext-mongodb": "^1.15",
+        "composer-runtime-api": "^2.0.0",
         "illuminate/support": "^10.0|^11",
         "illuminate/container": "^10.0|^11",
         "illuminate/database": "^10.30|^11",

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -16,7 +16,6 @@ use MongoDB\Driver\ReadPreference;
 use MongoDB\Laravel\Concerns\ManagesTransactions;
 use Throwable;
 
-use function class_exists;
 use function filter_var;
 use function implode;
 use function is_array;
@@ -324,14 +323,10 @@ class Connection extends BaseConnection
 
     private static function lookupVersion(): string
     {
-        if (class_exists(InstalledVersions::class)) {
-            try {
-                return self::$version = InstalledVersions::getPrettyVersion('mongodb/laravel-mongodb');
-            } catch (Throwable) {
-                return self::$version = 'error';
-            }
+        try {
+            return self::$version = InstalledVersions::getPrettyVersion('mongodb/laravel-mongodb');
+        } catch (Throwable) {
+            return self::$version = 'error';
         }
-
-        return self::$version = 'unknown';
     }
 }

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -324,7 +324,7 @@ class Connection extends BaseConnection
     private static function lookupVersion(): string
     {
         try {
-            return self::$version = InstalledVersions::getPrettyVersion('mongodb/laravel-mongodb');
+            return self::$version = InstalledVersions::getPrettyVersion('mongodb/laravel-mongodb') ?? 'unknown';
         } catch (Throwable) {
             return self::$version = 'error';
         }


### PR DESCRIPTION
Fix PHPORM-162

`mongodb/mongodb` already dropped support for Composer 1.x in https://github.com/mongodb/mongo-php-library/pull/1027

### Checklist

- [ ] ~Add tests and ensure they pass~
- [x] Add an entry to the CHANGELOG.md file
- [ ] ~Update documentation for new features~
