### PR TITLE
Upload code scanning results to correct ref when releasing

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -29,6 +29,11 @@ jobs:
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref }}
 
+      - name: "Get SHA hash of checked out ref"
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          echo CHECKED_OUT_SHA=$(git rev-parse HEAD) >> $GITHUB_ENV
+
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -58,12 +63,21 @@ jobs:
 
       - name: Run PHPStan
         run: ./vendor/bin/phpstan analyse --no-interaction --no-progress --ansi --error-format=sarif > phpstan.sarif
+        continue-on-error: true
 
       - name: "Upload SARIF report"
-        if: always()
+        if: ${{ github.event_name != 'workflow_dispatch' }}
         uses: "github/codeql-action/upload-sarif@v3"
         with:
           sarif_file: phpstan.sarif
+
+      - name: "Upload SARIF report"
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        uses: "github/codeql-action/upload-sarif@v3"
+        with:
+          sarif_file: phpstan.sarif
+          ref: ${{ inputs.ref }}
+          sha: ${{ env.CHECKED_OUT_SHA }}
 
       - name: Save cache PHPStan results
         id: phpstan-cache-save


### PR DESCRIPTION
Same issue as with https://github.com/mongodb/mongo-php-library/pull/1346.

When running the static analysis workflow from the release workflow, the `github.ref` and `github.sha` point to the release branch instead of the release tag. We have to account for this when uploading the sarif. Using `inputs.ref` works, but the `sarif-upload` action also expects a `sha` input when `ref` is given. To account for this, we get the ref for `HEAD` on `workflow_dispatch` events so the code scanning results are correctly attached to the release tag.