### PR TITLE
Unset `_id: null` to let it be autogenerated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [4.4.0] - unreleased
 
 * Support collection name prefix by @GromNaN in [#2930](https://github.com/mongodb/laravel-mongodb/pull/2930)
+* Ignore `_id: null` to let MongoDB generate an `ObjectId` by @GromNaN in [#2969](https://github.com/mongodb/laravel-mongodb/pull/2969)
 * Add `mongodb` driver for Batching by @GromNaN in [#2904](https://github.com/mongodb/laravel-mongodb/pull/2904)
 * Rename queue option `table` to `collection`
 * Replace queue option `expire` with `retry_after`

--- a/src/Eloquent/Builder.php
+++ b/src/Eloquent/Builder.php
@@ -234,8 +234,8 @@ class Builder extends EloquentBuilder
             try {
                 $document = $collection->findOneAndUpdate(
                     $attributes,
-                    // Before MongoDB 5.0, $setOnInsert requires a non-empty document,
-                    // this should not be an issue as $values include the query filter.
+                    // Before MongoDB 5.0, $setOnInsert requires a non-empty document.
+                    // This should not be an issue as $values includes the query filter.
                     ['$setOnInsert' => (object) $values],
                     [
                         'upsert' => true,

--- a/src/Eloquent/Builder.php
+++ b/src/Eloquent/Builder.php
@@ -21,6 +21,7 @@ use function array_merge;
 use function collect;
 use function is_array;
 use function iterator_to_array;
+use function json_encode;
 
 /** @method \MongoDB\Laravel\Query\Builder toBase() */
 class Builder extends EloquentBuilder
@@ -210,8 +211,8 @@ class Builder extends EloquentBuilder
      */
     public function createOrFirst(array $attributes = [], array $values = []): Model
     {
-        if ($attributes === []) {
-            throw new InvalidArgumentException('You must provide attributes to check for duplicates');
+        if ($attributes === [] || $attributes === ['_id' => null]) {
+            throw new InvalidArgumentException('You must provide attributes to check for duplicates. Got ' . json_encode($attributes));
         }
 
         // Apply casting and default values to the attributes
@@ -233,8 +234,8 @@ class Builder extends EloquentBuilder
             try {
                 $document = $collection->findOneAndUpdate(
                     $attributes,
-                    // Before MongoDB 5.0, $setOnInsert requires a non-empty document.
-                    // This should not be an issue as $values includes the query filter.
+                    // Before MongoDB 5.0, $setOnInsert requires a non-empty document,
+                    // this should not be an issue as $values include the query filter.
                     ['$setOnInsert' => (object) $values],
                     [
                         'upsert' => true,

--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -746,6 +746,12 @@ abstract class Model extends BaseModel
      */
     public function save(array $options = [])
     {
+        // SQL databases would use autoincrement the id field if set to null.
+        // Apply the same behavior to MongoDB with _id only, otherwise null would be stored.
+        if (array_key_exists('_id', $this->attributes) && $this->attributes['_id'] === null) {
+            unset($this->attributes['_id']);
+        }
+
         $saved = parent::save($options);
 
         // Clear list of unset fields

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -1151,4 +1151,21 @@ class ModelTest extends TestCase
         $this->assertEquals($createdAt, $checkUser->created_at->getTimestamp());
         $this->assertEquals($updatedAt, $checkUser->updated_at->getTimestamp());
     }
+
+    public function testCreateWithNullId()
+    {
+        $user = User::create(['_id' => null, 'email' => 'foo@bar']);
+        $this->assertNotNull(ObjectId::class, $user->id);
+        $this->assertSame(1, User::count());
+    }
+
+    public function testUpdateOrCreateWithNullId()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('You must provide attributes to check for duplicates');
+        User::updateOrCreate(
+            ['_id' => null],
+            ['email' => 'jane.doe@example.com'],
+        );
+    }
 }


### PR DESCRIPTION
Tentative fix for #2945

### Checklist

- [x] Add tests and ensure they pass
- [x] Add an entry to the CHANGELOG.md file
- [ ] Update documentation for new features
