### PR TITLE
DOCSP-35977: Find multiple usage example

### DIFF
--- a/docs/includes/usage-examples/FindManyTest.php
+++ b/docs/includes/usage-examples/FindManyTest.php
@@ -30,12 +30,11 @@ class FindManyTest extends TestCase
         ]);
 
         // begin-find
-        foreach (
-            Movie::where('runtime', '>', 900)
+        $cursor = Movie::where('runtime', '>', 900)
             ->orderBy('_id')
-            ->cursor() as $movie
-        ) {
-                echo $movie->toJson() . '<br>';
+            ->cursor();
+        foreach ($cursor as $movie) {
+            echo $movie->toJson() . '<br>';
         }
 
         // end-find

--- a/docs/includes/usage-examples/FindManyTest.php
+++ b/docs/includes/usage-examples/FindManyTest.php
@@ -20,9 +20,11 @@ class FindManyTest extends TestCase
         Movie::truncate();
 
         // begin-find
-        foreach (Movie::where('runtime', '>', 900)
+        foreach (
+            Movie::where('runtime', '>', 900)
             ->orderBy('_id')
-            ->cursor() as $movie) {
+            ->cursor() as $movie
+        ) {
                 echo $movie->toJson() . '<br>';
         }
 

--- a/docs/includes/usage-examples/FindManyTest.php
+++ b/docs/includes/usage-examples/FindManyTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Models\Movie;
+use MongoDB\Laravel\Tests\TestCase;
+
+class FindManyTest extends TestCase
+{
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function testFindMany(): void
+    {
+        require_once __DIR__ . '/Movie.php';
+
+        Movie::truncate();
+
+        // begin-find
+        $movies = Movie::where('runtime', '>', 800)
+            ->orderBy('_id')
+            ->get();
+
+        foreach ($movies as $m) {
+            echo $m->toJson() . '<br>';
+        }
+        // end-find
+
+        $this->assertInstanceOf(Movie::class, $movie);
+    }
+}

--- a/docs/includes/usage-examples/FindManyTest.php
+++ b/docs/includes/usage-examples/FindManyTest.php
@@ -39,4 +39,5 @@ class FindManyTest extends TestCase
         }
 
         // end-find
+    }
 }

--- a/docs/includes/usage-examples/FindManyTest.php
+++ b/docs/includes/usage-examples/FindManyTest.php
@@ -27,6 +27,7 @@ class FindManyTest extends TestCase
         foreach ($movies as $m) {
             echo $m->toJson() . '<br>';
         }
+
         // end-find
 
         $this->assertInstanceOf(Movie::class, $movie);

--- a/docs/includes/usage-examples/FindManyTest.php
+++ b/docs/includes/usage-examples/FindManyTest.php
@@ -39,6 +39,4 @@ class FindManyTest extends TestCase
         }
 
         // end-find
-        $this->expectOutputRegex('/^{"_id":"[a-z0-9]{24}","title":"Centennial","runtime":1256}\r\n{"_id":"[a-z0-9]{24}","title":"Baseball","runtime":1140}$/');
-    }
 }

--- a/docs/includes/usage-examples/FindManyTest.php
+++ b/docs/includes/usage-examples/FindManyTest.php
@@ -30,13 +30,11 @@ class FindManyTest extends TestCase
         ]);
 
         // begin-find
-        $cursor = Movie::where('runtime', '>', 900)
+        $movies = Movie::where('runtime', '>', 900)
             ->orderBy('_id')
-            ->cursor();
-        foreach ($cursor as $movie) {
-            echo $movie->toJson() . '<br>';
-        }
-
+            ->get();
         // end-find
+
+        $this->assertEquals(2, $movies->count());
     }
 }

--- a/docs/includes/usage-examples/FindManyTest.php
+++ b/docs/includes/usage-examples/FindManyTest.php
@@ -27,6 +27,10 @@ class FindManyTest extends TestCase
                 'title' => 'Baseball',
                 'runtime' => 1140,
             ],
+            [
+                'title' => 'Basketball',
+                'runtime' => 600,
+            ],
         ]);
 
         // begin-find

--- a/docs/includes/usage-examples/FindManyTest.php
+++ b/docs/includes/usage-examples/FindManyTest.php
@@ -18,6 +18,16 @@ class FindManyTest extends TestCase
         require_once __DIR__ . '/Movie.php';
 
         Movie::truncate();
