### PR TITLE
Add docs team as code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @mongodb/dbx-php
+/docs @mongodb/docs-drivers-team


### PR DESCRIPTION
Adds the docs team as code owners for documentation changes. This will allow the docs team to approve and merge pull requests independently of the PHP team.