### PR TITLE
PHPORM-175: Use foreign key name for MorphTo relationships

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -49,4 +49,8 @@
             <exclude-pattern>docs/**/*.php</exclude-pattern>
         </exclude>
     </rule>
+
+    <rule ref="PSR1.Classes.ClassDeclaration.MultipleClasses">
+        <exclude-pattern>tests/Ticket/*.php</exclude-pattern>
+    </rule>
 </ruleset>

--- a/src/Eloquent/HybridRelations.php
+++ b/src/Eloquent/HybridRelations.php
@@ -226,7 +226,7 @@ trait HybridRelations
                 $this->newQuery(),
                 $this,
                 $id,
-                $ownerKey ?: $this->getKeyName(),
+                $ownerKey,
                 $type,
                 $name,
             );

--- a/src/Relations/MorphTo.php
+++ b/src/Relations/MorphTo.php
@@ -17,7 +17,7 @@ class MorphTo extends EloquentMorphTo
             // or has many relationships, we need to actually query on the primary key
             // of the related models matching on the foreign key that's on a parent.
             $this->query->where(
-                $this->ownerKey,
+                $this->ownerKey ?? $this->getForeignKeyName(),
                 '=',
                 $this->getForeignKeyFrom($this->parent),
             );

--- a/tests/Ticket/GH2783Test.php
+++ b/tests/Ticket/GH2783Test.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace MongoDB\Laravel\Tests\Ticket;
 
+use Illuminate\Database\Eloquent\Relations\MorphOne;
 use MongoDB\Laravel\Eloquent\Model;
 use MongoDB\Laravel\Relations\MorphTo;
 use MongoDB\Laravel\Tests\TestCase;
-use Illuminate\Database\Eloquent\Relations\MorphOne;
 
 /**
  * @see https://github.com/mongodb/laravel-mongodb/issues/2783

--- a/tests/Ticket/GH2783Test.php
+++ b/tests/Ticket/GH2783Test.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Laravel\Tests\Ticket;
+
+use MongoDB\Laravel\Eloquent\Model;
+use MongoDB\Laravel\Relations\MorphTo;
+use Illuminate\Database\Eloquent\Relations\MorphOne;
+
+/**
+ * @see https://github.com/mongodb/laravel-mongodb/issues/2783
+ * @see https://jira.mongodb.org/browse/PHPORM-175
+ */
+class GH2783Test extends TestCase
+{
+    public function testMorphToInfersCustomOwnerKey()
+    {
+        GH2783Image::truncate();
+        GH2783Post::truncate();
+        GH2783User::truncate();
+
+        $post = GH2783Post::create(['text' => 'Lorem ipsum']);
+        $user = GH2783User::create(['username' => 'jsmith']);
+
+        $imageWithPost = GH2783Image::create(['uri' => 'http://example.com/post.png']);
+        $imageWithPost->imageable()->associate($post)->save();
+
+        $imageWithUser = GH2783Image::create(['uri' => 'http://example.com/user.png']);
+        $imageWithUser->imageable()->associate($user)->save();
+
+        $queriedImageWithPost = GH2783Image::with('imageable')->find($imageWithPost->getKey());
+        $this->assertInstanceOf(GH2783Post::class, $queriedImageWithPost->imageable);
+        $this->assertEquals($post->_id, $queriedImageWithPost->imageable->getKey());
+
+        $queriedImageWithUser = GH2783Image::with('imageable')->find($imageWithUser->getKey());
+        $this->assertInstanceOf(GH2783User::class, $queriedImageWithUser->imageable);
+        $this->assertEquals($user->username, $queriedImageWithUser->imageable->getKey());
+    }
+}
+
+class GH2783Image extends Model
+{
+    protected $connection = 'mongodb';
+    protected $fillable = ['uri'];
+
+    public function imageable(): MorphTo
+    {
+        return $this->morphTo(__FUNCTION__, 'imageable_type', 'imageable_id');
+    }
+}
+
+class GH2783Post extends Model
+{
+    protected $connection = 'mongodb';
+    protected $fillable = ['text'];
+
+    public function image(): MorphOne
+    {
+        return $this->morphOne(GH2783Image::class, 'imageable');
+    }
+}
+
+class GH2783User extends Model
+{
+    protected $connection = 'mongodb';
+    protected $fillable = ['username'];
+    protected $primaryKey = 'username';
+
+    public function image(): MorphOne
+    {
+        return $this->morphOne(GH2783Image::class, 'imageable');
+    }
+}

--- a/tests/Ticket/GH2783Test.php
+++ b/tests/Ticket/GH2783Test.php
@@ -6,6 +6,7 @@ namespace MongoDB\Laravel\Tests\Ticket;
 
 use MongoDB\Laravel\Eloquent\Model;
 use MongoDB\Laravel\Relations\MorphTo;
+use MongoDB\Laravel\Tests\TestCase;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
 
 /**


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPORM-175

Incorporates the proposed solution in mongodb/laravel-mongodb#2783 to not default $ownerKey to the current model's key name when constructing a MorphTo in HybridRelations::morphTo().

That change alone caused RelationsTest::testMorph() to fail, since MorphTo::addConstraints() would attempt to use a null ownerKey value. This required an additional change to fall back to the foreign key name when building the constraint.

### Checklist

- [x] Add tests and ensure they pass
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Update documentation for new features
