### PR TITLE
Implement `Builder::toSql` using JSON representation of the MQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## [4.3.0] - unreleased
+## [4.4.0] - unreleased
+
+* Implement `Builder::toSql` using JSON representation of the MQL by @GromNaN in [#2931](https://github.com/mongodb/laravel-mongodb/pull/2931)
+
+## [4.3.0] - 2024-04-26
 
 * New aggregation pipeline builder by @GromNaN in [#2738](https://github.com/mongodb/laravel-mongodb/pull/2738)
 * Drop support for Composer 1.x by @GromNaN in [#2784](https://github.com/mongodb/laravel-mongodb/pull/2784)

--- a/src/Eloquent/Builder.php
+++ b/src/Eloquent/Builder.php
@@ -55,6 +55,8 @@ class Builder extends EloquentBuilder
         'raw',
         'sum',
         'tomql',
+        'tosql',
+        'torawsql',
     ];
 
     /**

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -18,6 +18,7 @@ use Illuminate\Support\LazyCollection;
 use InvalidArgumentException;
 use LogicException;
 use MongoDB\BSON\Binary;
+use MongoDB\BSON\Document;
 use MongoDB\BSON\ObjectID;
 use MongoDB\BSON\Regex;
 use MongoDB\BSON\UTCDateTime;
@@ -1446,16 +1447,26 @@ class Builder extends BaseBuilder
         return parent::__call($method, $parameters);
     }
 
-    /** @internal This method is not supported by MongoDB. */
+    /**
+     * Return the JSON representation of the MongoDB Query.
+     * Naming is inherited and used for compatibility with third-party packages.
+     *
+     * @internal
+     */
     public function toSql()
     {
-        throw new BadMethodCallException('This method is not supported by MongoDB. Try "toMql()" instead.');
+        return Document::fromPHP($this->toMql())->toCanonicalExtendedJSON();
     }
 
-    /** @internal This method is not supported by MongoDB. */
+    /**
+     * Return the JSON representation of the MongoDB Query.
+     * Naming is inherited and used for compatibility with third-party packages.
+     *
+     * @internal
+     */
     public function toRawSql()
     {
-        throw new BadMethodCallException('This method is not supported by MongoDB. Try "toMql()" instead.');
+        return $this->toSql();
     }
 
     /** @internal This method is not supported by MongoDB. */
@@ -1532,6 +1543,12 @@ class Builder extends BaseBuilder
 
     /** @internal This method is not supported by MongoDB. */
     public function orWhereIntegerNotInRaw($column, $values, $boolean = 'and')
+    {
+        throw new BadMethodCallException('This method is not supported by MongoDB');
+    }
+
+    /** @internal This method is not supported by MongoDB. */
+    public function insertUsing(array $columns, $query)
     {
         throw new BadMethodCallException('This method is not supported by MongoDB');
     }

--- a/tests/Eloquent/CallBuilderTest.php
+++ b/tests/Eloquent/CallBuilderTest.php
@@ -24,34 +24,36 @@ final class CallBuilderTest extends TestCase
     }
 
     #[Dataprovider('provideFunctionNames')]
-    public function testCallingABuilderMethodDoesNotReturnTheBuilderInstance(string $method, string $className, $parameters = []): void
+    public function testCallingABuilderMethodDoesNotReturnTheBuilderInstance(string $method, $parameters = []): void
     {
         $builder = User::query()->newQuery();
         assert($builder instanceof Builder);
 
-        self::assertNotInstanceOf(expected: $className, actual: $builder->{$method}(...$parameters));
+        self::assertNotInstanceOf(Builder::class, $builder->{$method}(...$parameters));
     }
 
     public static function provideFunctionNames(): Generator
     {
-        yield 'does not exist' => ['doesntExist', Builder::class];
-        yield 'get bindings' => ['getBindings', Builder::class];
-        yield 'get connection' => ['getConnection', Builder::class];
-        yield 'get grammar' => ['getGrammar', Builder::class];
-        yield 'insert get id' => ['insertGetId', Builder::class, [['user' => 'foo']]];
-        yield 'to Mql' => ['toMql', Builder::class];
-        yield 'average' => ['average', Builder::class, ['name']];
-        yield 'avg' => ['avg', Builder::class, ['name']];
-        yield 'count' => ['count', Builder::class, ['name']];
-        yield 'exists' => ['exists', Builder::class];
-        yield 'insert' => ['insert', Builder::class, [['name']]];
-        yield 'max' => ['max', Builder::class, ['name']];
-        yield 'min' => ['min', Builder::class, ['name']];
-        yield 'pluck' => ['pluck', Builder::class, ['name']];
-        yield 'pull' => ['pull', Builder::class, ['name']];
-        yield 'push' => ['push', Builder::class, ['name']];
-        yield 'raw' => ['raw', Builder::class];
-        yield 'sum' => ['sum', Builder::class, ['name']];
+        yield 'does not exist' => ['doesntExist'];
+        yield 'get bindings' => ['getBindings'];
+        yield 'get connection' => ['getConnection'];
+        yield 'get grammar' => ['getGrammar'];
+        yield 'insert get id' => ['insertGetId', [['user' => 'foo']]];
+        yield 'to Mql' => ['toMql'];
+        yield 'to Sql' => ['toSql'];
+        yield 'to Raw Sql' => ['toRawSql'];
+        yield 'average' => ['average', ['name']];
+        yield 'avg' => ['avg', ['name']];
+        yield 'count' => ['count', ['name']];
+        yield 'exists' => ['exists'];
+        yield 'insert' => ['insert', [['name']]];
+        yield 'max' => ['max', ['name']];
+        yield 'min' => ['min', ['name']];
+        yield 'pluck' => ['pluck', ['name']];
+        yield 'pull' => ['pull', ['name']];
+        yield 'push' => ['push', ['name']];
+        yield 'raw' => ['raw'];
+        yield 'sum' => ['sum', ['name']];
     }
 
     #[Test]
@@ -79,14 +81,7 @@ final class CallBuilderTest extends TestCase
         yield 'insert using' => [
             'insertUsing',
             BadMethodCallException::class,
-            'This method is not supported by MongoDB. Try "toMql()" instead',
-            [[['name' => 'Jane']], fn (QueryBuilder $builder) => $builder],
-        ];
-
-        yield 'to sql' => [
-            'toSql',
-            BadMethodCallException::class,
-            'This method is not supported by MongoDB. Try "toMql()" instead',
+            'This method is not supported by MongoDB',
             [[['name' => 'Jane']], fn (QueryBuilder $builder) => $builder],
         ];
     }

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -1396,6 +1396,18 @@ class BuilderTest extends TestCase
         ];
     }
 
