### PR TITLE
[Bug fix] Fix BelongToMany when using ObjectId in relation

### DIFF
--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -812,7 +812,7 @@ abstract class Model extends BaseModel
      */
     public function is($model)
     {
-        return ! is_null($model) &&
+        return $model !== null &&
             $this->getSerializedKey() === $model->getSerializedKey() &&
             $this->getTable() === $model->getTable() &&
             $this->getConnectionName() === $model->getConnectionName();

--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -775,7 +775,8 @@ abstract class Model extends BaseModel
     /**
      * Get a serialized attribute from the model.
      *
-     * @param  string  $key
+     * @param  string $key
+     *
      * @return mixed
      */
     public function getSerializedAttribute($key)
@@ -807,7 +808,8 @@ abstract class Model extends BaseModel
     /**
      * Determine if two models have the same ID and belong to the same table.
      *
-     * @param  \Illuminate\Database\Eloquent\Model|null  $model
+     * @param  \Illuminate\Database\Eloquent\Model|null $model
+     *
      * @return bool
      */
     public function is($model)

--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -771,4 +771,29 @@ abstract class Model extends BaseModel
 
         return $this;
     }
+
+    /**
+     * Determine if two models have the same ID and belong to the same table.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model|null  $model
+     * @return bool
+     */
+    public function is($model)
+    {
+        $modelKey = $model?->getKey();
+        $currentKey = $this->getKey();
+
+        if ($modelKey instanceof \MongoDB\BSON\ObjectId) {
+            $modelKey = (string) $modelKey;
+        }
+
+        if ($currentKey instanceof \MongoDB\BSON\ObjectId) {
+            $currentKey = (string) $currentKey;
+        }
+
+        return ! is_null($model) &&
+            $currentKey === $modelKey &&
+            $this->getTable() === $model->getTable() &&
+            $this->getConnectionName() === $model->getConnectionName();
+    }
 }

--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -773,6 +773,38 @@ abstract class Model extends BaseModel
     }
 
     /**
+     * Get a serialized attribute from the model.
+     *
+     * @param  string  $key
+     * @return mixed
+     */
+    public function getSerializedAttribute($key)
+    {
+        $value = $this->getAttribute($key);
+
+        // Convert ObjectID to string.
+        if ($value instanceof ObjectID) {
+            return (string) $value;
+        }
+
+        if ($value instanceof Binary) {
+            return (string) $value->getData();
+        }
+
+        return $value;
+    }
+
+    /**
+     * Get the serialized value of the model's primary key.
+     *
+     * @return mixed
+     */
+    public function getSerializedKey()
+    {
+        return $this->getSerializedAttribute($this->getKeyName());
+    }
+
+    /**
      * Determine if two models have the same ID and belong to the same table.
      *
      * @param  \Illuminate\Database\Eloquent\Model|null  $model
@@ -780,19 +812,8 @@ abstract class Model extends BaseModel
      */
     public function is($model)
     {
-        $modelKey = $model?->getKey();
-        $currentKey = $this->getKey();
-
-        if ($modelKey instanceof \MongoDB\BSON\ObjectId) {
-            $modelKey = (string) $modelKey;
-        }
-
-        if ($currentKey instanceof \MongoDB\BSON\ObjectId) {
-            $currentKey = (string) $currentKey;
-        }
-
         return ! is_null($model) &&
-            $currentKey === $modelKey &&
+            $this->getSerializedKey() === $model->getSerializedKey() &&
             $this->getTable() === $model->getTable() &&
             $this->getConnectionName() === $model->getConnectionName();
     }

--- a/src/Relations/BelongsToMany.php
+++ b/src/Relations/BelongsToMany.php
@@ -11,6 +11,8 @@ use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany as EloquentBelongsToMany;
 use Illuminate\Support\Arr;
+use MongoDB\BSON\Binary;
+use MongoDB\BSON\ObjectId;
 
 use function array_diff;
 use function array_map;
