### PR TITLE
[fix] Prevent exception when connection is closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [4.3.1]
 
 * Fix memory leak when filling nested fields using dot notation by @GromNaN in [#2962](https://github.com/mongodb/laravel-mongodb/pull/2962)
+* Fix PHP error when accessing the connection after disconnect by @SanderMuller in [#2967](https://github.com/mongodb/laravel-mongodb/pull/2967)
 
 ## [4.3.0] - 2024-04-26
 

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -208,7 +208,7 @@ class Connection extends BaseConnection
     /** @inheritdoc */
     public function disconnect()
     {
-        unset($this->connection);
+        $this->connection = null;
     }
 
     /**

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -38,6 +38,22 @@ class ConnectionTest extends TestCase
         $this->assertNotEquals(spl_object_hash($c1), spl_object_hash($c2));
     }
 
+    public function testDisconnectAndCreateNewConnection()
+    {
+        $connection = DB::connection('mongodb');
+        $this->assertInstanceOf(Connection::class, $connection);
+        $client = $connection->getMongoClient();
+        $this->assertInstanceOf(Client::class, $client);
+        $connection->disconnect();
+        $client = $connection->getMongoClient();
+        $this->assertNull($client);
+        DB::purge('mongodb');
+        $connection = DB::connection('mongodb');
+        $this->assertInstanceOf(Connection::class, $connection);
+        $client = $connection->getMongoClient();
+        $this->assertInstanceOf(Client::class, $client);
+    }
+
     public function testDb()
     {
         $connection = DB::connection('mongodb');


### PR DESCRIPTION
When the MongoDB connection disconnects, it currently unsets the connection property altogether. This causes the following exception when trying to use a MongoDB connection afterwards: `Prevent Undefined property: MongoDB\Laravel\Connection::$connection`

This PR sets the connection (client) to `null` instead of using `unset()`.

Unfortunately there doesn't seem to be a reconnector configured by default, otherwise `$connection->reconnect()` could be used, but this has no effect right now. Could be a good next step for someone to implement.

It's possible that this issue only occurs when using Database Transactions (that's my use case. Didn't get any exceptions locally despite long periods of heavy load, but on our Atlas instance it is getting this exception a real lot)

### Checklist

- [x] Add tests and ensure they pass
- [x] Add an entry to the CHANGELOG.md file
- [ ] Update documentation for new features
