### PR TITLE
DOCSP-41305: update compat table for 4.6

### DIFF
--- a/docs/includes/framework-compatibility-laravel.rst
+++ b/docs/includes/framework-compatibility-laravel.rst
@@ -7,7 +7,7 @@
      - Laravel 10.x
      - Laravel 9.x
 
-   * - 4.2 to 4.5
+   * - 4.2 to 4.6
      - ✓
      - ✓
      -


### PR DESCRIPTION
Updates compat table to list 4.6 as the latest version

4.6 branch was renamed to 4.7, so requesting to merge into that.

`docs-laravel` PR: https://github.com/10gen/docs-laravel/pull/112

### Checklist

- [x] Add tests and ensure they pass
- [ ] Add an entry to the CHANGELOG.md file
- [x] Update documentation for new features