@@ -304,7 +306,7 @@ class BelongsToMany extends EloquentBelongsToMany
 
         // Attach the new ids to the parent model.
         if ($this->parent instanceof \MongoDB\Laravel\Eloquent\Model) {
-            if ($id instanceof \MongoDB\BSON\ObjectId) {
+            if ($id instanceof ObjectId) {
                 $id = [$id];
             } else {
                 $id = (array) $id;
@@ -340,7 +342,7 @@ class BelongsToMany extends EloquentBelongsToMany
         // If associated IDs were passed to the method we will only delete those
         // associations, otherwise all of the association ties will be broken.
         // We'll return the numbers of affected rows when we do the deletes.
-        if ($ids instanceof \MongoDB\BSON\ObjectId) {
+        if ($ids instanceof ObjectId) {
             $ids = [$ids];
         } else {
             $ids = (array) $ids;
@@ -388,8 +390,12 @@ class BelongsToMany extends EloquentBelongsToMany
             foreach ($result->$foreign as $item) {
 
                 //Prevent if id is non keyable
-                if ($item instanceof \MongoDB\BSON\ObjectId) {
+                if ($item instanceof ObjectId) {
                     $item = (string) $item;
+                }
+
+                if ($item instanceof Binary) {
+                    $item =  (string) $item->getData();
                 }
 
                 $dictionary[$item][] = $result;

--- a/src/Relations/BelongsToMany.php
+++ b/src/Relations/BelongsToMany.php
@@ -235,7 +235,11 @@ class BelongsToMany extends EloquentBelongsToMany
         // If associated IDs were passed to the method we will only delete those
         // associations, otherwise all of the association ties will be broken.
         // We'll return the numbers of affected rows when we do the deletes.
-        $ids = (array) $ids;
+        if ($ids instanceof \MongoDB\BSON\ObjectId) {
+            $ids = [$ids];
+        } else {
+            $ids = (array) $ids;
+        }
 
         // Detach all ids from the parent model.
         if ($this->parent instanceof \MongoDB\Laravel\Eloquent\Model) {

--- a/src/Relations/BelongsToMany.php
+++ b/src/Relations/BelongsToMany.php
@@ -4,16 +4,16 @@ declare(strict_types=1);
 
 namespace MongoDB\Laravel\Relations;
 
+use BackedEnum;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
+use \Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany as EloquentBelongsToMany;
 use Illuminate\Support\Arr;
 
 use function array_diff;
-use function array_keys;
 use function array_map;
-use function array_merge;
 use function array_values;
 use function assert;
 use function count;
@@ -107,7 +107,108 @@ class BelongsToMany extends EloquentBelongsToMany
         return $instance;
     }
 
-    /** @inheritdoc */
+    /**
+     * Format the sync / toggle record list so that it is keyed by ID.
+     *
+     * @param  array  $records
+     * @return array
+     */
+    protected function formatRecordsList($records): array
+    {
+        //Support for an object type id.
+        //Removal of attribute management because there is no pivot table
+        return collect($records)->map(function ($id) {
+            if ($id instanceof BackedEnum) {
+                $id = $id->value;
+            }
+
+            return $id;
+        })->all();
+    }
+
+    /**
+     * Toggles a model (or models) from the parent.
+     *
+     * Each existing model is detached, and non existing ones are attached.
+     *
+     * @param  mixed  $ids
+     * @param  bool  $touch
+     * @return array
+     */
+    public function toggle($ids, $touch = true)
+    {
+        $changes = [
+            'attached' => [],
+            'detached' => [],
+            'updated' => [],
+        ];
+
+        if ($ids instanceof Collection) {
+            $ids = $this->parseIds($ids);
+        } elseif ($ids instanceof Model) {
+            $ids = $this->parseIds($ids);
+        }
+
+        // First we need to attach any of the associated models that are not currently
+        // in this joining table. We'll spin through the given IDs, checking to see
+        // if they exist in the array of current ones, and if not we will insert.
+        $current = match ($this->parent instanceof \MongoDB\Laravel\Eloquent\Model) {
+            true => $this->parent->{$this->relatedPivotKey} ?: [],
+            false => $this->parent->{$this->relationName} ?: [],
+        };
+
+        // Support Base Collection
+        if ($current instanceof BaseCollection) {
+            $current = $this->parseIds($current);
+        }
+
+        $current = Arr::wrap($current);
+        $records = $this->formatRecordsList($ids);
+
+        $detach = array_values(array_intersect($current, $records));
+
+        if (count($detach) > 0) {
+            $this->detach($detach, false);
+
+            $changes['detached'] = (array) array_map(function ($v) {
+                return is_numeric($v) ? (int) $v : (string) $v;
+            }, $detach);
+        }
+
+        // Finally, for all of the records which were not "detached", we'll attach the
+        // records into the intermediate table. Then, we will add those attaches to
+        // this change list and get ready to return these results to the callers.
+        $attach = array_values(array_diff($records, $current));
+
+        if (count($attach) > 0) {
+            $this->attach($attach, [], false);
+
+            $changes['attached'] = (array) array_map(function ($v) {
+                return $this->castKey($v);
+            }, $attach);
+        }
+
+        // Once we have finished attaching or detaching the records, we will see if we
+        // have done any attaching or detaching, and if we have we will touch these
+        // relationships if they are configured to touch on any database updates.
+        if ($touch && (count($changes['attached']) ||
+                count($changes['detached']))) {
+
+            $this->parent->touch();
+            $this->newRelatedQuery()->whereIn($this->relatedKey, $ids)->touch();
+        }
+
+        return $changes;
+    }
+
+
+    /**
+     * Sync the intermediate tables with a list of IDs or collection of models.
+     *
+     * @param  \Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Model|array  $ids
+     * @param  bool  $detaching
+     * @return array
+     */
     public function sync($ids, $detaching = true)
     {
         $changes = [
@@ -130,25 +231,21 @@ class BelongsToMany extends EloquentBelongsToMany
             false => $this->parent->{$this->relationName} ?: [],
         };
 
-        if ($current instanceof Collection) {
+        // Support Base Collection
+        if ($current instanceof BaseCollection) {
             $current = $this->parseIds($current);
         }
 
+        $current = Arr::wrap($current);
         $records = $this->formatRecordsList($ids);
 
-        $current = Arr::wrap($current);
-
-        $detach = array_diff($current, array_keys($records));
-
-        // We need to make sure we pass a clean array, so that it is not interpreted
-        // as an associative array.
-        $detach = array_values($detach);
+        $detach = array_values(array_diff($current, $records));
 
         // Next, we will take the differences of the currents and given IDs and detach
         // all of the entities that exist in the "current" array but are not in the
         // the array of the IDs given to the method which will complete the sync.
         if ($detaching && count($detach) > 0) {
-            $this->detach($detach);
+            $this->detach($detach, false);
 
             $changes['detached'] = (array) array_map(function ($v) {
                 return is_numeric($v) ? (int) $v : (string) $v;
@@ -158,13 +255,18 @@ class BelongsToMany extends EloquentBelongsToMany
         // Now we are finally ready to attach the new records. Note that we'll disable
         // touching until after the entire operation is complete so we don't fire a
         // ton of touch operations until we are totally done syncing the records.
-        $changes = array_merge(
-            $changes,
-            $this->attachNew($records, $current, false),
-        );
+        foreach ($records as $id) {
+            // Only non strict check if exist no update s possible beacause no attributtes
+            if (!in_array($id, $current)) {
+                $this->attach($id, [], false);
+                $changes['attached'][] = $this->castKey($id);
+            }
+        }
 
-        if (count($changes['attached']) || count($changes['updated'])) {
-            $this->touchIfTouching();
+        if ((count($changes['attached']) || count($changes['detached']))) {
+            $touches = array_merge($detach, $records);
+            $this->parent->touch();
+            $this->newRelatedQuery()->whereIn($this->relatedKey, $touches)->touch();
         }
 
         return $changes;
@@ -207,7 +309,7 @@ class BelongsToMany extends EloquentBelongsToMany
             } else {
                 $id = (array) $id;
             }
-            
+
             $this->parent->push($this->relatedPivotKey, $id, true);
         } else {
             $instance = new $this->related();
@@ -220,13 +322,16 @@ class BelongsToMany extends EloquentBelongsToMany
             return;
         }
 
-        $this->touchIfTouching();
+        $this->parent->touch();
+        $this->newRelatedQuery()->whereIn($this->relatedKey, (array) $id);
     }
 
     /** @inheritdoc */
     public function detach($ids = [], $touch = true)
     {
-        if ($ids instanceof Model) {
+        if ($ids instanceof Collection) {
+            $ids = $this->parseIds($ids);
+        } elseif ($ids instanceof Model) {
             $ids = $this->parseIds($ids);
         }
 
@@ -247,6 +352,7 @@ class BelongsToMany extends EloquentBelongsToMany
         } else {
             $value = $this->parent->{$this->relationName}
                 ->filter(fn ($rel) => ! in_array($rel->{$this->relatedKey}, $ids));
+
             $this->parent->setRelation($this->relationName, $value);
         }
 
@@ -261,7 +367,8 @@ class BelongsToMany extends EloquentBelongsToMany
         $query->pull($this->foreignPivotKey, $this->parent->{$this->parentKey});
 
         if ($touch) {
-            $this->touchIfTouching();
+            $this->parent->touch();
+            $query->touch();
         }
 
         return count($ids);

--- a/src/Relations/BelongsToMany.php
+++ b/src/Relations/BelongsToMany.php
@@ -7,7 +7,7 @@ namespace MongoDB\Laravel\Relations;
 use BackedEnum;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
-use \Illuminate\Support\Collection as BaseCollection;
+use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany as EloquentBelongsToMany;
 use Illuminate\Support\Arr;

--- a/src/Relations/BelongsToMany.php
+++ b/src/Relations/BelongsToMany.php
@@ -202,7 +202,13 @@ class BelongsToMany extends EloquentBelongsToMany
 
         // Attach the new ids to the parent model.
         if ($this->parent instanceof \MongoDB\Laravel\Eloquent\Model) {
-            $this->parent->push($this->relatedPivotKey, (array) $id, true);
+            if ($id instanceof \MongoDB\BSON\ObjectId) {
+                $id = [$id];
+            } else {
+                $id = (array) $id;
+            }
+            
+            $this->parent->push($this->relatedPivotKey, $id, true);
         } else {
             $instance = new $this->related();
             $instance->forceFill([$this->relatedKey => $id]);

--- a/src/Relations/BelongsToMany.php
+++ b/src/Relations/BelongsToMany.php
@@ -7,17 +7,20 @@ namespace MongoDB\Laravel\Relations;
 use BackedEnum;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany as EloquentBelongsToMany;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Collection as BaseCollection;
 use MongoDB\BSON\Binary;
 use MongoDB\BSON\ObjectId;
 
 use function array_diff;
+use function array_intersect;
 use function array_map;
+use function array_merge;
 use function array_values;
 use function assert;
+use function collect;
 use function count;
 use function in_array;
 use function is_numeric;
@@ -112,7 +115,8 @@ class BelongsToMany extends EloquentBelongsToMany
     /**
      * Format the sync / toggle record list so that it is keyed by ID.
      *
-     * @param  array  $records
+     * @param  array $records
+     *
      * @return array
      */
     protected function formatRecordsList($records): array
@@ -133,8 +137,9 @@ class BelongsToMany extends EloquentBelongsToMany
      *
      * Each existing model is detached, and non existing ones are attached.
      *
-     * @param  mixed  $ids
+     * @param  mixed $ids
      * @param  bool  $touch
+     *
      * @return array
      */
     public function toggle($ids, $touch = true)
@@ -193,9 +198,10 @@ class BelongsToMany extends EloquentBelongsToMany
         // Once we have finished attaching or detaching the records, we will see if we
         // have done any attaching or detaching, and if we have we will touch these
         // relationships if they are configured to touch on any database updates.
-        if ($touch && (count($changes['attached']) ||
-                count($changes['detached']))) {
-
+        if (
+            $touch && (count($changes['attached']) ||
+                count($changes['detached']))
+        ) {
             $this->parent->touch();
             $this->newRelatedQuery()->whereIn($this->relatedKey, $ids)->touch();
         }
@@ -203,12 +209,12 @@ class BelongsToMany extends EloquentBelongsToMany
         return $changes;
     }
 
-
     /**
      * Sync the intermediate tables with a list of IDs or collection of models.
      *
-     * @param  \Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Model|array  $ids
-     * @param  bool  $detaching
+     * @param  \Illuminate\Support\Collection|Model|array $ids
+     * @param  bool                                       $detaching
+     *
      * @return array
      */
     public function sync($ids, $detaching = true)
@@ -259,7 +265,7 @@ class BelongsToMany extends EloquentBelongsToMany
         // ton of touch operations until we are totally done syncing the records.
         foreach ($records as $id) {
             // Only non strict check if exist no update s possible beacause no attributtes
-            if (!in_array($id, $current)) {
+            if (! in_array($id, $current)) {
                 $this->attach($id, [], false);
                 $changes['attached'][] = $this->castKey($id);
             }
@@ -388,7 +394,6 @@ class BelongsToMany extends EloquentBelongsToMany
 
         foreach ($results as $result) {
             foreach ($result->$foreign as $item) {
-
                 //Prevent if id is non keyable
                 if ($item instanceof ObjectId) {
                     $item = (string) $item;

--- a/src/Relations/BelongsToMany.php
+++ b/src/Relations/BelongsToMany.php
@@ -386,6 +386,12 @@ class BelongsToMany extends EloquentBelongsToMany
 
         foreach ($results as $result) {
             foreach ($result->$foreign as $item) {
+
+                //Prevent if id is non keyable
+                if ($item instanceof \MongoDB\BSON\ObjectId) {
+                    $item = (string) $item;
+                }
+
                 $dictionary[$item][] = $result;
             }
         }

--- a/tests/Models/PlanetOid.php
+++ b/tests/Models/PlanetOid.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Laravel\Tests\Models;
+
+use MongoDB\Laravel\Eloquent\Model as Eloquent;
+
+class PlanetOid extends Eloquent
+{
+    protected $connection = 'mongodb';
+    protected static $unguarded = true;
+
+    public function getIdAttribute($value = null)
+    {
+        return $value;
+    }
+
+    public function visitors()
+    {
+        return $this->belongsToMany(SpaceExplorerOid::class);
+    }
+}

--- a/tests/Models/SpaceExplorerOid.php
+++ b/tests/Models/SpaceExplorerOid.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Laravel\Tests\Models;
+
+use MongoDB\Laravel\Eloquent\Model as Eloquent;
+
+class SpaceExplorerOid extends Eloquent
+{
+    protected $connection = 'mongodb';
+    protected static $unguarded = true;
+
+    public function getIdAttribute($value = null)
+    {
+        return $value;
+    }
+
+    public function planetsVisited()
+    {
+        return $this->belongsToMany(PlanetOid::class);
+    }
+}

--- a/tests/RelationsTest.php
+++ b/tests/RelationsTest.php
@@ -1338,7 +1338,6 @@ class RelationsTest extends TestCase
         $this->assertCount(2, $explorer->planetsVisited);
         $this->assertCount(2, $planet->visitors);
 
-
         // Detach planets from explorer
         $explorer->planetsVisited()->sync([]);
 


### PR DESCRIPTION
When we use mongodb ObjectIDs for relationships
In the case of a BelongToMany relation, the foreignKeys was incorrectly cast

```json
{
    "_id" : ObjectId("667e831289f74871500d80a7"),
    "name" : "Jean-Luc Picard",
    "updated_at" : ISODate("2024-06-28T09:32:02.401+0000"),
    "created_at" : ISODate("2024-06-28T09:32:02.401+0000"),
    "planetIds" : [
        {
            "oid" : "667e831289f74871500d80a2"
        },
        {
            "oid" : "667e831289f74871500d80a3"
        },
        {
            "oid" : "667e831289f74871500d80a4"
        }
    ]
}
```

With the type check, the cast is adapted to avoid converting an object into an associative array.

```json
{
    "_id" : ObjectId("667e91e6bfeefc593308f745"),
    "name" : "Tanya Kirbuk",
    "updated_at" : ISODate("2024-06-28T10:35:18.459+0000"),
    "created_at" : ISODate("2024-06-28T10:35:18.459+0000"),
    "planetIds" : [
        ObjectId("667e91e6bfeefc593308f742"),
        ObjectId("667e91e6bfeefc593308f743"),
        ObjectId("667e91e6bfeefc593308f744")
    ]
}
```

#3015 

### Checklist

- [x] Add tests and ensure they pass
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Update documentation for new features
