### PR TITLE
PHPORM-99 Enable TTL index to auto-purge of expired cache and lock items

### DIFF
--- a/src/Cache/MongoLock.php
+++ b/src/Cache/MongoLock.php
@@ -4,11 +4,13 @@ namespace MongoDB\Laravel\Cache;
 
 use Illuminate\Cache\Lock;
 use Illuminate\Support\Carbon;
+use InvalidArgumentException;
 use MongoDB\BSON\UTCDateTime;
 use MongoDB\Laravel\Collection;
 use MongoDB\Operation\FindOneAndUpdate;
 use Override;
 
+use function is_numeric;
 use function random_int;
 
 final class MongoLock extends Lock
@@ -29,6 +31,10 @@ final class MongoLock extends Lock
         ?string $owner = null,
         private readonly array $lottery = [2, 100],
     ) {
+        if (! is_numeric($this->lottery[0] ?? null) || ! is_numeric($this->lottery[1] ?? null) || $this->lottery[0] > $this->lottery[1]) {
+            throw new InvalidArgumentException('Lock lottery must be a couple of integers [$chance, $total] where $chance <= $total. Example [2, 100]');
+        }
+
         parent::__construct($name, $seconds, $owner);
     }
 

--- a/src/Cache/MongoStore.php
+++ b/src/Cache/MongoStore.php
@@ -182,12 +182,9 @@ final class MongoStore implements LockProvider, Store
     #[Override]
     public function increment($key, $value = 1): int|float|false
     {
-        $this->forgetIfExpired($key);
-
         $result = $this->collection->findOneAndUpdate(
             [
                 '_id' => $this->prefix . $key,
-                'expiration' => ['$gte' => $this->getUTCDateTime()],
             ],
             [
                 '$inc' => ['value' => $value],

--- a/src/Cache/MongoStore.php
+++ b/src/Cache/MongoStore.php
@@ -34,7 +34,7 @@ final class MongoStore implements LockProvider, Store
      * @param string          $prefix                      Prefix for the name of cache items
      * @param Connection|null $lockConnection              The MongoDB connection to use for the lock, if different from the cache connection
      * @param string          $lockCollectionName          Name of the collection where locks are stored
-     * @param array{int, int} $lockLottery                 Probability [chance, total] of pruning expired cache items
+     * @param array{int, int} $lockLottery                 Probability [chance, total] of pruning expired cache items. Set to [0, 0] to disable
      * @param int             $defaultLockTimeoutInSeconds Time-to-live of the locks in seconds
      */
     public function __construct(
@@ -62,10 +62,9 @@ final class MongoStore implements LockProvider, Store
         return new MongoLock(
             ($this->lockConnection ?? $this->connection)->getCollection($this->lockCollectionName),
             $this->prefix . $name,
-            $seconds,
+            $seconds ?: $this->defaultLockTimeoutInSeconds,
             $owner,
             $this->lockLottery,
-            $this->defaultLockTimeoutInSeconds,
         );
     }
 
@@ -307,7 +306,7 @@ final class MongoStore implements LockProvider, Store
         return unserialize($value);
     }
 
-    protected function getUTCDateTime(int $additionalSeconds = 0): UTCDateTime
+    private function getUTCDateTime(int $additionalSeconds = 0): UTCDateTime
     {
         return new UTCDateTime(Carbon::now()->addSeconds($additionalSeconds));
     }

--- a/tests/Cache/MongoCacheStoreTest.php
+++ b/tests/Cache/MongoCacheStoreTest.php
@@ -236,7 +236,7 @@ class MongoCacheStoreTest extends TestCase
             ->insertOne([
                 '_id' => $this->withCachePrefix($key),
                 'value' => $value,
-                'expiration' => new UTCDateTime(Carbon::now()->addSeconds($ttl)),
+                'expires_at' => new UTCDateTime(Carbon::now()->addSeconds($ttl)),
             ]);
     }
 }

--- a/tests/Cache/MongoCacheStoreTest.php
+++ b/tests/Cache/MongoCacheStoreTest.php
@@ -6,6 +6,7 @@ use Illuminate\Cache\Repository;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
+use MongoDB\BSON\UTCDateTime;
 use MongoDB\Laravel\Tests\TestCase;
 
 use function assert;
@@ -200,7 +201,17 @@ class MongoCacheStoreTest extends TestCase
         $this->assertFalse($store->increment('foo', 5));
     }
 
-    protected function getStore(): Repository
+    public function testTTLIndex()
+    {
+        $store = $this->getStore();
+        $store->createTTLIndex();
+
+        // TTL index remove expired items asynchronously, this test would be very slow
+        $indexes = DB::connection('mongodb')->getCollection($this->getCacheCollectionName())->listIndexes();
+        $this->assertCount(2, $indexes);
+    }
+
+    private function getStore(): Repository
     {
         $repository = Cache::store('mongodb');
         assert($repository instanceof Repository);
@@ -208,24 +219,24 @@ class MongoCacheStoreTest extends TestCase
         return $repository;
     }
 
-    protected function getCacheCollectionName(): string
+    private function getCacheCollectionName(): string
     {
         return config('cache.stores.mongodb.collection');
     }
 
