### PR TITLE
fix attributeToArray method

### DIFF
--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -328,12 +328,20 @@ abstract class Model extends BaseModel
         // MongoDB related objects to a string representation. This kind
         // of mimics the SQL behaviour so that dates are formatted
         // nicely when your models are converted to JSON.
-        foreach ($attributes as $key => &$value) {
+        $convertMongoObjects = function (&$value) use (&$convertMongoObjects) {
             if ($value instanceof ObjectID) {
                 $value = (string) $value;
             } elseif ($value instanceof Binary) {
                 $value = (string) $value->getData();
+            } elseif (is_array($value)) {
+                foreach ($value as &$embedValue) {
+                    $convertMongoObjects($embedValue);
+                }
             }
+        };
+
+        foreach ($attributes as $key => &$value) {
+            $convertMongoObjects($value);
         }
 
         return $attributes;

--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -333,6 +333,8 @@ abstract class Model extends BaseModel
                 $value = (string) $value;
             } elseif ($value instanceof Binary) {
                 $value = (string) $value->getData();
+            } elseif ($value instanceof UTCDateTime) {
+                $value = $this->serializeDate($value->toDateTime());
             } elseif (is_array($value)) {
                 foreach ($value as &$embedValue) {
                     $convertMongoObjects($embedValue);

--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -352,6 +352,7 @@ abstract class Model extends BaseModel
     {
         $attributes = parent::attributesToArray();
 
+        // Because the original Eloquent never returns objects, we convert
         // MongoDB related objects to a string representation. This kind
         // of mimics the SQL behaviour so that dates are formatted
         // nicely when your models are converted to JSON.

--- a/tests/EmbeddedRelationsTest.php
+++ b/tests/EmbeddedRelationsTest.php
@@ -953,6 +953,6 @@ class EmbeddedRelationsTest extends TestCase
         $user->addresses()->save(new Address(['city' => 'New York']));
 
         $results = $user->toArray();
-        assertIsString($results['addresses'][0]['_id']);
+        $this->assertIsString($results['addresses'][0]['_id']);
     }
 }

--- a/tests/EmbeddedRelationsTest.php
+++ b/tests/EmbeddedRelationsTest.php
@@ -19,7 +19,6 @@ use MongoDB\Laravel\Tests\Models\Role;
 use MongoDB\Laravel\Tests\Models\User;
 
 use function array_merge;
-use function PHPUnit\Framework\assertIsString;
 
 class EmbeddedRelationsTest extends TestCase
 {
@@ -34,6 +33,7 @@ class EmbeddedRelationsTest extends TestCase
         Client::truncate();
         Group::truncate();
         Photo::truncate();
+        Address::truncate();
     }
 
     public function testEmbedsManySave()
@@ -949,10 +949,13 @@ class EmbeddedRelationsTest extends TestCase
 
     public function testEmbedManySerialization()
     {
-        $user = User::create(['name' => 'John Doe']);
-        $user->addresses()->save(new Address(['city' => 'New York']));
+        $address = new Address(['country' => 'France']);
+        $address->save();
 
-        $results = $user->toArray();
+        $address->addresses()->create(['city' => 'Paris']);
+        $address->addresses()->create(['city' => 'Nice']);
+
+        $results = $address->toArray();
         $this->assertIsString($results['addresses'][0]['_id']);
     }
 }

--- a/tests/EmbeddedRelationsTest.php
+++ b/tests/EmbeddedRelationsTest.php
@@ -19,6 +19,7 @@ use MongoDB\Laravel\Tests\Models\Role;
 use MongoDB\Laravel\Tests\Models\User;
 
 use function array_merge;
+use function PHPUnit\Framework\assertIsString;
 
 class EmbeddedRelationsTest extends TestCase
 {
@@ -944,5 +945,14 @@ class EmbeddedRelationsTest extends TestCase
 
         $this->assertEquals(['father'], $user->getQueueableRelations());
         $this->assertEquals([], $user->father->getQueueableRelations());
+    }
+
+    public function testEmbedManySerialization()
+    {
+        $user = User::create(['name' => 'John Doe']);
+        $user->addresses()->save(new Address(['city' => 'New York']));
+
+        $results = $user->toArray();
+        assertIsString($results['addresses'][0]['_id']);
     }
 }


### PR DESCRIPTION
 - Fix model serialization, when model has embed relation or nested fields.

When dealing with embedded models with relationships (EmbedOne and/or EmbedMany), the serialization methods do not serialize Mongo BSON types in nested fields, as the function only converts top-level attributes.

In the exemple, prices is embedMany Relationship

```php
 public function prices(): EmbedsMany
 {
      return $this->embedsMany(Price::class, 'prices', 'product');
 }
```

Before fix =>

```php
 [
    "_id" => "667be7212ea8e4cc8b0dd636",
    "isActive" => true,
    "name" => "CREDIT_PACKAGE_3",
    "category" => "CREDIT_BALANCE",
    "quantity" => 3.0,
    "prices" => [
      [
        "currency" => "EUR",
        "price" => 5.99,
        "_id" => MongoDB\BSON\ObjectId {#4456
          +"oid": "667be7212ea8e4cc8b0dd634",
        },
      ],
    ],
]
```
After fix =>

```php
 [
    "_id" => "667be7212ea8e4cc8b0dd636",
    "isActive" => true,
    "name" => "CREDIT_PACKAGE_3",
    "category" => "CREDIT_BALANCE",
    "quantity" => 3.0,
    "prices" => [
      [
        "currency" => "EUR",
        "price" => 5.99,
        "_id" => "667be7212ea8e4cc8b0dd634",
      ],
    ],
]
```