+    public function testToSql()
+    {
+        $builder = self::getBuilder();
+        $builder
+            ->where('foo', 'bar')
+            ->limit(10);
+
+        $expected = '{ "find" : [ { "foo" : "bar" }, { "limit" : { "$numberInt" : "10" }, "typeMap" : { "root" : "array", "document" : "array" } } ] }';
+        $this->assertSame($expected, $builder->toSql());
+        $this->assertSame($expected, $builder->toRawSql());
+    }
+
     /** @dataProvider getEloquentMethodsNotSupported */
     public function testEloquentMethodsNotSupported(Closure $callback)
     {
@@ -1411,9 +1423,6 @@ class BuilderTest extends TestCase
     {
         // Most of this methods can be implemented using aggregation framework
         // whereInRaw, whereNotInRaw, orWhereInRaw, orWhereNotInRaw, whereBetweenColumns
-
-        yield 'toSql' => [fn (Builder $builder) => $builder->toSql()];
-        yield 'toRawSql' => [fn (Builder $builder) => $builder->toRawSql()];
 
         /** @see DatabaseQueryBuilderTest::testBasicWhereColumn() */
         /** @see DatabaseQueryBuilderTest::testArrayWhereColumn() */


### PR DESCRIPTION
Fix #2797

The method `toSql` is used by third party packages like [`rappasoft/laravel-liveware-tables`](https://github.com/rappasoft/laravel-livewire-tables/blob/2bd477ec1d5b10fede53cfa0cbc8ffbb815b3a74/src/DataTransferObjects/DebuggableData.php#L19). 

### Checklist

- [x] Add tests and ensure they pass
- [x] Add an entry to the CHANGELOG.md file
- [ ] Update documentation for new features
