### PR TITLE
DOCSP-37770: Return results as JSON

### DIFF
--- a/docs/query-builder.txt
+++ b/docs/query-builder.txt
@@ -74,7 +74,7 @@ To run the code examples in this guide, complete the
 :ref:`Quick Start <laravel-quick-start>` tutorial to configure a web
 application, load sample datasets into your MongoDB deployment, and
 run the example code from a controller method. To see the expected code
-output, follow the instructions in the optional :ref:`View your results as JSON documents
+output, use the ``toJson()`` method shown in the optional :ref:`View your results as JSON documents
 <laravel-quick-start-json>` step of the Quick Start.
 
 To perform read and write operations by using the query builder, import the

--- a/docs/query-builder.txt
+++ b/docs/query-builder.txt
@@ -86,7 +86,7 @@ Retrieve Matching Documents
 ---------------------------
 
 This section includes query builder examples for read operations in the
-following operator categoriess
+following operator categories:
 
 - :ref:`Where method <laravel-query-builder-where-example>`
 - :ref:`Logical conditionals <laravel-query-builder-logical-operations>`

--- a/docs/query-builder.txt
+++ b/docs/query-builder.txt
@@ -73,7 +73,9 @@ Before You Get Started
 To run the code examples in this guide, complete the
 :ref:`Quick Start <laravel-quick-start>` tutorial to configure a web
 application, load sample datasets into your MongoDB deployment, and
-run the example code from a controller method.
+run the example code from a controller method. To see the expected code
+output, follow the instructions in the optional :ref:`View your results as JSON documents
+<laravel-quick-start-json>` step of the Quick Start.
 
 To perform read and write operations by using the query builder, import the
 ``Illuminate\Support\Facades\DB`` facade and compose your query.
@@ -84,7 +86,7 @@ Retrieve Matching Documents
 ---------------------------
 
 This section includes query builder examples for read operations in the
-following operator categories:
+following operator categoriess
 
 - :ref:`Where method <laravel-query-builder-where-example>`
 - :ref:`Logical conditionals <laravel-query-builder-logical-operations>`

--- a/docs/query-builder.txt
+++ b/docs/query-builder.txt
@@ -74,8 +74,9 @@ To run the code examples in this guide, complete the
 :ref:`Quick Start <laravel-quick-start>` tutorial to configure a web
 application, load sample datasets into your MongoDB deployment, and
 run the example code from a controller method. To see the expected code
-output, use the ``toJson()`` method shown in the optional :ref:`View your results as JSON documents
-<laravel-quick-start-json>` step of the Quick Start.
+output as JSON documents, use the ``toJson()`` method shown in the optional
+:ref:`View your results as JSON documents <laravel-quick-start-json>` step
+of the Quick Start.
 
 To perform read and write operations by using the query builder, import the
 ``Illuminate\Support\Facades\DB`` facade and compose your query.

--- a/docs/quick-start/view-data.txt
+++ b/docs/quick-start/view-data.txt
@@ -158,7 +158,7 @@ View MongoDB Data
                  ->get();
 
              foreach ($results as $movie) {
-               echo $movie->toJson() . '<br>\n';
+                 echo $movie->toJson() . '<br>\n';
              }
          }
 

--- a/docs/quick-start/view-data.txt
+++ b/docs/quick-start/view-data.txt
@@ -157,9 +157,7 @@ View MongoDB Data
                  ->take(10)
                  ->get();
 
-             foreach ($results as $movie) {
-                 echo $movie->toJson() . '<br>\n';
-             }
+             return $results->toJson();
          }
 
    .. step:: Start your Laravel application

--- a/docs/quick-start/view-data.txt
+++ b/docs/quick-start/view-data.txt
@@ -136,6 +136,31 @@ View MongoDB Data
 
          </body>
          </html>
+ 
+   .. _laravel-quick-start-json:
+
+   .. step:: Optionally, view your results as JSON documents
+
+      Rather than generating a view and editing the ``browse_movie.blade.php`` file, you can
+      use the ``toJson()`` method to display your results in JSON format.
+      
+      Replace the ``show()`` function with the following code to retrieve results and
+      return them as JSON documents:
+
+      .. code-block:: php
+
+         public function show()
+         {
+             $results = Movie::where('runtime', '<', 60)
+                 ->where('imdb.rating', '>', 8.5)
+                 ->orderBy('imdb.rating', 'desc')
+                 ->take(10)
+                 ->get();
+
+             foreach ($results as $movie) {
+               echo $movie->toJson() . '<br>\n';
+             }
+         }
 
    .. step:: Start your Laravel application
 


### PR DESCRIPTION
<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.
-->
JIRA - https://jira.mongodb.org/browse/DOCSP-37770
Staging - 
https://preview-mongodbnorareidy.gatsbyjs.io/laravel/DOCSP-37770/quick-start/view-data/#optionally--view-your-results-as-json-documents
https://preview-mongodbnorareidy.gatsbyjs.io/laravel/DOCSP-37770/query-builder/#before-you-get-started

Implementing the solution in this JIRA comment:

```
After investigation, the solution could be to add an optional task in the Quick Start to convert the result to JSON instead of HTML.

This section could be linked to by other docs as "To learn how to view the output..."
```
### Checklist

- [ ] Add tests and ensure they pass
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Update documentation for new features
