### PR TITLE
PHPORM-180 Trigger events in Model::createOrFirst

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 * Add `mongodb` driver for Batching by @GromNaN in [#2904](https://github.com/mongodb/laravel-mongodb/pull/2904)
 * Rename queue option `table` to `collection`
 * Replace queue option `expire` with `retry_after`
+* Trigger events in `Model::createOrFirst()` @GromNaN in [#2980](https://github.com/mongodb/laravel-mongodb/pull/2980)
 
 ## [4.3.1]
 


### PR DESCRIPTION
Fix PHPORM-180 
Fix #2935

In order to trigger the same events as Eloquent's `createOrFirst`, the process must be in the `Model` class. So I created a new `saveOrFirst` method that needs to be public to be called by the `Eloquent\Query` class, but I want to keep it internal. I tried to add an option to `Model::save`, but this method returns an boolean and I need the object if found.

### Checklist

- [x] Add tests and ensure they pass
- [x] Add an entry to the CHANGELOG.md file
- [ ] ~Update documentation for new features~
