### PR TITLE
Remove `@mixin` on Model class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 * Fix memory leak when filling nested fields using dot notation by @GromNaN in [#2962](https://github.com/mongodb/laravel-mongodb/pull/2962)
 * Fix PHP error when accessing the connection after disconnect by @SanderMuller in [#2967](https://github.com/mongodb/laravel-mongodb/pull/2967)
 * Improve error message for invalid configuration by @GromNaN in [#2975](https://github.com/mongodb/laravel-mongodb/pull/2975)
+* Remove `@mixin` annotation from `MongoDB\Laravel\Model` class by @GromNaN in [#2981](https://github.com/mongodb/laravel-mongodb/pull/2981)
 
 ## [4.3.0] - 2024-04-26
 

--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -48,7 +48,6 @@ use function str_starts_with;
 use function strcmp;
 use function var_export;
 
-/** @mixin Builder */
 abstract class Model extends BaseModel
 {
     use HybridRelations;


### PR DESCRIPTION
Fix #2923

It seems that `@mixin` is too naive, doesn't support all dynamic methods and doesn't translate return types correctly.

### Checklist

- [ ] Add tests and ensure they pass
- [x] Add an entry to the CHANGELOG.md file
- [ ] Update documentation for new features
