### PR TITLE
PHPORM-167 Fix and test MongoDB failed queue provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 * New aggregation pipeline builder by @GromNaN in [#2738](https://github.com/mongodb/laravel-mongodb/pull/2738)
 * Drop support for Composer 1.x by @GromNaN in [#2784](https://github.com/mongodb/laravel-mongodb/pull/2784)
+* Fix `artisan query:retry` command by @GromNaN in [#2838](https://github.com/mongodb/laravel-mongodb/pull/2838)
 
 ## [4.2.0] - 2024-03-14
 

--- a/src/Queue/Failed/MongoFailedJobProvider.php
+++ b/src/Queue/Failed/MongoFailedJobProvider.php
@@ -90,7 +90,7 @@ class MongoFailedJobProvider extends DatabaseFailedJobProvider
      *
      * @param  string|null $queue
      *
-     * @return array
+     * @return list<mixed>
      */
     public function ids($queue = null)
     {

--- a/src/Queue/Failed/MongoFailedJobProvider.php
+++ b/src/Queue/Failed/MongoFailedJobProvider.php
@@ -8,6 +8,7 @@ use Carbon\Carbon;
 use DateTimeInterface;
 use Exception;
 use Illuminate\Queue\Failed\DatabaseFailedJobProvider;
+use MongoDB\BSON\ObjectId;
 use MongoDB\BSON\UTCDateTime;
 
 use function array_map;
@@ -86,11 +87,11 @@ class MongoFailedJobProvider extends DatabaseFailedJobProvider
     }
 
     /**
-     * Get the IDs of all of the failed jobs.
+     * Get the IDs of all the failed jobs.
      *
      * @param  string|null $queue
      *
-     * @return list<mixed>
+     * @return list<ObjectId>
      */
     public function ids($queue = null)
     {
@@ -102,7 +103,7 @@ class MongoFailedJobProvider extends DatabaseFailedJobProvider
     }
 
     /**
-     * Prune all entries older than the given date.
+     * Prune all failed jobs older than the given date.
      *
      * @param  DateTimeInterface $before
      *

--- a/tests/Queue/Failed/MongoFailedJobProviderTest.php
+++ b/tests/Queue/Failed/MongoFailedJobProviderTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace MongoDB\Laravel\Tests\Queue\Failed;
+
+use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Facades\DB;
+use MongoDB\BSON\ObjectId;
+use MongoDB\BSON\UTCDateTime;
+use MongoDB\Laravel\Queue\Failed\MongoFailedJobProvider;
+use MongoDB\Laravel\Tests\TestCase;
+use OutOfBoundsException;
+
+use function array_map;
+use function range;
+use function sprintf;
+
+class MongoFailedJobProviderTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        DB::connection('mongodb')
+            ->collection('failed_jobs')
+            ->raw()
+            ->insertMany(array_map(static fn ($i) => [
+                '_id' => new ObjectId(sprintf('%024d', $i)),
+                'connection' => 'mongodb',
+                'queue' => $i % 2 ? 'default' : 'other',
+                'failed_at' => new UTCDateTime(Date::now()->subHours($i)),
+            ], range(1, 5)));
+    }
+
+    public function tearDown(): void
+    {
+        DB::connection('mongodb')
+            ->collection('failed_jobs')
+            ->raw()
+            ->drop();
+
+        parent::tearDown();
+    }
+
+    public function testLog(): void
+    {
+        $provider = $this->getProvider();
+
+        $provider->log('mongodb', 'default', '{"foo":"bar"}', new OutOfBoundsException('This is the error'));
+
+        $ids = $provider->ids();
+
+        $this->assertCount(6, $ids);
+
+        $inserted = $provider->find($ids[0]);
+
+        $this->assertSame('mongodb', $inserted->connection);
+        $this->assertSame('default', $inserted->queue);
+        $this->assertSame('{"foo":"bar"}', $inserted->payload);
+        $this->assertStringContainsString('OutOfBoundsException: This is the error', $inserted->exception);
+        $this->assertInstanceOf(ObjectId::class, $inserted->_id);
+        $this->assertSame((string) $inserted->_id, $inserted->id);
+    }
+
+    public function testCount(): void
+    {
+        $provider = $this->getProvider();
+
+        $this->assertEquals(5, $provider->count());
+        $this->assertEquals(3, $provider->count('mongodb', 'default'));
+        $this->assertEquals(2, $provider->count('mongodb', 'other'));
+    }
+
+    public function testAll(): void
+    {
+        $all = $this->getProvider()->all();
+
+        $this->assertCount(5, $all);
+        $this->assertEquals(new ObjectId(sprintf('%024d', 5)), $all[0]->_id);
+        $this->assertEquals(sprintf('%024d', 5), $all[0]->id, 'id field is added for compatibility with DatabaseFailedJobProvider');
+    }
+
+    public function testFindAndForget(): void
+    {
+        $provider = $this->getProvider();
+
+        $id = sprintf('%024d', 2);
+        $found = $provider->find($id);
+
+        $this->assertIsObject($found, 'The job is found');
+        $this->assertEquals(new ObjectId($id), $found->_id);
+        $this->assertObjectHasProperty('failed_at', $found);
+
+        // Delete the job
+        $result = $provider->forget($id);
+
+        $this->assertTrue($result, 'forget return true when the job have been deleted');
+        $this->assertNull($provider->find($id), 'the job have been deleted');
+
+        // Delete the same job again
+        $result = $provider->forget($id);
+
+        $this->assertFalse($result, 'forget return false when the job does not exist');
+
+        $this->assertCount(4, $provider->ids(), 'Other jobs are kept');
+    }
+
+    public function testIds(): void
+    {
+        $ids = $this->getProvider()->ids();
+
+        $this->assertCount(5, $ids);
+        $this->assertEquals(new ObjectId(sprintf('%024d', 5)), $ids[0]);
+    }
+
+    public function testIdsFilteredByQuery(): void
+    {
+        $ids = $this->getProvider()->ids('other');
+
+        $this->assertCount(2, $ids);
+        $this->assertEquals(new ObjectId(sprintf('%024d', 4)), $ids[0]);
+    }
+
+    public function testFlush(): void
+    {
+        $provider = $this->getProvider();
+
+        $this->assertEquals(5, $provider->count());
+
+        $provider->flush(4);
+
+        $this->assertEquals(3, $provider->count());
+    }
+
+    public function testPrune(): void
+    {
+        $provider = $this->getProvider();
+
+        $this->assertEquals(5, $provider->count());
+
+        $result = $provider->prune(Date::now()->subHours(4));
+
+        $this->assertEquals(2, $result);
+        $this->assertEquals(3, $provider->count());
+    }
+
+    private function getProvider(): MongoFailedJobProvider
+    {
+        return new MongoFailedJobProvider(DB::getFacadeRoot(), '', 'failed_jobs');
+    }
+}


### PR DESCRIPTION
Fix PHPORM-167

In Laravel 11.35, the `DatabaseFailedJobProvider::ids` was added in order to optimize loading this ids only instead of the full documents. https://github.com/laravel/framework/pull/49186

This implementation is not compatible with MongoDB since it references the field `id` instead of `_id`.

Also, the method [`DatabaseFailedJobProvider::prune`](https://github.com/laravel/framework/blob/d63d2b1f50b6bbf8beb88b7b4ad5a4d230244443/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php#L140) is not compatible with MongoDB because it tries to delete document by bulks of 1000, which is not supported. MongoDB can only delete one or all documents matching a criteria.

I'm also adding tests to the methods inherited from the parent `DatabaseFailedJobProvider` to ensure they work with a MongoDB connection.

### Checklist

- [x] Add tests and ensure they pass
- [x] Add an entry to the CHANGELOG.md file
- [x] Update documentation for new features
