### PR TITLE
Removed `@mixin Builder` comment from Model.php

### DIFF
--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -49,6 +49,7 @@ use function strcmp;
 use function uniqid;
 use function var_export;
 
+/** @mixin QueryBuilder */
 abstract class Model extends BaseModel
 {
     use HybridRelations;

--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -49,7 +49,6 @@ use function strcmp;
 use function uniqid;
 use function var_export;
 
-/** @mixin Builder */
 abstract class Model extends BaseModel
 {
     use HybridRelations;


### PR DESCRIPTION
Fix for https://github.com/mongodb/laravel-mongodb/issues/2922.

This change https://github.com/mongodb/laravel-mongodb/commit/fdfb5e5027bf46744c28862d042b3063c7d7a782#diff-284e164f76aeb13f424d154f9208d91fdbb0112b0a50ad8b1dfa237176f03cf2 introduced a breaking change for phpstan, it now wrongly infers models as `Illuminate\Database\Eloquent\Model`, instead of it's main class.

Salut @GromNaN!
As the author of that change, is it necessary? Can we go back to what it was?

### Checklist

- [ ] ~~Add tests and ensure they pass~~
- [ ] Add an entry to the CHANGELOG.md file
- [ ] ~~Update documentation for new features~~
