### PR TITLE
add return type void in FindAndModifyCommandSubscriber.php to avoid deprecation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [4.2.2] - 2024-04-25
+
+* Add return types to `FindAndModifyCommandSubscriber`, used by `firstOrCreate` by @wivaku in [#2913](https://github.com/mongodb/laravel-mongodb/pull/2913)
+
 ## [4.2.1] - 2024-04-25
 
 * Set timestamps when using `Model::createOrFirst()` by @GromNaN in [#2905](https://github.com/mongodb/laravel-mongodb/pull/2905)

--- a/src/Internal/FindAndModifyCommandSubscriber.php
+++ b/src/Internal/FindAndModifyCommandSubscriber.php
@@ -19,15 +19,15 @@ final class FindAndModifyCommandSubscriber implements CommandSubscriber
 {
     public bool $created;
 
-    public function commandFailed(CommandFailedEvent $event)
+    public function commandFailed(CommandFailedEvent $event): void
     {
     }
 
-    public function commandStarted(CommandStartedEvent $event)
+    public function commandStarted(CommandStartedEvent $event): void
     {
     }
 
-    public function commandSucceeded(CommandSucceededEvent $event)
+    public function commandSucceeded(CommandSucceededEvent $event): void
     {
         $this->created = ! $event->getReply()->lastErrorObject->updatedExisting;
     }


### PR DESCRIPTION
Using `$model::firstOrCreate(...)`
currently results in deprecation warnings.  
Can be addressed by adding `void` return type.

Warnings: 
```
   DEPRECATED  Return type of MongoDB\Laravel\Internal\FindAndModifyCommandSubscriber::commandStarted(MongoDB\Driver\Monitoring\CommandStartedEvent $event) should either be compatible with MongoDB\Driver\Monitoring\CommandSubscriber::commandStarted(MongoDB\Driver\Monitoring\CommandStartedEvent $event): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in vendor/mongodb/laravel-mongodb/src/Internal/FindAndModifyCommandSubscriber.php on line 26.


   DEPRECATED  Return type of MongoDB\Laravel\Internal\FindAndModifyCommandSubscriber::commandSucceeded(MongoDB\Driver\Monitoring\CommandSucceededEvent $event) should either be compatible with MongoDB\Driver\Monitoring\CommandSubscriber::commandSucceeded(MongoDB\Driver\Monitoring\CommandSucceededEvent $event): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in vendor/mongodb/laravel-mongodb/src/Internal/FindAndModifyCommandSubscriber.php on line 30.


   DEPRECATED  Return type of MongoDB\Laravel\Internal\FindAndModifyCommandSubscriber::commandFailed(MongoDB\Driver\Monitoring\CommandFailedEvent $event) should either be compatible with MongoDB\Driver\Monitoring\CommandSubscriber::commandFailed(MongoDB\Driver\Monitoring\CommandFailedEvent $event): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in vendor/mongodb/laravel-mongodb/src/Internal/FindAndModifyCommandSubscriber.php on line 22.
```

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.
-->

### Checklist

- [ ] Add tests and ensure they pass
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Update documentation for new features
