### PR TITLE
PHPORM-171 Set timestamps when using `createOrFirst`

### DIFF
--- a/src/Eloquent/Builder.php
+++ b/src/Eloquent/Builder.php
@@ -204,6 +204,12 @@ class Builder extends EloquentBuilder
         // Apply casting and default values to the attributes
         // In case of duplicate key between the attributes and the values, the values have priority
         $instance = $this->newModelInstance($values + $attributes);
+
+        /* @see \Illuminate\Database\Eloquent\Model::performInsert */
+        if ($instance->usesTimestamps()) {
+            $instance->updateTimestamps();
+        }
+
         $values = $instance->getAttributes();
         $attributes = array_intersect_key($attributes, $values);
 

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -1048,12 +1048,17 @@ class ModelTest extends TestCase
 
     public function testCreateOrFirst()
     {
+        Carbon::setTestNow('2010-06-22');
+        $createdAt = Carbon::now()->getTimestamp();
         $user1 = User::createOrFirst(['email' => 'john.doe@example.com']);
 
         $this->assertSame('john.doe@example.com', $user1->email);
         $this->assertNull($user1->name);
         $this->assertTrue($user1->wasRecentlyCreated);
+        $this->assertEquals($createdAt, $user1->created_at->getTimestamp());
+        $this->assertEquals($createdAt, $user1->updated_at->getTimestamp());
 
+        Carbon::setTestNow('2020-12-28');
         $user2 = User::createOrFirst(
             ['email' => 'john.doe@example.com'],
             ['name' => 'John Doe', 'birthday' => new DateTime('1987-05-28')],
@@ -1064,6 +1069,8 @@ class ModelTest extends TestCase
         $this->assertNull($user2->name);
         $this->assertNull($user2->birthday);
         $this->assertFalse($user2->wasRecentlyCreated);
+        $this->assertEquals($createdAt, $user1->created_at->getTimestamp());
+        $this->assertEquals($createdAt, $user1->updated_at->getTimestamp());
 
         $user3 = User::createOrFirst(
             ['email' => 'jane.doe@example.com'],
@@ -1075,6 +1082,8 @@ class ModelTest extends TestCase
         $this->assertSame('Jane Doe', $user3->name);
         $this->assertEquals(new DateTime('1987-05-28'), $user3->birthday);
         $this->assertTrue($user3->wasRecentlyCreated);
+        $this->assertEquals($createdAt, $user1->created_at->getTimestamp());
+        $this->assertEquals($createdAt, $user1->updated_at->getTimestamp());
 
         $user4 = User::createOrFirst(
             ['name' => 'Robert Doe'],


### PR DESCRIPTION
Fix PHPORM-171
Issue reported by @nicohell https://github.com/mongodb/laravel-mongodb/issues/2720#issuecomment-2071709454



### Checklist

- [x] Add tests and ensure they pass
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Update documentation for new features
