### PR TITLE
PHPORM-184 Use fixed key for temporary setting nested field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## [4.3.0] - unreleased
+## [4.3.1]
+
+* Fix memory leak when filling nested fields using dot notation by @GromNaN in [#2962](https://github.com/mongodb/laravel-mongodb/pull/2962)
+
+## [4.3.0] - 2024-04-26
 
 * New aggregation pipeline builder by @GromNaN in [#2738](https://github.com/mongodb/laravel-mongodb/pull/2738)
 * Drop support for Composer 1.x by @GromNaN in [#2784](https://github.com/mongodb/laravel-mongodb/pull/2784)

--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -46,7 +46,6 @@ use function sprintf;
 use function str_contains;
 use function str_starts_with;
 use function strcmp;
-use function uniqid;
 use function var_export;
 
 /** @mixin Builder */
@@ -54,6 +53,8 @@ abstract class Model extends BaseModel
 {
     use HybridRelations;
     use EmbedsRelations;
+
+    private const TEMPORARY_KEY = '__LARAVEL_TEMPORARY_KEY__';
 
     /**
      * The collection associated with the model.
@@ -271,12 +272,10 @@ abstract class Model extends BaseModel
         // Support keys in dot notation.
         if (str_contains($key, '.')) {
             // Store to a temporary key, then move data to the actual key
-            $uniqueKey = uniqid($key);
+            parent::setAttribute(self::TEMPORARY_KEY, $value);
 
-            parent::setAttribute($uniqueKey, $value);
-
-            Arr::set($this->attributes, $key, $this->attributes[$uniqueKey] ?? null);
-            unset($this->attributes[$uniqueKey]);
+            Arr::set($this->attributes, $key, $this->attributes[self::TEMPORARY_KEY] ?? null);
+            unset($this->attributes[self::TEMPORARY_KEY]);
 
             return $this;
         }


### PR DESCRIPTION
Fix PHPORM-184
Fix #2959

The memory leak reported in #2959 is caused by the random temporary key used before setting a nested value. There is a cache in [`Illuminate\Suport\Str::studly`](https://github.com/laravel/framework/blob/41409f47a361f691b2cf8bc7668959eb842bd359/src/Illuminate/Support/Str.php#L1514) that inflate for each random key.

Also, `uniqid` is [slow](https://blog.kevingomez.fr/til/2015/07/26/why-is-uniqid-slow/) and not necessary here. The temporary key can be static as there is not risk of conflict/collision.

- The last operation of `parent::setAttribute()` is `$this->attributes[$key] = $value`;
- Then `$this->attributes[$key]` is read and wrote in the nested array;
- Then `$this->attributes[$key]` is unset.

There is no possibility of a code acting on this key in the meantime.

### Checklist

- [x] Add tests and ensure they pass
- [x] Add an entry to the CHANGELOG.md file
- [x] Update documentation for new features
