### PR TITLE
PHPORM-164 Run tests with PHP 8.4

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -30,7 +30,11 @@ jobs:
                     - php: "8.1"
                       laravel: "10.*"
                       mongodb: "5.0"
-                      mode: "low-deps"
+                      mode: "--prefer-lowest"
+                    - php: "8.4"
+                      laravel: "11.*"
+                      mongodb: "7.0"
+                      mode: "--ignore-platform-reqs"
                 exclude:
                     - php: "8.1"
                       laravel: "11.*"
@@ -80,7 +84,7 @@ jobs:
                     restore-keys: "${{ matrix.os }}-composer-"
 
             -   name: "Install dependencies"
-                run: composer update --no-interaction $([[ "${{ matrix.mode }}" == low-deps ]] && echo ' --prefer-lowest')
+                run: composer update --no-interaction ${{ matrix.mode }}
             -   name: "Run tests"
                 run: "./vendor/bin/phpunit --coverage-clover coverage.xml"
                 env:

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -30,11 +30,13 @@ jobs:
                     - php: "8.1"
                       laravel: "10.*"
                       mongodb: "5.0"
-                      mode: "--prefer-lowest"
+                      mode: "low-deps"
+                      os: "ubuntu-latest"
                     - php: "8.4"
                       laravel: "11.*"
                       mongodb: "7.0"
-                      mode: "--ignore-platform-reqs"
+                      mode: "ignore-php-req"
+                      os: "ubuntu-latest"
                 exclude:
                     - php: "8.1"
                       laravel: "11.*"
@@ -84,7 +86,10 @@ jobs:
                     restore-keys: "${{ matrix.os }}-composer-"
 
             -   name: "Install dependencies"
-                run: composer update --no-interaction ${{ matrix.mode }}
+                run: |
+                  composer update --no-interaction \
+                    $([[ "${{ matrix.mode }}" == low-deps ]] && echo ' --prefer-lowest') \
+                    $([[ "${{ matrix.mode }}" == ignore-php-req ]] && echo ' --ignore-platform-req=php+')
             -   name: "Run tests"
                 run: "./vendor/bin/phpunit --coverage-clover coverage.xml"
                 env:


### PR DESCRIPTION
Fix PHPORM-164

[See what's new in PHP 8.4 on php.watch](https://php.watch/versions/8.4).

We have no implicitly nullable arguments. So nothing to fix so far.

### Checklist

- [x] Add tests and ensure they pass
- [x] Add an entry to the CHANGELOG.md file
- [x] Update documentation for new features
