### PR TITLE
PHPORM-82 Support prefix for collection names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## [4.3.0] - unreleased
+## [4.4.0] - unreleased
+
+* Support collection name prefix by @GromNaN in [#2930](https://github.com/mongodb/laravel-mongodb/pull/2930)
+
+## [4.3.0] - 2024-04-26
 
 * New aggregation pipeline builder by @GromNaN in [#2738](https://github.com/mongodb/laravel-mongodb/pull/2738)
 * Drop support for Composer 1.x by @GromNaN in [#2784](https://github.com/mongodb/laravel-mongodb/pull/2784)

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -66,6 +66,8 @@ class Connection extends BaseConnection
         // Select database
         $this->db = $this->connection->selectDatabase($this->getDefaultDatabaseName($dsn, $config));
 
+        $this->tablePrefix = $config['prefix'] ?? '';
+
         $this->useDefaultPostProcessor();
 
         $this->useDefaultSchemaGrammar();
@@ -109,7 +111,7 @@ class Connection extends BaseConnection
      */
     public function getCollection($name)
     {
-        return new Collection($this, $this->db->selectCollection($name));
+        return new Collection($this, $this->db->selectCollection($this->tablePrefix . $name));
     }
 
     /** @inheritdoc */

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -178,6 +178,8 @@ class ConnectionTest extends TestCase
 
         $this->assertSame($expectedUri, (string) $client);
         $this->assertSame($expectedDatabaseName, $connection->getMongoDB()->getDatabaseName());
+        $this->assertSame('foo', $connection->getCollection('foo')->getCollectionName());
+        $this->assertSame('foo', $connection->collection('foo')->raw()->getCollectionName());
     }
 
     public function testConnectionWithoutConfiguredDatabase(): void
@@ -198,6 +200,20 @@ class ConnectionTest extends TestCase
 
         $collection = DB::connection('mongodb')->table('unittests');
         $this->assertInstanceOf(Builder::class, $collection);
+    }
+
+    public function testPrefix()
+    {
+        $config = [
+            'dsn' => 'mongodb://127.0.0.1/',
+            'database' => 'tests',
+            'prefix' => 'prefix_',
+        ];
+
+        $connection = new Connection($config);
+
+        $this->assertSame('prefix_foo', $connection->getCollection('foo')->getCollectionName());
+        $this->assertSame('prefix_foo', $connection->collection('foo')->raw()->getCollectionName());
     }
 
     public function testQueryLog()


### PR DESCRIPTION
Fix PHPORM-82

I'll have to check if that works with relations.

### Checklist

- [x] Add tests and ensure they pass
- [x] Add an entry to the CHANGELOG.md file
- [ ] Update documentation for new features
