### PR TITLE
PHPORM-160: Add documentation tests to PHPUnit suite config

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,6 +12,9 @@
         <testsuite name="Test Suite">
             <directory>tests/</directory>
         </testsuite>
+        <testsuite name="Documentation">
+            <directory>docs/includes/</directory>
+        </testsuite>
     </testsuites>
     <php>
         <env name="MONGODB_URI" value="mongodb://mongodb/"/>


### PR DESCRIPTION
Missing from #2775

Add a test suite for docs examples.