-    protected function withCachePrefix(string $key): string
+    private function withCachePrefix(string $key): string
     {
         return config('cache.prefix') . $key;
     }
 
-    protected function insertToCacheTable(string $key, $value, $ttl = 60)
+    private function insertToCacheTable(string $key, $value, $ttl = 60)
     {
         DB::connection('mongodb')
             ->getCollection($this->getCacheCollectionName())
             ->insertOne([
                 '_id' => $this->withCachePrefix($key),
                 'value' => $value,
-                'expiration' => Carbon::now()->addSeconds($ttl)->getTimestamp(),
+                'expiration' => new UTCDateTime(Carbon::now()->addSeconds($ttl)),
             ]);
     }
 }

--- a/tests/Cache/MongoLockTest.php
+++ b/tests/Cache/MongoLockTest.php
@@ -5,8 +5,11 @@ namespace MongoDB\Laravel\Tests\Cache;
 use Illuminate\Cache\Repository;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
 use MongoDB\Laravel\Cache\MongoLock;
+use MongoDB\Laravel\Collection;
 use MongoDB\Laravel\Tests\TestCase;
+use PHPUnit\Framework\Attributes\TestWith;
 
 use function now;
 
@@ -17,6 +20,23 @@ class MongoLockTest extends TestCase
         DB::connection('mongodb')->getCollection('foo_cache_locks')->drop();
 
         parent::tearDown();
+    }
+
+    #[TestWith([[5, 2]])]
+    #[TestWith([['foo', 10]])]
+    #[TestWith([[10, 'foo']])]
+    #[TestWith([[10]])]
+    public function testInvalidLottery(array $lottery)
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Lock lottery must be a couple of integers');
+
+        new MongoLock(
+            $this->createMock(Collection::class),
+            'cache_lock',
+            10,
+            lottery: $lottery,
+        );
     }
 
     public function testLockCanBeAcquired()

--- a/tests/Cache/MongoLockTest.php
+++ b/tests/Cache/MongoLockTest.php
@@ -3,15 +3,15 @@
 namespace MongoDB\Laravel\Tests\Cache;
 
 use Illuminate\Cache\Repository;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use InvalidArgumentException;
+use MongoDB\BSON\UTCDateTime;
 use MongoDB\Laravel\Cache\MongoLock;
 use MongoDB\Laravel\Collection;
 use MongoDB\Laravel\Tests\TestCase;
 use PHPUnit\Framework\Attributes\TestWith;
-
-use function now;
 
 class MongoLockTest extends TestCase
 {
@@ -73,7 +73,7 @@ class MongoLockTest extends TestCase
     {
         $lock = $this->getCache()->lock('foo');
         $this->assertTrue($lock->get());
-        DB::table('foo_cache_locks')->update(['expires_at' => now()->subDays(1)->getTimestamp()]);
+        DB::table('foo_cache_locks')->update(['expires_at' => new UTCDateTime(Carbon::now('UTC')->subDays(1))]);
 
         $otherLock = $this->getCache()->lock('foo');
         $this->assertTrue($otherLock->get());

--- a/tests/Cache/MongoLockTest.php
+++ b/tests/Cache/MongoLockTest.php
@@ -53,7 +53,7 @@ class MongoLockTest extends TestCase
     {
         $lock = $this->getCache()->lock('foo');
         $this->assertTrue($lock->get());
-        DB::table('foo_cache_locks')->update(['expiration' => now()->subDays(1)->getTimestamp()]);
+        DB::table('foo_cache_locks')->update(['expires_at' => now()->subDays(1)->getTimestamp()]);
 
         $otherLock = $this->getCache()->lock('foo');
         $this->assertTrue($otherLock->get());

--- a/tests/Cache/MongoLockTest.php
+++ b/tests/Cache/MongoLockTest.php
@@ -88,6 +88,15 @@ class MongoLockTest extends TestCase
         $this->assertFalse($resoredLock->isOwnedByCurrentProcess());
     }
 
+    public function testTTLIndex()
+    {
+        $store = $this->getCache()->lock('')->createTTLIndex();
+
+        // TTL index remove expired items asynchronously, this test would be very slow
+        $indexes = DB::connection('mongodb')->getCollection('foo_cache_locks')->listIndexes();
+        $this->assertCount(2, $indexes);
+    }
+
     private function getCache(): Repository
     {
         $repository = Cache::driver('mongodb');


### PR DESCRIPTION
Fix PHPORM-99
Complement to #2877

By using an `UTCDateTime` for the expiration field of cache and lock collections, we can create a [TTL index](https://www.mongodb.com/docs/manual/core/index-ttl/).

```php
// Create TTL index on cache collection
Cache::driver('mongodb')->createTTLIndex();

// Create TTL index on lock collection
Cache::driver('mongodb')->lock('')->createTTLIndex();
```

Once TTL index have been created (using a migration), the `lock_lottery` value can be set to `[0, 0]` in order to disable random pruning of expired locks.

Also, using a `UTCDateTime` is more precise than the int timestamp in seconds. So we can use `updateOne` as [discussed here](https://github.com/mongodb/laravel-mongodb/pull/2877#discussion_r1569031485).