+        Movie::insert([
+            [
+                'title' => 'Centennial',
+                'runtime' => 1256,
+            ],
+            [
+                'title' => 'Baseball',
+                'runtime' => 1140,
+            ],
+        ]);
 
         // begin-find
         foreach (
@@ -29,5 +39,6 @@ class FindManyTest extends TestCase
         }
 
         // end-find
+        $this->expectOutputRegex('/^{"_id":"[a-z0-9]{24}","title":"Centennial","runtime":1256}\r\n{"_id":"[a-z0-9]{24}","title":"Baseball","runtime":1140}$/');
     }
 }

--- a/docs/includes/usage-examples/FindManyTest.php
+++ b/docs/includes/usage-examples/FindManyTest.php
@@ -20,16 +20,12 @@ class FindManyTest extends TestCase
         Movie::truncate();
 
         // begin-find
-        $movies = Movie::where('runtime', '>', 800)
+        foreach (Movie::where('runtime', '>', 900)
             ->orderBy('_id')
-            ->get();
-
-        foreach ($movies as $m) {
-            echo $m->toJson() . '<br>';
+            ->cursor() as $movie) {
+                echo $movie->toJson() . '<br>';
         }
 
         // end-find
-
-        $this->assertInstanceOf(Movie::class, $movie);
     }
 }

--- a/docs/usage-examples.txt
+++ b/docs/usage-examples.txt
@@ -72,4 +72,5 @@ calls the controller function and returns the result to a web interface.
    :maxdepth: 1
 
    /usage-examples/findOne
+   /usage-examples/find
    /usage-examples/updateOne

--- a/docs/usage-examples/find.txt
+++ b/docs/usage-examples/find.txt
@@ -28,6 +28,7 @@ The example calls the following methods on the ``Movie`` model:
 - ``get()``: retrieves the query results
 
 .. io-code-block::
+   :copyable: true
 
    .. input:: ../includes/usage-examples/FindManyTest.php
       :start-after: begin-find
@@ -50,15 +51,8 @@ The example calls the following methods on the ``Movie`` model:
           "Drama"
       ],
       "runtime": 1256,
-      "cast": [
-          "Raymond Burr",
-          "Barbara Carrera",
-          "Richard Chamberlain",
-          "Robert Conrad"
-      ],
-      "num_mflix_comments": 1,
-      "poster": "https://m.media-amazon.com/images/M/MV5BMTM4OTMyMzg4MV5BMl5BanBnXkFtZTcwMTMzMzU1MQ@@._V1_SY1000_SX677_AL_.jpg",
-     "title": "Centennial",
+      ...
+      "title": "Centennial",
       ...
       }
 
@@ -72,18 +66,11 @@ The example calls the following methods on the ``Movie`` model:
           "Sport"
       ],
       "runtime": 1140,
-      "cast": [
-          "John Chancellor",
-          "Daniel Okrent",
-          "Ossie Davis",
-          "Paul Roebling"
-      ],
-      "num_mflix_comments": 0,
-      "poster": "https://m.media-amazon.com/images/M/MV5BN2FmNjM0NzMtYjZjZi00NzQ0LWE5MjMtOWEzOGNmYjZkNmI1XkEyXkFqcGdeQXVyNTAyODkwOQ@@._V1_SY1000_SX677_AL_.jpg",
+      ...
       "title": "Baseball",
       ...
       }
-      
+
       {
       "_id": "573a13a6f29313caabd18ae0",
       "plot": "Taken spans five decades and four generations, centering on three families: the Keys, Crawfords, and Clarkes.
@@ -93,18 +80,10 @@ The example calls the following methods on the ``Movie`` model:
           "Sci-Fi"
       ],
       "runtime": 877,
-      "cast": [
-          "Dakota Fanning",
-          "Matt Frewer",
-          "Emily Bergl",
-          "Heather Donahue"
-      ],
-      "num_mflix_comments": 1,
-      "poster": "https://m.media-amazon.com/images/M/MV5BMTI0NTI0NjAxMV5BMl5BanBnXkFtZTYwOTM3MTg5._V1_SY1000_SX677_AL_.jpg",
+      ...
       "title": "Taken",
       ...
       }
-
 
 For instructions on editing your Laravel application to run the usage example, see the
 :ref:`Usage Example landing page <laravel-usage-examples>`.

