### PR TITLE
Add link to filesystems docs

### DIFF
--- a/docs/index.txt
+++ b/docs/index.txt
@@ -23,6 +23,7 @@
    /cache
    /queues
    /transactions
+   /filesystems
    /issues-and-help
    /feature-compatibility
    /compatibility
@@ -73,6 +74,7 @@ see the following content:
 - :ref:`laravel-cache`
 - :ref:`laravel-queues`
 - :ref:`laravel-transactions`
+- :ref:`laravel-filesystems`
 
 Issues & Help
 -------------


### PR DESCRIPTION
Add link in the toc tree and the index page.

Missing from https://github.com/mongodb/laravel-mongodb/pull/2985