--- a/docs/usage-examples/find.txt
+++ b/docs/usage-examples/find.txt
@@ -43,7 +43,7 @@ The example calls the following methods on the ``Movie`` model:
       // Results are truncated
       
       {
-      "_id": "573a1397f29313caabce69db",
+      "_id": "...",
       "plot": "The economic and cultural growth of Colorado spanning two centuries from the mid-1700s to the late-1970s.",
       "genres": [
           "Action",
@@ -57,7 +57,7 @@ The example calls the following methods on the ``Movie`` model:
       }
 
       {
-      "_id": "573a1399f29313caabcee1aa",
+      "_id": "...",
       "plot": "A documentary on the history of the sport with major topics including Afro-American players, player/team
       owner relations and the resilience of the game.",
       "genres": [
@@ -72,7 +72,7 @@ The example calls the following methods on the ``Movie`` model:
       }
 
       {
-      "_id": "573a13a6f29313caabd18ae0",
+      "_id": "...",
       "plot": "Taken spans five decades and four generations, centering on three families: the Keys, Crawfords, and Clarkes.
       World War II veteran Russell Keys is plagued by nightmares of his abduction by ...",
       "genres": [

--- a/docs/usage-examples/find.txt
+++ b/docs/usage-examples/find.txt
@@ -17,15 +17,18 @@ Find Multiple Documents
    :depth: 1
    :class: singlecol
 
-You can retrieve multiple documents from a collection by chaining a retrieval
-method such as ``where()`` with the ``get()`` method to retrieve the results.
-You can chain these methods to an Eloquent model or a query builder.
+You can retrieve multiple documents from a collection by creating a query
+builder using a method such as ``Model::where()`` or by using the ``DB``
+facade, and then chaining the ``get()`` method to retrieve the result.
 
 Pass a query filter to the ``where()`` method to retrieve documents that meet a
 set of criteria. When you call the ``get()`` method, MongoDB returns the
 matching documents according to their :term:`natural order` in the database or
 according to the sort order that you can specify by using the ``orderBy()``
 method.
+
+To learn more about query builder methods, see the :ref:`laravel-query-builder`
+guide.
 
 Example
 -------

--- a/docs/usage-examples/find.txt
+++ b/docs/usage-examples/find.txt
@@ -32,11 +32,11 @@ This usage example performs the following actions:
 
 - Uses the ``Movie`` Eloquent model to represent the ``movies`` collection in the
   ``sample_mflix`` database
-- Retrieves documents from the ``movies`` collection that match a query filter
+- Retrieves and prints documents from the ``movies`` collection that match a query filter
 
 The example calls the following methods on the ``Movie`` model:
 
-- ``where()``: matches documents in which the value of the ``runtime`` field is greater than ``800``
+- ``where()``: matches documents in which the value of the ``runtime`` field is greater than ``900``
 - ``orderBy()``: sorts matched documents by their ascending ``_id`` values
 - ``get()``: retrieves the query results
 
@@ -56,13 +56,8 @@ The example calls the following methods on the ``Movie`` model:
       // Results are truncated
       
       {
-      "_id": "...",
-      "plot": "The economic and cultural growth of Colorado spanning two centuries from the mid-1700s to the late-1970s.",
-      "genres": [
-          "Action",
-          "Adventure",
-          "Drama"
-      ],
+      "_id": "573a1397f29313caabce69db",
+      ...
       "runtime": 1256,
       ...
       "title": "Centennial",
@@ -70,38 +65,18 @@ The example calls the following methods on the ``Movie`` model:
       }
 
       {
-      "_id": "...",
-      "plot": "A documentary on the history of the sport with major topics including Afro-American players, player/team
-      owner relations and the resilience of the game.",
-      "genres": [
-          "Documentary",
-          "History",
-          "Sport"
-      ],
+      "_id": "573a1399f29313caabcee1aa",
+      ...
       "runtime": 1140,
       ...
       "title": "Baseball",
       ...
       }
 
-      {
-      "_id": "...",
-      "plot": "Taken spans five decades and four generations, centering on three families: the Keys, Crawfords, and Clarkes.
-      World War II veteran Russell Keys is plagued by nightmares of his abduction by ...",
-      "genres": [
-          "Drama",
-          "Sci-Fi"
-      ],
-      "runtime": 877,
-      ...
-      "title": "Taken",
-      ...
-      }
-
 For instructions on editing your Laravel application to run the usage example, see the
-:ref:`Usage Example landing page <laravel-usage-examples>`.
+:ref:`Usage Examples landing page <laravel-usage-examples>`.
 
 .. tip::
 
-   To learn more about retrieving documents with {+odm-short+}, see the
-   :ref:`laravel-fundamentals-retrieve` guide
+   To learn about other ways to retrieve documents with {+odm-short+}, see the
+   :ref:`laravel-fundamentals-retrieve` guide.

--- a/docs/usage-examples/find.txt
+++ b/docs/usage-examples/find.txt
@@ -17,13 +17,15 @@ Find Multiple Documents
    :depth: 1
    :class: singlecol
 
-You can retrieve multiple documents from a collection by calling the ``where()`` method
-on an Eloquent model or a query builder.
+You can retrieve multiple documents from a collection by chaining a retrieval
+method such as ``where()`` with the ``get()`` method to retrieve the results.
+You can chain these methods to an Eloquent model or a query builder.
 
 Pass a query filter to the ``where()`` method to retrieve documents that meet a
-set of criteria. MongoDB returns the matching documents according to their
-:term:`natural order` in the database or according to the sort order that you can specify
-by using the ``orderBy()`` method.
+set of criteria. When you call the ``get()`` method, MongoDB returns the
+matching documents according to their :term:`natural order` in the database or
+according to the sort order that you can specify by using the ``orderBy()``
+method.
 
 Example
 -------
@@ -38,7 +40,7 @@ The example calls the following methods on the ``Movie`` model:
 
 - ``where()``: matches documents in which the value of the ``runtime`` field is greater than ``900``
 - ``orderBy()``: sorts matched documents by their ascending ``_id`` values
-- ``cursor()``: retrieves the query results by loading each ``Movie`` model into memory one at a time
+- ``get()``: retrieves the query results as a Laravel collection object
 
 .. io-code-block::
    :copyable: true
@@ -50,28 +52,26 @@ The example calls the following methods on the ``Movie`` model:
       :dedent:
 
    .. output::
-      :language: console
+      :language:  json
       :visible: false
 
       // Results are truncated
-      
-      {
-      "_id": "573a1397f29313caabce69db",
-      ...
-      "runtime": 1256,
-      ...
-      "title": "Centennial",
-      ...
-      }
 
-      {
-      "_id": "573a1399f29313caabcee1aa",
-      ...
-      "runtime": 1140,
-      ...
-      "title": "Baseball",
-      ...
-      }
+      [
+        {
+          "_id": ...,
+          "runtime": 1256,
+          "title": "Centennial",
+          ...,
+        },
+        {
+          "_id": ...,
+          "runtime": 1140,
+          "title": "Baseball",
+          ...,
+        },
+        ...
+      ]
 
 For instructions on editing your Laravel application to run the usage example, see the
 :ref:`Usage Examples landing page <laravel-usage-examples>`.

--- a/docs/usage-examples/find.txt
+++ b/docs/usage-examples/find.txt
@@ -1,0 +1,115 @@
+.. _laravel-find-usage:
+
+=======================
+Find Multiple Documents
+=======================
+
+You can retrieve multiple documents from a collection by calling the ``where()`` method
+on an Eloquent model or a query builder.
+
+Pass a query filter to the ``where()`` method to retrieve documents that meet a
+set of criteria. MongoDB returns the matching documents according to their
+:term:`natural order` in the database or according to the sort order that you can specify
+by using the ``orderBy()`` method.
+
+Example
+-------
+
+This usage example performs the following actions:
+
+- Uses the ``Movie`` Eloquent model to represent the ``movies`` collection in the
+  ``sample_mflix`` database
+- Retrieves documents from the ``movies`` collection that match a query filter
+
+The example calls the following methods on the ``Movie`` model:
+
+- ``where()``: matches documents in which the value of the ``runtime`` field is greater than ``800``
+- ``orderBy()``: sorts matched documents by their ascending ``_id`` values
+- ``get()``: retrieves the query results
+
+.. io-code-block::
+
+   .. input:: ../includes/usage-examples/FindManyTest.php
+      :start-after: begin-find
+      :end-before: end-find
+      :language: php
+      :dedent:
+
+   .. output::
+      :language: console
+      :visible: false
+
+      // Results are truncated
+      
+      {
+      "_id": "573a1397f29313caabce69db",
+      "plot": "The economic and cultural growth of Colorado spanning two centuries from the mid-1700s to the late-1970s.",
+      "genres": [
+          "Action",
+          "Adventure",
+          "Drama"
+      ],
+      "runtime": 1256,
+      "cast": [
+          "Raymond Burr",
+          "Barbara Carrera",
+          "Richard Chamberlain",
+          "Robert Conrad"
+      ],
+      "num_mflix_comments": 1,
+      "poster": "https://m.media-amazon.com/images/M/MV5BMTM4OTMyMzg4MV5BMl5BanBnXkFtZTcwMTMzMzU1MQ@@._V1_SY1000_SX677_AL_.jpg",
+     "title": "Centennial",
+      ...
+      }
+
+      {
+      "_id": "573a1399f29313caabcee1aa",
+      "plot": "A documentary on the history of the sport with major topics including Afro-American players, player/team
+      owner relations and the resilience of the game.",
+      "genres": [
+          "Documentary",
+          "History",
+          "Sport"
+      ],
+      "runtime": 1140,
+      "cast": [
+          "John Chancellor",
+          "Daniel Okrent",
+          "Ossie Davis",
+          "Paul Roebling"
+      ],
+      "num_mflix_comments": 0,
+      "poster": "https://m.media-amazon.com/images/M/MV5BN2FmNjM0NzMtYjZjZi00NzQ0LWE5MjMtOWEzOGNmYjZkNmI1XkEyXkFqcGdeQXVyNTAyODkwOQ@@._V1_SY1000_SX677_AL_.jpg",
+      "title": "Baseball",
+      ...
+      }
+      
+      {
+      "_id": "573a13a6f29313caabd18ae0",
+      "plot": "Taken spans five decades and four generations, centering on three families: the Keys, Crawfords, and Clarkes.
+      World War II veteran Russell Keys is plagued by nightmares of his abduction by ...",
+      "genres": [
+          "Drama",
+          "Sci-Fi"
+      ],
+      "runtime": 877,
+      "cast": [
+          "Dakota Fanning",
+          "Matt Frewer",
+          "Emily Bergl",
+          "Heather Donahue"
+      ],
+      "num_mflix_comments": 1,
+      "poster": "https://m.media-amazon.com/images/M/MV5BMTI0NTI0NjAxMV5BMl5BanBnXkFtZTYwOTM3MTg5._V1_SY1000_SX677_AL_.jpg",
+      "title": "Taken",
+      ...
+      }
+
+
+For instructions on editing your Laravel application to run the usage example, see the
+:ref:`Usage Example landing page <laravel-usage-examples>`.
+
+.. tip::
+
+   To learn more about retrieving documents with {+odm-short+}, see the
+   :ref:`laravel-fundamentals-retrieve` guide

--- a/docs/usage-examples/find.txt
+++ b/docs/usage-examples/find.txt
@@ -4,6 +4,19 @@
 Find Multiple Documents
 =======================
 
+.. facet::
+   :name: genre
+   :values: reference
+
+.. meta::
+   :keywords: find many, retrieve, code example
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
 You can retrieve multiple documents from a collection by calling the ``where()`` method
 on an Eloquent model or a query builder.
 

--- a/docs/usage-examples/find.txt
+++ b/docs/usage-examples/find.txt
@@ -38,7 +38,7 @@ The example calls the following methods on the ``Movie`` model:
 
 - ``where()``: matches documents in which the value of the ``runtime`` field is greater than ``900``
 - ``orderBy()``: sorts matched documents by their ascending ``_id`` values
-- ``get()``: retrieves the query results
+- ``cursor()``: retrieves the query results by loading each ``Movie`` model into memory one at a time
 
 .. io-code-block::
    :copyable: true


### PR DESCRIPTION
<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.
-->
Adds a usage example showing how to retrieve multiple documents.
JIRA - https://jira.mongodb.org/browse/DOCSP-35977
Staging -
https://preview-mongodbcchomongodb.gatsbyjs.io/laravel/DOCSP-35977-ccho/usage-examples/find/

### Checklist

- [ ] Add tests and ensure they pass
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Update documentation for new features
