### PR TITLE
PHPORM-147 Make `id` an alias for `_id`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [5.0.0] - next
+
+* **BREAKING CHANGE** Use `id` as an alias for `_id` in commands and queries for compatibility with Eloquent packages by @GromNaN in [#3040](https://github.com/mongodb/laravel-mongodb/pull/3040)
+
 ## [4.8.0] - next
 
 * Add `Query\Builder::incrementEach()` and `decrementEach()` methods by @SmallRuralDog in [#2550](https://github.com/mongodb/laravel-mongodb/pull/2550)

--- a/docs/includes/auth/PersonalAccessToken.php
+++ b/docs/includes/auth/PersonalAccessToken.php
@@ -11,6 +11,5 @@ class PersonalAccessToken extends SanctumToken
 
     protected $connection = 'mongodb';
     protected $table = 'personal_access_tokens';
-    protected $primaryKey = '_id';
     protected $keyType = 'string';
 }

--- a/docs/includes/eloquent-models/PlanetThirdParty.php
+++ b/docs/includes/eloquent-models/PlanetThirdParty.php
@@ -10,6 +10,5 @@ class Planet extends CelestialBody
     use DocumentModel;
 
     protected $fillable = ['name', 'diameter'];
-    protected $primaryKey = '_id';
     protected $keyType = 'string';
 }

--- a/docs/includes/fundamentals/write-operations/WriteOperationsTest.php
+++ b/docs/includes/fundamentals/write-operations/WriteOperationsTest.php
@@ -162,7 +162,7 @@ class WriteOperationsTest extends TestCase
 
         // begin model update one fluent
         $concert = Concert::where(['performer' => 'Brad Mehldau'])
-            ->orderBy('_id')
+            ->orderBy('id')
             ->first()
             ->update(['venue' => 'Manchester Arena', 'ticketsSold' => 9543]);
         // end model update one fluent
@@ -370,7 +370,7 @@ class WriteOperationsTest extends TestCase
 
         $data = [
             [
-                '_id' => 'CH-0401242000',
+                'id' => 'CH-0401242000',
                 'performer' => 'Mitsuko Uchida',
                 'venue' => 'Carnegie Hall',
                 'genres' => ['classical'],
@@ -378,7 +378,7 @@ class WriteOperationsTest extends TestCase
                 'performanceDate' => new UTCDateTime(Carbon::create(2024, 4, 1, 20, 0, 0, 'EST')),
             ],
             [
-                '_id' => 'MSG-0212252000',
+                'id' => 'MSG-0212252000',
                 'performer' => 'Brad Mehldau',
                 'venue' => 'Philharmonie de Paris',
                 'genres' => [ 'jazz', 'post-bop' ],
@@ -386,7 +386,7 @@ class WriteOperationsTest extends TestCase
                 'performanceDate' => new UTCDateTime(Carbon::create(2025, 2, 12, 20, 0, 0, 'CET')),
             ],
             [
-                '_id' => 'MSG-021222000',
+                'id' => 'MSG-021222000',
                 'performer' => 'Billy Joel',
                 'venue' => 'Madison Square Garden',
                 'genres' => [ 'rock', 'soft rock', 'pop rock' ],
@@ -394,7 +394,7 @@ class WriteOperationsTest extends TestCase
                 'performanceDate' => new UTCDateTime(Carbon::create(2025, 2, 12, 20, 0, 0, 'CET')),
             ],
             [
-                '_id' => 'SF-06302000',
+                'id' => 'SF-06302000',
                 'performer' => 'The Rolling Stones',
                 'venue' => 'Soldier Field',
                 'genres' => [ 'rock', 'pop', 'blues' ],
@@ -478,22 +478,22 @@ class WriteOperationsTest extends TestCase
         Concert::truncate();
         $data = [
             [
-                '_id' => 3,
+                'id' => 3,
                 'performer' => 'Mitsuko Uchida',
                 'venue' => 'Carnegie Hall',
             ],
             [
-                '_id' => 5,
+                'id' => 5,
                 'performer' => 'Brad Mehldau',
                 'venue' => 'Philharmonie de Paris',
             ],
             [
-                '_id' => 7,
+                'id' => 7,
                 'performer' => 'Billy Joel',
                 'venue' => 'Madison Square Garden',
             ],
             [
-                '_id' => 9,
+                'id' => 9,
                 'performer' => 'The Rolling Stones',
                 'venue' => 'Soldier Field',
             ],

--- a/docs/includes/usage-examples/DeleteOneTest.php
+++ b/docs/includes/usage-examples/DeleteOneTest.php
@@ -27,7 +27,7 @@ class DeleteOneTest extends TestCase
 
         // begin-delete-one
         $deleted = Movie::where('title', 'Quiz Show')
-            ->orderBy('_id')
+            ->orderBy('id')
             ->limit(1)
             ->delete();
 

--- a/docs/includes/usage-examples/FindManyTest.php
+++ b/docs/includes/usage-examples/FindManyTest.php
@@ -35,7 +35,7 @@ class FindManyTest extends TestCase
 
         // begin-find
         $movies = Movie::where('runtime', '>', 900)
-            ->orderBy('_id')
+            ->orderBy('id')
             ->get();
         // end-find
 

--- a/docs/includes/usage-examples/FindOneTest.php
+++ b/docs/includes/usage-examples/FindOneTest.php
@@ -24,13 +24,13 @@ class FindOneTest extends TestCase
 
         // begin-find-one
         $movie = Movie::where('directors', 'Rob Reiner')
-          ->orderBy('_id')
+          ->orderBy('id')
           ->first();
 
         echo $movie->toJson();
         // end-find-one
 
         $this->assertInstanceOf(Movie::class, $movie);
-        $this->expectOutputRegex('/^{"_id":"[a-z0-9]{24}","title":"The Shawshank Redemption","directors":\["Frank Darabont","Rob Reiner"\]}$/');
+        $this->expectOutputRegex('/^{"_id":"[a-z0-9]{24}","title":"The Shawshank Redemption","directors":\["Frank Darabont","Rob Reiner"\],"id":"[a-z0-9]{24}"}$/');
     }
 }

--- a/docs/includes/usage-examples/InsertOneTest.php
+++ b/docs/includes/usage-examples/InsertOneTest.php
@@ -30,6 +30,6 @@ class InsertOneTest extends TestCase
         // end-insert-one
 
         $this->assertInstanceOf(Movie::class, $movie);
-        $this->expectOutputRegex('/^{"title":"Marriage Story","year":2019,"runtime":136,"updated_at":".{27}","created_at":".{27}","_id":"[a-z0-9]{24}"}$/');
+        $this->expectOutputRegex('/^{"title":"Marriage Story","year":2019,"runtime":136,"updated_at":".{27}","created_at":".{27}","id":"[a-z0-9]{24}"}$/');
     }
 }

--- a/docs/includes/usage-examples/UpdateOneTest.php
+++ b/docs/includes/usage-examples/UpdateOneTest.php
@@ -30,7 +30,7 @@ class UpdateOneTest extends TestCase
 
         // begin-update-one
         $updates = Movie::where('title', 'Carol')
-            ->orderBy('_id')
+            ->orderBy('id')
             ->first()
             ->update([
                 'imdb' => [

--- a/src/Auth/User.php
+++ b/src/Auth/User.php
@@ -11,6 +11,5 @@ class User extends BaseUser
 {
     use DocumentModel;
 
-    protected $primaryKey = '_id';
     protected $keyType = 'string';
 }

--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -17,13 +17,6 @@ abstract class Model extends BaseModel
     use DocumentModel;
 
     /**
-     * The primary key for the model.
-     *
-     * @var string
-     */
-    protected $primaryKey = '_id';
-
-    /**
      * The primary key type.
      *
      * @var string

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -375,7 +375,7 @@ class Builder extends BaseBuilder
 
             // Apply order and limit
             if ($this->orders) {
-                $pipeline[] = ['$sort' => $this->orders];
+                $pipeline[] = ['$sort' => $this->aliasIdForQuery($this->orders)];
             }
 
             if ($this->offset) {
@@ -416,7 +416,7 @@ class Builder extends BaseBuilder
 
         // Normal query
         // Convert select columns to simple projections.
-        $projection = array_fill_keys($columns, true);
+        $projection = $this->aliasIdForQuery(array_fill_keys($columns, true));
 
         // Add custom projections.
         if ($this->projections) {
@@ -431,7 +431,7 @@ class Builder extends BaseBuilder
         }
 
         if ($this->orders) {
-            $options['sort'] = $this->orders;
+            $options['sort'] = $this->aliasIdForQuery($this->orders);
         }
 
         if ($this->offset) {
@@ -506,13 +506,17 @@ class Builder extends BaseBuilder
         if ($returnLazy) {
             return LazyCollection::make(function () use ($result) {
                 foreach ($result as $item) {
-                    yield $item;
+                    yield $this->aliasIdForResult($item);
                 }
             });
         }
 
         if ($result instanceof Cursor) {
             $result = $result->toArray();
+        }
+
+        foreach ($result as &$document) {
+            $document = $this->aliasIdForResult($document);
         }
 
         return new Collection($result);
@@ -593,7 +597,7 @@ class Builder extends BaseBuilder
     /** @inheritdoc */
     public function exists()
     {
-        return $this->first(['_id']) !== null;
+        return $this->first(['id']) !== null;
     }
 
     /** @inheritdoc */
@@ -682,6 +686,18 @@ class Builder extends BaseBuilder
             $values = [$values];
         }
 
+        // Compatibility with Eloquent queries that uses "id" instead of MongoDB's _id
+        foreach ($values as &$document) {
+            if (isset($document['id'])) {
+                if (isset($document['_id']) && $document['_id'] !== $document['id']) {
+                    throw new InvalidArgumentException('Cannot insert document with different "id" and "_id" values');
+                }
+
+                $document['_id'] = $document['id'];
+                unset($document['id']);
+            }
+        }
+
         $options = $this->inheritConnectionOptions();
 
         $result = $this->collection->insertMany($values, $options);
@@ -700,11 +716,10 @@ class Builder extends BaseBuilder
             return null;
         }
 
-        if ($sequence === null || $sequence === '_id') {
-            return $result->getInsertedId();
-        }
-
-        return $values[$sequence];
+        return match ($sequence) {
+            '_id', 'id', null => $result->getInsertedId(),
+            default => $values[$sequence],
+        };
     }
 
     /** @inheritdoc */
@@ -720,7 +735,12 @@ class Builder extends BaseBuilder
             unset($values[$key]);
         }
 
-        $options = $this->inheritConnectionOptions($options);
+        // Since "id" is an alias for "_id", we prevent updating it
+        foreach ($values as $fields) {
+            if (array_key_exists('id', $fields)) {
+                throw new InvalidArgumentException('Cannot update "id" field.');
+            }
+        }
 
         return $this->performUpdate($values, $options);
     }
@@ -819,18 +839,6 @@ class Builder extends BaseBuilder
         }
 
         return $this->incrementEach($decrement, $extra, $options);
-    }
-
-    /** @inheritdoc */
-    public function chunkById($count, callable $callback, $column = '_id', $alias = null)
-    {
-        return parent::chunkById($count, $callback, $column, $alias);
-    }
-
-    /** @inheritdoc */
-    public function forPageAfterId($perPage = 15, $lastId = 0, $column = '_id')
-    {
-        return parent::forPageAfterId($perPage, $lastId, $column);
     }
 
     /** @inheritdoc */
@@ -1048,21 +1056,26 @@ class Builder extends BaseBuilder
     /**
      * Perform an update query.
      *
-     * @param  array $query
-     *
      * @return int
      */
-    protected function performUpdate($query, array $options = [])
+    protected function performUpdate(array $update, array $options = [])
     {
         // Update multiple items by default.
         if (! array_key_exists('multiple', $options)) {
             $options['multiple'] = true;
         }
 
+        // Since "id" is an alias for "_id", we prevent updating it
+        foreach ($update as $operator => $fields) {
+            if (array_key_exists('id', $fields)) {
+                throw new InvalidArgumentException('Cannot update "id" field.');
+            }
+        }
+
         $options = $this->inheritConnectionOptions($options);
 
         $wheres = $this->compileWheres();
-        $result = $this->collection->updateMany($wheres, $query, $options);
+        $result = $this->collection->updateMany($wheres, $update, $options);
         if ($result->isAcknowledged()) {
             return $result->getModifiedCount() ? $result->getModifiedCount() : $result->getUpsertedCount();
         }
@@ -1155,16 +1168,21 @@ class Builder extends BaseBuilder
             // Convert column name to string to use as array key
             if (isset($where['column'])) {
                 $where['column'] = (string) $where['column'];
-            }
 
-            // Convert id's.
-            if (isset($where['column']) && ($where['column'] === '_id' || str_ends_with($where['column'], '._id'))) {
-                if (isset($where['values'])) {
-                    // Multiple values.
-                    $where['values'] = array_map($this->convertKey(...), $where['values']);
-                } elseif (isset($where['value'])) {
-                    // Single value.
-                    $where['value'] = $this->convertKey($where['value']);
+                // Compatibility with Eloquent queries that uses "id" instead of MongoDB's _id
+                if ($where['column'] === 'id') {
+                    $where['column'] = '_id';
+                }
+
+                // Convert id's.
+                if ($where['column'] === '_id' || str_ends_with($where['column'], '._id')) {
+                    if (isset($where['values'])) {
+                        // Multiple values.
+                        $where['values'] = array_map($this->convertKey(...), $where['values']);
+                    } elseif (isset($where['value'])) {
+                        // Single value.
+                        $where['value'] = $this->convertKey($where['value']);
+                    }
                 }
             }
 
@@ -1603,5 +1621,24 @@ class Builder extends BaseBuilder
     public function orWhereIntegerNotInRaw($column, $values, $boolean = 'and')
     {
         throw new BadMethodCallException('This method is not supported by MongoDB');
+    }
+
+    private function aliasIdForQuery(array $values): array
+    {
+        if (isset($values['id'])) {
+            $values['_id'] = $values['id'];
+            unset($values['id']);
+        }
+
+        return $values;
+    }
+
+    private function aliasIdForResult(array $values): array
+    {
+        if (isset($values['_id'])) {
+            $values['id'] = $values['_id'];
+        }
+
+        return $values;
     }
 }

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -516,7 +516,9 @@ class Builder extends BaseBuilder
         }
 
         foreach ($result as &$document) {
-            $document = $this->aliasIdForResult($document);
+            if (is_array($document)) {
+                $document = $this->aliasIdForResult($document);
+            }
         }
 
         return new Collection($result);
@@ -709,6 +711,8 @@ class Builder extends BaseBuilder
     public function insertGetId(array $values, $sequence = null)
     {
         $options = $this->inheritConnectionOptions();
+
+        $values = $this->aliasIdForQuery($values);
 
         $result = $this->collection->insertOne($values, $options);
 

--- a/src/Relations/EmbedsMany.php
+++ b/src/Relations/EmbedsMany.php
@@ -46,9 +46,9 @@ class EmbedsMany extends EmbedsOneOrMany
      */
     public function performInsert(Model $model)
     {
-        // Generate a new key if needed.
-        if ($model->getKeyName() === '_id' && ! $model->getKey()) {
-            $model->setAttribute('_id', new ObjectID());
+        // Create a new key if needed.
+        if (($model->getKeyName() === '_id' || $model->getKeyName() === 'id') && ! $model->getKey()) {
+            $model->setAttribute($model->getKeyName(), new ObjectID());
         }
 
         // For deeply nested documents, let the parent handle the changes.
@@ -249,8 +249,8 @@ class EmbedsMany extends EmbedsOneOrMany
     protected function associateNew($model)
     {
         // Create a new key if needed.
-        if ($model->getKeyName() === '_id' && ! $model->getAttribute('_id')) {
-            $model->setAttribute('_id', new ObjectID());
+        if (($model->getKeyName() === '_id' || $model->getKeyName() === 'id') && ! $model->getKey()) {
+            $model->setAttribute($model->getKeyName(), new ObjectID());
         }
 
         $records = $this->getEmbedded();

--- a/src/Relations/EmbedsOne.php
+++ b/src/Relations/EmbedsOne.php
@@ -42,9 +42,9 @@ class EmbedsOne extends EmbedsOneOrMany
      */
     public function performInsert(Model $model)
     {
-        // Generate a new key if needed.
-        if ($model->getKeyName() === '_id' && ! $model->getKey()) {
-            $model->setAttribute('_id', new ObjectID());
+        // Create a new key if needed.
+        if (($model->getKeyName() === '_id' || $model->getKeyName() === 'id') && ! $model->getKey()) {
+            $model->setAttribute($model->getKeyName(), new ObjectID());
         }
 
         // For deeply nested documents, let the parent handle the changes.

--- a/tests/AuthTest.php
+++ b/tests/AuthTest.php
@@ -52,7 +52,7 @@ class AuthTest extends TestCase
             $broker->sendResetLink(
                 ['email' => 'john.doe@example.com'],
                 function ($actualUser, $actualToken) use ($user, &$token) {
-                    $this->assertEquals($user->_id, $actualUser->_id);
+                    $this->assertEquals($user->id, $actualUser->id);
                     // Store token for later use
                     $token = $actualToken;
                 },

--- a/tests/EmbeddedRelationsTest.php
+++ b/tests/EmbeddedRelationsTest.php
@@ -48,15 +48,15 @@ class EmbeddedRelationsTest extends TestCase
         $this->assertEquals(['London'], $user->addresses->pluck('city')->all());
         $this->assertInstanceOf(DateTime::class, $address->created_at);
         $this->assertInstanceOf(DateTime::class, $address->updated_at);
-        $this->assertNotNull($address->_id);
-        $this->assertIsString($address->_id);
+        $this->assertNotNull($address->id);
+        $this->assertIsString($address->id);
 
         $raw = $address->getAttributes();
-        $this->assertInstanceOf(ObjectId::class, $raw['_id']);
+        $this->assertInstanceOf(ObjectId::class, $raw['id']);
 
         $address = $user->addresses()->save(new Address(['city' => 'Paris']));
 
-        $user = User::find($user->_id);
+        $user = User::find($user->id);
         $this->assertEquals(['London', 'Paris'], $user->addresses->pluck('city')->all());
 
         $address->setEventDispatcher($events = Mockery::mock(Dispatcher::class));
@@ -82,7 +82,7 @@ class EmbeddedRelationsTest extends TestCase
         $this->assertEquals(2, $user->addresses()->count());
         $this->assertEquals(['London', 'New York'], $user->addresses->pluck('city')->all());
 
-        $freshUser = User::find($user->_id);
+        $freshUser = User::find($user->id);
         $this->assertEquals(['London', 'New York'], $freshUser->addresses->pluck('city')->all());
 
         $address = $user->addresses->first();
@@ -92,7 +92,7 @@ class EmbeddedRelationsTest extends TestCase
         $this->assertInstanceOf(User::class, $address->user);
         $this->assertEmpty($address->relationsToArray()); // prevent infinite loop
 
-        $user = User::find($user->_id);
+        $user = User::find($user->id);
         $user->addresses()->save(new Address(['city' => 'Bruxelles']));
         $this->assertEquals(['London', 'New York', 'Bruxelles'], $user->addresses->pluck('city')->all());
 
@@ -101,7 +101,7 @@ class EmbeddedRelationsTest extends TestCase
         $user->addresses()->save($address);
         $this->assertEquals(['London', 'Manhattan', 'Bruxelles'], $user->addresses->pluck('city')->all());
 
-        $freshUser = User::find($user->_id);
+        $freshUser = User::find($user->id);
         $this->assertEquals(['London', 'Manhattan', 'Bruxelles'], $freshUser->addresses->pluck('city')->all());
     }
 
@@ -122,16 +122,16 @@ class EmbeddedRelationsTest extends TestCase
 
         $user->addresses()->associate($address);
         $this->assertEquals(['London'], $user->addresses->pluck('city')->all());
-        $this->assertNotNull($address->_id);
+        $this->assertNotNull($address->id);
 
-        $freshUser = User::find($user->_id);
+        $freshUser = User::find($user->id);
         $this->assertEquals([], $freshUser->addresses->pluck('city')->all());
 
         $address->city = 'Londinium';
         $user->addresses()->associate($address);
         $this->assertEquals(['Londinium'], $user->addresses->pluck('city')->all());
 
-        $freshUser = User::find($user->_id);
+        $freshUser = User::find($user->id);
         $this->assertEquals([], $freshUser->addresses->pluck('city')->all());
     }
 
@@ -162,7 +162,7 @@ class EmbeddedRelationsTest extends TestCase
         $this->assertEquals(1, $user->addresses->count());
         $this->assertEquals(['Paris'], $user->addresses->pluck('city')->all());
 
-        $user->addresses()->create(['_id' => $address->_id, 'city' => 'Bruxelles']);
+        $user->addresses()->create(['id' => $address->id, 'city' => 'Bruxelles']);
         $this->assertEquals(1, $user->addresses->count());
         $this->assertEquals(['Bruxelles'], $user->addresses->pluck('city')->all());
     }
@@ -172,21 +172,21 @@ class EmbeddedRelationsTest extends TestCase
         $user    = User::create([]);
         $address = $user->addresses()->create(['city' => 'Bruxelles']);
         $this->assertInstanceOf(Address::class, $address);
-        $this->assertIsString($address->_id);
+        $this->assertIsString($address->id);
         $this->assertEquals(['Bruxelles'], $user->addresses->pluck('city')->all());
 
         $raw = $address->getAttributes();
-        $this->assertInstanceOf(ObjectId::class, $raw['_id']);
+        $this->assertInstanceOf(ObjectId::class, $raw['id']);
 
         $freshUser = User::find($user->id);
         $this->assertEquals(['Bruxelles'], $freshUser->addresses->pluck('city')->all());
 
         $user    = User::create([]);
-        $address = $user->addresses()->create(['_id' => '', 'city' => 'Bruxelles']);
-        $this->assertIsString($address->_id);
+        $address = $user->addresses()->create(['id' => '', 'city' => 'Bruxelles']);
+        $this->assertIsString($address->id);
 
         $raw = $address->getAttributes();
-        $this->assertInstanceOf(ObjectId::class, $raw['_id']);
+        $this->assertInstanceOf(ObjectId::class, $raw['id']);
     }
 
     public function testEmbedsManyCreateMany()
@@ -222,7 +222,7 @@ class EmbeddedRelationsTest extends TestCase
             ->once()
             ->with('eloquent.deleted: ' . $address::class, Mockery::type(Address::class));
 
-        $user->addresses()->destroy($address->_id);
+        $user->addresses()->destroy($address->id);
         $this->assertEquals(['Bristol', 'Bruxelles'], $user->addresses->pluck('city')->all());
 
         $address->unsetEventDispatcher();
@@ -237,7 +237,7 @@ class EmbeddedRelationsTest extends TestCase
         $freshUser = User::find($user->id);
         $this->assertEquals(['Bruxelles', 'Paris', 'San Francisco'], $freshUser->addresses->pluck('city')->all());
 
-        $ids = $user->addresses->pluck('_id');
+        $ids = $user->addresses->pluck('id');
         $user->addresses()->destroy($ids);
         $this->assertEquals([], $user->addresses->pluck('city')->all());
 
@@ -414,13 +414,13 @@ class EmbeddedRelationsTest extends TestCase
         $address1 = $user->addresses()->save(new Address(['city' => 'New York']));
         $address2 = $user->addresses()->save(new Address(['city' => 'Paris']));
 
-        $address = $user->addresses()->find($address1->_id);
+        $address = $user->addresses()->find($address1->id);
         $this->assertEquals($address->city, $address1->city);
 
-        $address = $user->addresses()->find($address2->_id);
+        $address = $user->addresses()->find($address2->id);
         $this->assertEquals($address->city, $address2->city);
 
-        $this->assertTrue($user->addresses()->contains($address2->_id));
+        $this->assertTrue($user->addresses()->contains($address2->id));
         $this->assertFalse($user->addresses()->contains('123'));
     }
 
@@ -552,11 +552,11 @@ class EmbeddedRelationsTest extends TestCase
         $this->assertEquals('Mark Doe', $user->father->name);
         $this->assertInstanceOf(DateTime::class, $father->created_at);
         $this->assertInstanceOf(DateTime::class, $father->updated_at);
-        $this->assertNotNull($father->_id);
-        $this->assertIsString($father->_id);
+        $this->assertNotNull($father->id);
+        $this->assertIsString($father->id);
 
         $raw = $father->getAttributes();
-        $this->assertInstanceOf(ObjectId::class, $raw['_id']);
+        $this->assertInstanceOf(ObjectId::class, $raw['id']);
 
         $father->setEventDispatcher($events = Mockery::mock(Dispatcher::class));
         $events->shouldReceive('dispatch')->with('eloquent.retrieved: ' . $father::class, Mockery::any());

--- a/tests/HybridRelationsTest.php
+++ b/tests/HybridRelationsTest.php
@@ -83,7 +83,7 @@ class HybridRelationsTest extends TestCase
         // MongoDB has many
         $book = new SqlBook(['title' => 'Game of Thrones']);
         $user->sqlBooks()->save($book);
-        $user = User::find($user->_id); // refetch
+        $user = User::find($user->id); // refetch
         $this->assertCount(1, $user->sqlBooks);
 
         // SQL belongs to
@@ -93,7 +93,7 @@ class HybridRelationsTest extends TestCase
         // MongoDB has one
         $role = new SqlRole(['type' => 'admin']);
         $user->sqlRole()->save($role);
-        $user = User::find($user->_id); // refetch
+        $user = User::find($user->id); // refetch
         $this->assertEquals('admin', $user->sqlRole->type);
 
         // SQL belongs to
@@ -239,16 +239,16 @@ class HybridRelationsTest extends TestCase
 
         // sync (pivot is empty)
         $skill->sqlUsers()->sync([$user->id, $user2->id]);
-        $check = Skill::query()->find($skill->_id);
+        $check = Skill::query()->find($skill->id);
         $this->assertEquals(2, $check->sqlUsers->count());
 
         // sync (pivot is not empty)
         $skill->sqlUsers()->sync($user);
-        $check = Skill::query()->find($skill->_id);
+        $check = Skill::query()->find($skill->id);
         $this->assertEquals(1, $check->sqlUsers->count());
 
         // Inverse sync (pivot is empty)
-        $user->skills()->sync([$skill->_id, $skill2->_id]);
+        $user->skills()->sync([$skill->id, $skill2->id]);
         $check = SqlUser::find($user->id);
         $this->assertEquals(2, $check->skills->count());
 
@@ -288,7 +288,7 @@ class HybridRelationsTest extends TestCase
         $label2 = Label::query()->create(['name' => 'MongoDB']);
 
         // MorphToMany (pivot is empty)
-        $user->labels()->sync([$label->_id, $label2->_id]);
+        $user->labels()->sync([$label->id, $label2->id]);
         $check = SqlUser::query()->find($user->id);
         $this->assertEquals(2, $check->labels->count());
 
@@ -308,12 +308,12 @@ class HybridRelationsTest extends TestCase
 
         // Inverse MorphToMany (pivot is empty)
         $label->sqlUsers()->sync([$user->id, $user2->id]);
-        $check = Label::query()->find($label->_id);
+        $check = Label::query()->find($label->id);
         $this->assertEquals(2, $check->sqlUsers->count());
 
         // Inverse MorphToMany (pivot is empty)
         $label->sqlUsers()->sync([$user->id, $user2->id]);
-        $check = Label::query()->find($label->_id);
+        $check = Label::query()->find($label->id);
         $this->assertEquals(2, $check->sqlUsers->count());
     }
 
@@ -340,21 +340,21 @@ class HybridRelationsTest extends TestCase
 
         // MorphToMany (pivot is empty)
         $experience->sqlUsers()->sync([$user->id, $user2->id]);
-        $check = Experience::query()->find($experience->_id);
+        $check = Experience::query()->find($experience->id);
         $this->assertEquals(2, $check->sqlUsers->count());
 
         // MorphToMany (pivot is not empty)
         $experience->sqlUsers()->sync([$user->id]);
-        $check = Experience::query()->find($experience->_id);
+        $check = Experience::query()->find($experience->id);
         $this->assertEquals(1, $check->sqlUsers->count());
 
         // Inverse MorphToMany (pivot is empty)
-        $user->experiences()->sync([$experience->_id, $experience2->_id]);
+        $user->experiences()->sync([$experience->id, $experience2->id]);
         $check = SqlUser::query()->find($user->id);
         $this->assertEquals(2, $check->experiences->count());
 
         // Inverse MorphToMany (pivot is not empty)
-        $user->experiences()->sync([$experience->_id]);
+        $user->experiences()->sync([$experience->id]);
         $check = SqlUser::query()->find($user->id);
         $this->assertEquals(1, $check->experiences->count());
 

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -63,7 +63,7 @@ class ModelTest extends TestCase
         $this->assertInstanceOf(Connection::class, $user->getConnection());
         $this->assertFalse($user->exists);
         $this->assertEquals('users', $user->getTable());
-        $this->assertEquals('_id', $user->getKeyName());
+        $this->assertEquals('id', $user->getKeyName());
     }
 
     public function testQualifyColumn(): void
@@ -89,14 +89,14 @@ class ModelTest extends TestCase
         $this->assertTrue($user->exists);
         $this->assertEquals(1, User::count());
 
-        $this->assertTrue(isset($user->_id));
-        $this->assertIsString($user->_id);
-        $this->assertNotEquals('', (string) $user->_id);
-        $this->assertNotEquals(0, strlen((string) $user->_id));
+        $this->assertTrue(isset($user->id));
+        $this->assertIsString($user->id);
+        $this->assertNotEquals('', (string) $user->id);
+        $this->assertNotEquals(0, strlen((string) $user->id));
         $this->assertInstanceOf(Carbon::class, $user->created_at);
 
         $raw = $user->getAttributes();
-        $this->assertInstanceOf(ObjectID::class, $raw['_id']);
+        $this->assertInstanceOf(ObjectID::class, $raw['id']);
 
         $this->assertEquals('John Doe', $user->name);
         $this->assertEquals(35, $user->age);
@@ -111,9 +111,9 @@ class ModelTest extends TestCase
         $user->save();
 
         $raw = $user->getAttributes();
-        $this->assertInstanceOf(ObjectID::class, $raw['_id']);
+        $this->assertInstanceOf(ObjectID::class, $raw['id']);
 
-        $check = User::find($user->_id);
+        $check = User::find($user->id);
         $this->assertInstanceOf(User::class, $check);
         $check->age = 36;
         $check->save();
@@ -129,16 +129,16 @@ class ModelTest extends TestCase
         $user->update(['age' => 20]);
 
         $raw = $user->getAttributes();
-        $this->assertInstanceOf(ObjectID::class, $raw['_id']);
+        $this->assertInstanceOf(ObjectID::class, $raw['id']);
 
-        $check = User::find($user->_id);
+        $check = User::find($user->id);
         $this->assertEquals(20, $check->age);
 
         $check->age      = 24;
         $check->fullname = 'Hans Thomas'; // new field
         $check->save();
 
-        $check = User::find($user->_id);
+        $check = User::find($user->id);
         $this->assertEquals(24, $check->age);
         $this->assertEquals('Hans Thomas', $check->fullname);
     }
@@ -180,46 +180,46 @@ class ModelTest extends TestCase
     public function testManualStringId(): void
     {
         $user        = new User();
-        $user->_id   = '4af9f23d8ead0e1d32000000';
+        $user->id   = '4af9f23d8ead0e1d32000000';
         $user->name  = 'John Doe';
         $user->title = 'admin';
         $user->age   = 35;
         $user->save();
 
         $this->assertTrue($user->exists);
-        $this->assertEquals('4af9f23d8ead0e1d32000000', $user->_id);
+        $this->assertEquals('4af9f23d8ead0e1d32000000', $user->id);
 
         $raw = $user->getAttributes();
-        $this->assertInstanceOf(ObjectID::class, $raw['_id']);
+        $this->assertInstanceOf(ObjectID::class, $raw['id']);
 
         $user        = new User();
-        $user->_id   = 'customId';
+        $user->id   = 'customId';
         $user->name  = 'John Doe';
         $user->title = 'admin';
         $user->age   = 35;
         $user->save();
 
         $this->assertTrue($user->exists);
-        $this->assertEquals('customId', $user->_id);
+        $this->assertEquals('customId', $user->id);
 
         $raw = $user->getAttributes();
-        $this->assertIsString($raw['_id']);
+        $this->assertIsString($raw['id']);
     }
 
     public function testManualIntId(): void
     {
         $user        = new User();
-        $user->_id   = 1;
+        $user->id   = 1;
         $user->name  = 'John Doe';
         $user->title = 'admin';
         $user->age   = 35;
         $user->save();
 
         $this->assertTrue($user->exists);
-        $this->assertEquals(1, $user->_id);
+        $this->assertEquals(1, $user->id);
 
         $raw = $user->getAttributes();
-        $this->assertIsInt($raw['_id']);
+        $this->assertIsInt($raw['id']);
     }
 
     public function testDelete(): void
@@ -267,11 +267,11 @@ class ModelTest extends TestCase
         $user->age   = 35;
         $user->save();
 
-        $check = User::find($user->_id);
+        $check = User::find($user->id);
         $this->assertInstanceOf(User::class, $check);
         $this->assertTrue(Model::isDocumentModel($check));
         $this->assertTrue($check->exists);
-        $this->assertEquals($user->_id, $check->_id);
+        $this->assertEquals($user->id, $check->id);
 
         $this->assertEquals('John Doe', $check->name);
         $this->assertEquals(35, $check->age);
@@ -339,7 +339,7 @@ class ModelTest extends TestCase
 
         $check = User::where('name', 'Jane Poe')->first();
         $this->assertInstanceOf(User::class, $check);
-        $this->assertEquals($user->_id, $check->_id);
+        $this->assertEquals($user->id, $check->id);
     }
 
     public function testDestroy(): void
@@ -350,7 +350,7 @@ class ModelTest extends TestCase
         $user->age   = 35;
         $user->save();
 
-        User::destroy((string) $user->_id);
+        User::destroy((string) $user->id);
 
         $this->assertEquals(0, User::count());
     }
@@ -367,7 +367,7 @@ class ModelTest extends TestCase
         sleep(1);
         $user->touch();
 
-        $check = User::find($user->_id);
+        $check = User::find($user->id);
         $this->assertInstanceOf(User::class, $check);
 
         $this->assertNotEquals($old, $check->updated_at);
@@ -412,12 +412,12 @@ class ModelTest extends TestCase
         $expectedType = get_debug_type($expected);
 
         $document = new $model();
-        $this->assertEquals('_id', $document->getKeyName());
+        $this->assertEquals('id', $document->getKeyName());
 
-        $document->_id = $id;
+        $document->id = $id;
         $document->save();
-        $this->assertSame($expectedType, get_debug_type($document->_id));
-        $this->assertEquals($expected, $document->_id);
+        $this->assertSame($expectedType, get_debug_type($document->id));
+        $this->assertEquals($expected, $document->id);
         $this->assertSame($expectedType, get_debug_type($document->getKey()));
         $this->assertEquals($expected, $document->getKey());
 
@@ -425,8 +425,8 @@ class ModelTest extends TestCase
 
         if ($expectedFound) {
             $this->assertNotNull($check, 'Not found');
-            $this->assertSame($expectedType, get_debug_type($check->_id));
-            $this->assertEquals($id, $check->_id);
+            $this->assertSame($expectedType, get_debug_type($check->id));
+            $this->assertEquals($id, $check->id);
             $this->assertSame($expectedType, get_debug_type($check->getKey()));
             $this->assertEquals($id, $check->getKey());
         } else {
@@ -534,10 +534,10 @@ class ModelTest extends TestCase
         $array = $item->toArray();
         $keys  = array_keys($array);
         sort($keys);
-        $this->assertEquals(['_id', 'created_at', 'name', 'type', 'updated_at'], $keys);
+        $this->assertEquals(['created_at', 'id', 'name', 'type', 'updated_at'], $keys);
         $this->assertIsString($array['created_at']);
         $this->assertIsString($array['updated_at']);
-        $this->assertIsString($array['_id']);
+        $this->assertIsString($array['id']);
     }
 
     public function testUnset(): void
@@ -559,8 +559,8 @@ class ModelTest extends TestCase
         $this->assertTrue(isset($user2->note2));
 
         // Re-fetch to be sure
-        $user1 = User::find($user1->_id);
-        $user2 = User::find($user2->_id);
+        $user1 = User::find($user1->id);
+        $user2 = User::find($user2->id);
 
         $this->assertFalse(isset($user1->note1));
         $this->assertTrue(isset($user1->note2));
@@ -574,7 +574,7 @@ class ModelTest extends TestCase
         $this->assertFalse(isset($user2->note2));
 
         // Re-re-fetch to be sure
-        $user2 = User::find($user2->_id);
+        $user2 = User::find($user2->id);
 
         $this->assertFalse(isset($user2->note1));
         $this->assertFalse(isset($user2->note2));
@@ -622,14 +622,14 @@ class ModelTest extends TestCase
         $this->assertSame(['note1' => 'GHI'], $user->getDirty());
 
         // Fetch to be sure the changes are not persisted yet
-        $userCheck = User::find($user->_id);
+        $userCheck = User::find($user->id);
         $this->assertSame('ABC', $userCheck['note1']);
 
         // Persist the changes
         $user->save();
 
         // Re-fetch to be sure
-        $user = User::find($user->_id);
+        $user = User::find($user->id);
 
         $this->assertTrue(isset($user->note1));
         $this->assertSame('GHI', $user->note1);
@@ -656,7 +656,7 @@ class ModelTest extends TestCase
         $this->assertTrue(isset($user->notes['note2']));
 
         // Re-fetch to be sure
-        $user = User::find($user->_id);
+        $user = User::find($user->id);
 
         $this->assertFalse(isset($user->notes['note1']));
         $this->assertTrue(isset($user->notes['note2']));
@@ -673,7 +673,7 @@ class ModelTest extends TestCase
         $this->assertFalse(isset($user->notes));
 
         // Re-fetch to be sure
-        $user = User::find($user->_id);
+        $user = User::find($user->id);
 
         $this->assertFalse(isset($user->notes));
     }
@@ -705,7 +705,7 @@ class ModelTest extends TestCase
         $this->assertSame(['note2' => 'DEF', 'note1' => 'ABC'], $user->notes);
 
         // Re-fetch to be sure
-        $user = User::find($user->_id);
+        $user = User::find($user->id);
 
         $this->assertSame(['note2' => 'DEF', 'note1' => 'ABC'], $user->notes);
     }
@@ -722,14 +722,14 @@ class ModelTest extends TestCase
         $this->assertEquals($tz, $user->birthday->getTimezone()->getName());
         $user->save();
 
-        $user = User::find($user->_id);
+        $user = User::find($user->id);
         $this->assertEquals($date, $user->birthday);
         $this->assertEquals($tz, $user->birthday->getTimezone()->getName());
         $this->assertSame('1965-03-02T15:30:10+10:00', $user->birthday->format(DATE_ATOM));
 
         $tz = 'America/New_York';
         date_default_timezone_set($tz);
-        $user = User::find($user->_id);
+        $user = User::find($user->id);
         $this->assertEquals($date, $user->birthday);
         $this->assertEquals($tz, $user->birthday->getTimezone()->getName());
         $this->assertSame('1965-03-02T00:30:10-05:00', $user->birthday->format(DATE_ATOM));
@@ -748,7 +748,7 @@ class ModelTest extends TestCase
         $user = User::create(['name' => 'John Doe', 'birthday' => new DateTime('1980/1/1')]);
         $this->assertInstanceOf(Carbon::class, $user->birthday);
 
-        $check = User::find($user->_id);
+        $check = User::find($user->id);
         $this->assertInstanceOf(Carbon::class, $check->birthday);
         $this->assertEquals($user->birthday, $check->birthday);
 
@@ -833,7 +833,7 @@ class ModelTest extends TestCase
         $user->save();
 
         // Re-fetch to be sure
-        $user = User::find($user->_id);
+        $user = User::find($user->id);
         $this->assertNull($user->birthday);
 
         // Nested field with dot notation
@@ -845,7 +845,7 @@ class ModelTest extends TestCase
         $this->assertNull($user->getAttribute('entry.date'));
 
         // Re-fetch to be sure
-        $user = User::find($user->_id);
+        $user = User::find($user->id);
         $this->assertNull($user->getAttribute('entry.date'));
     }
 
@@ -863,10 +863,10 @@ class ModelTest extends TestCase
     {
         $user = User::create(['name' => 'John Doe']);
         $this->assertInstanceOf(User::class, $user);
-        $this->assertEquals($user->id, $user->_id);
+        $this->assertSame($user->id, $user->_id);
 
         $user = User::create(['id' => 'custom_id', 'name' => 'John Doe']);
-        $this->assertNotEquals($user->id, $user->_id);
+        $this->assertSame($user->id, $user->_id);
     }
 
     public function testPushPull(): void
@@ -879,20 +879,20 @@ class ModelTest extends TestCase
         $user->push('tags', 'tag2', true);
 
         $this->assertEquals(['tag1', 'tag1', 'tag2'], $user->tags);
-        $user = User::where('_id', $user->_id)->first();
+        $user = User::where('id', $user->id)->first();
         $this->assertEquals(['tag1', 'tag1', 'tag2'], $user->tags);
 
         $user->pull('tags', 'tag1');
 
         $this->assertEquals(['tag2'], $user->tags);
-        $user = User::where('_id', $user->_id)->first();
+        $user = User::where('id', $user->id)->first();
         $this->assertEquals(['tag2'], $user->tags);
 
         $user->push('tags', 'tag3');
         $user->pull('tags', ['tag2', 'tag3']);
 
         $this->assertEquals([], $user->tags);
-        $user = User::where('_id', $user->_id)->first();
+        $user = User::where('id', $user->id)->first();
         $this->assertEquals([], $user->tags);
     }
 
@@ -1048,7 +1048,7 @@ class ModelTest extends TestCase
 
         $check = User::where('name', $name)->first();
         $this->assertInstanceOf(User::class, $check);
-        $this->assertEquals($user->_id, $check->_id);
+        $this->assertEquals($user->id, $check->id);
     }
 
     public function testEnumCast(): void
@@ -1163,6 +1163,7 @@ class ModelTest extends TestCase
     }
 
     #[TestWith([['_id' => new ObjectID()]])]
+    #[TestWith([['id' => new ObjectID()]])]
     #[TestWith([['foo' => 'bar']])]
     public function testUpdateOrCreate(array $criteria)
     {
@@ -1215,9 +1216,11 @@ class ModelTest extends TestCase
         $this->assertEquals($updatedAt, $checkUser->updated_at->getTimestamp());
     }
 
-    public function testCreateWithNullId()
+    #[TestWith(['_id'])]
+    #[TestWith(['id'])]
+    public function testCreateWithNullId(string $id)
     {
-        $user = User::create(['_id' => null, 'email' => 'foo@bar']);
+        $user = User::create([$id => null, 'email' => 'foo@bar']);
         $this->assertNotNull(ObjectId::class, $user->id);
         $this->assertSame(1, User::count());
     }

--- a/tests/Models/Address.php
+++ b/tests/Models/Address.php
@@ -12,7 +12,6 @@ class Address extends Model
 {
     use DocumentModel;
 
-    protected $primaryKey = '_id';
     protected $keyType = 'string';
     protected $connection = 'mongodb';
     protected static $unguarded = true;

--- a/tests/Models/Birthday.php
+++ b/tests/Models/Birthday.php
@@ -16,7 +16,6 @@ class Birthday extends Model
 {
     use DocumentModel;
 
-    protected $primaryKey = '_id';
     protected $keyType = 'string';
     protected $connection = 'mongodb';
     protected $table = 'birthday';

--- a/tests/Models/Client.php
+++ b/tests/Models/Client.php
@@ -14,7 +14,6 @@ class Client extends Model
 {
     use DocumentModel;
 
-    protected $primaryKey = '_id';
     protected $keyType = 'string';
     protected $connection = 'mongodb';
     protected $table = 'clients';

--- a/tests/Models/Experience.php
+++ b/tests/Models/Experience.php
@@ -12,7 +12,6 @@ class Experience extends Model
 {
     use DocumentModel;
 
-    protected $primaryKey = '_id';
     protected $keyType = 'string';
     protected $connection = 'mongodb';
     protected $table = 'experiences';

--- a/tests/Models/Group.php
+++ b/tests/Models/Group.php
@@ -12,7 +12,6 @@ class Group extends Model
 {
     use DocumentModel;
 
-    protected $primaryKey = '_id';
     protected $keyType = 'string';
     protected $connection = 'mongodb';
     protected $table = 'groups';
@@ -20,6 +19,6 @@ class Group extends Model
 
     public function users(): BelongsToMany
     {
-        return $this->belongsToMany(User::class, 'users', 'groups', 'users', '_id', '_id', 'users');
+        return $this->belongsToMany(User::class, 'users', 'groups', 'users', 'id', 'id', 'users');
     }
 }

--- a/tests/Models/Guarded.php
+++ b/tests/Models/Guarded.php
@@ -11,7 +11,6 @@ class Guarded extends Model
 {
     use DocumentModel;
 
-    protected $primaryKey = '_id';
     protected $keyType = 'string';
     protected $connection = 'mongodb';
     protected $table = 'guarded';

--- a/tests/Models/HiddenAnimal.php
+++ b/tests/Models/HiddenAnimal.php
@@ -22,7 +22,6 @@ final class HiddenAnimal extends Model
 {
     use DocumentModel;
 
-    protected $primaryKey = '_id';
     protected $keyType = 'string';
     protected $fillable = [
         'name',

--- a/tests/Models/IdIsBinaryUuid.php
+++ b/tests/Models/IdIsBinaryUuid.php
@@ -12,11 +12,10 @@ class IdIsBinaryUuid extends Model
 {
     use DocumentModel;
 
-    protected $primaryKey = '_id';
     protected $keyType = 'string';
     protected $connection = 'mongodb';
     protected static $unguarded = true;
     protected $casts = [
-        '_id' => BinaryUuid::class,
+        'id' => BinaryUuid::class,
     ];
 }

--- a/tests/Models/IdIsInt.php
+++ b/tests/Models/IdIsInt.php
@@ -11,9 +11,8 @@ class IdIsInt extends Model
 {
     use DocumentModel;
 
-    protected $primaryKey = '_id';
     protected $keyType = 'int';
     protected $connection = 'mongodb';
     protected static $unguarded = true;
-    protected $casts = ['_id' => 'int'];
+    protected $casts = ['id' => 'int'];
 }

--- a/tests/Models/IdIsString.php
+++ b/tests/Models/IdIsString.php
@@ -11,9 +11,8 @@ class IdIsString extends Model
 {
     use DocumentModel;
 
-    protected $primaryKey = '_id';
     protected $keyType = 'string';
     protected $connection = 'mongodb';
     protected static $unguarded = true;
-    protected $casts = ['_id' => 'string'];
+    protected $casts = ['id' => 'string'];
 }

--- a/tests/Models/Item.php
+++ b/tests/Models/Item.php
@@ -15,7 +15,6 @@ class Item extends Model
 {
     use DocumentModel;
 
-    protected $primaryKey = '_id';
     protected $keyType = 'string';
     protected $connection = 'mongodb';
     protected $table = 'items';

--- a/tests/Models/Label.php
+++ b/tests/Models/Label.php
@@ -17,7 +17,6 @@ class Label extends Model
 {
     use DocumentModel;
 
-    protected $primaryKey = '_id';
     protected $keyType = 'string';
     protected $connection = 'mongodb';
     protected $table = 'labels';

--- a/tests/Models/Location.php
+++ b/tests/Models/Location.php
@@ -11,7 +11,6 @@ class Location extends Model
 {
     use DocumentModel;
 
-    protected $primaryKey = '_id';
     protected $keyType = 'string';
     protected $connection = 'mongodb';
     protected $table = 'locations';

--- a/tests/Models/Photo.php
+++ b/tests/Models/Photo.php
@@ -12,7 +12,6 @@ class Photo extends Model
 {
     use DocumentModel;
 
-    protected $primaryKey = '_id';
     protected $keyType = 'string';
     protected $connection = 'mongodb';
     protected $table = 'photos';

--- a/tests/Models/Role.php
+++ b/tests/Models/Role.php
@@ -12,7 +12,6 @@ class Role extends Model
 {
     use DocumentModel;
 
-    protected $primaryKey = '_id';
     protected $keyType = 'string';
     protected $connection = 'mongodb';
     protected $table = 'roles';

--- a/tests/Models/Scoped.php
+++ b/tests/Models/Scoped.php
@@ -12,7 +12,6 @@ class Scoped extends Model
 {
     use DocumentModel;
 
-    protected $primaryKey = '_id';
     protected $keyType = 'string';
     protected $connection = 'mongodb';
     protected $table = 'scoped';

--- a/tests/Models/Skill.php
+++ b/tests/Models/Skill.php
@@ -12,7 +12,6 @@ class Skill extends Model
 {
     use DocumentModel;
 
-    protected $primaryKey = '_id';
     protected $keyType = 'string';
     protected $connection = 'mongodb';
     protected $table = 'skills';

--- a/tests/Models/Soft.php
+++ b/tests/Models/Soft.php
@@ -18,7 +18,6 @@ class Soft extends Model
     use SoftDeletes;
     use MassPrunable;
 
-    protected $primaryKey = '_id';
     protected $keyType = 'string';
     protected $connection = 'mongodb';
     protected $table = 'soft';

--- a/tests/Models/User.php
+++ b/tests/Models/User.php
@@ -19,7 +19,7 @@ use MongoDB\Laravel\Eloquent\DocumentModel;
 use MongoDB\Laravel\Eloquent\MassPrunable;
 
 /**
- * @property string $_id
+ * @property string $id
  * @property string $name
  * @property string $email
  * @property string $title
@@ -38,7 +38,6 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
     use Notifiable;
     use MassPrunable;
 
-    protected $primaryKey = '_id';
     protected $keyType = 'string';
     protected $connection = 'mongodb';
     protected $casts = [
@@ -100,7 +99,7 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
 
     public function groups()
     {
-        return $this->belongsToMany(Group::class, 'groups', 'users', 'groups', '_id', '_id', 'groups');
+        return $this->belongsToMany(Group::class, 'groups', 'users', 'groups', 'id', 'id', 'groups');
     }
 
     public function photos()

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -124,7 +124,6 @@ class BuilderTest extends TestCase
         ];
 
         // Nested array are not flattened like in the Eloquent builder. MongoDB can compare objects.
-        // When id is used as data field name, it's not converted to _id
         $array = [['issue' => 45582], ['id' => 2], [3]];
         yield 'whereIn nested array' => [
             ['find' => [['_id' => ['$in' => $array]], []]],

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -124,9 +124,10 @@ class BuilderTest extends TestCase
         ];
 
         // Nested array are not flattened like in the Eloquent builder. MongoDB can compare objects.
+        // When id is used as data field name, it's not converted to _id
         $array = [['issue' => 45582], ['id' => 2], [3]];
         yield 'whereIn nested array' => [
-            ['find' => [['id' => ['$in' => $array]], []]],
+            ['find' => [['_id' => ['$in' => $array]], []]],
             fn (Builder $builder) => $builder->whereIn('id', $array),
         ];
 
@@ -135,21 +136,21 @@ class BuilderTest extends TestCase
                 'find' => [
                     [
                         '$or' => [
-                            ['id' => 1],
-                            ['id' => ['$in' => [1, 2, 3]]],
+                            ['foo' => 1],
+                            ['foo' => ['$in' => [1, 2, 3]]],
                         ],
                     ],
                     [], // options
                 ],
             ],
-            fn (Builder $builder) => $builder->where('id', '=', 1)
-                ->orWhereIn('id', [1, 2, 3]),
+            fn (Builder $builder) => $builder->where('foo', '=', 1)
+                ->orWhereIn('foo', [1, 2, 3]),
         ];
 
         /** @see DatabaseQueryBuilderTest::testBasicWhereNotIns */
         yield 'whereNotIn' => [
-            ['find' => [['id' => ['$nin' => [1, 2, 3]]], []]],
-            fn (Builder $builder) => $builder->whereNotIn('id', [1, 2, 3]),
+            ['find' => [['foo' => ['$nin' => [1, 2, 3]]], []]],
+            fn (Builder $builder) => $builder->whereNotIn('foo', [1, 2, 3]),
         ];
 
         yield 'orWhereNotIn' => [
@@ -157,20 +158,20 @@ class BuilderTest extends TestCase
                 'find' => [
                     [
                         '$or' => [
-                            ['id' => 1],
-                            ['id' => ['$nin' => [1, 2, 3]]],
+                            ['foo' => 1],
+                            ['foo' => ['$nin' => [1, 2, 3]]],
                         ],
                     ],
                     [], // options
                 ],
             ],
-            fn (Builder $builder) => $builder->where('id', '=', 1)
-                ->orWhereNotIn('id', [1, 2, 3]),
+            fn (Builder $builder) => $builder->where('foo', '=', 1)
+                ->orWhereNotIn('foo', [1, 2, 3]),
         ];
 
         /** @see DatabaseQueryBuilderTest::testEmptyWhereIns */
         yield 'whereIn empty array' => [
-            ['find' => [['id' => ['$in' => []]], []]],
+            ['find' => [['_id' => ['$in' => []]], []]],
             fn (Builder $builder) => $builder->whereIn('id', []),
         ];
 
@@ -220,7 +221,7 @@ class BuilderTest extends TestCase
                 'find' => [
                     [
                         '$or' => [
-                            ['id' => 1],
+                            ['age' => 1],
                             ['email' => 'foo'],
                         ],
                     ],
@@ -228,7 +229,7 @@ class BuilderTest extends TestCase
                 ],
             ],
             fn (Builder $builder) => $builder
-                ->where('id', '=', 1)
+                ->where('age', '=', 1)
                 ->orWhere('email', '=', 'foo'),
         ];
 
@@ -497,6 +498,11 @@ class BuilderTest extends TestCase
                 ->orderBy('age', 'desc'),
         ];
 
+        yield 'orders by id field' => [
+            ['find' => [[], ['sort' => ['_id' => 1]]]],
+            fn (Builder $builder) => $builder->orderBy('id'),
+        ];
+
         yield 'orders = null' => [
             ['find' => [[], []]],
             function (Builder $builder) {
@@ -553,12 +559,12 @@ class BuilderTest extends TestCase
 
         /** @see DatabaseQueryBuilderTest::testWhereBetweens() */
         yield 'whereBetween array of numbers' => [
-            ['find' => [['id' => ['$gte' => 1, '$lte' => 2]], []]],
+            ['find' => [['_id' => ['$gte' => 1, '$lte' => 2]], []]],
             fn (Builder $builder) => $builder->whereBetween('id', [1, 2]),
         ];
 
         yield 'whereBetween nested array of numbers' => [
-            ['find' => [['id' => ['$gte' => [1], '$lte' => [2, 3]]], []]],
+            ['find' => [['_id' => ['$gte' => [1], '$lte' => [2, 3]]], []]],
             fn (Builder $builder) => $builder->whereBetween('id', [[1], [2, 3]]),
         ];
 
@@ -579,7 +585,7 @@ class BuilderTest extends TestCase
         ];
 
         yield 'whereBetween collection' => [
-            ['find' => [['id' => ['$gte' => 1, '$lte' => 2]], []]],
+            ['find' => [['_id' => ['$gte' => 1, '$lte' => 2]], []]],
             fn (Builder $builder) => $builder->whereBetween('id', collect([1, 2])),
         ];
 
@@ -589,16 +595,16 @@ class BuilderTest extends TestCase
                 'find' => [
                     [
                         '$or' => [
-                            ['id' => 1],
-                            ['id' => ['$gte' => 3, '$lte' => 5]],
+                            ['age' => 1],
+                            ['age' => ['$gte' => 3, '$lte' => 5]],
                         ],
                     ],
                     [], // options
                 ],
             ],
             fn (Builder $builder) => $builder
-                ->where('id', '=', 1)
-                ->orWhereBetween('id', [3, 5]),
+                ->where('age', '=', 1)
+                ->orWhereBetween('age', [3, 5]),
         ];
 
         /** @link https://www.mongodb.com/docs/manual/reference/bson-type-comparison-order/#arrays */
@@ -607,16 +613,16 @@ class BuilderTest extends TestCase
                 'find' => [
                     [
                         '$or' => [
-                            ['id' => 1],
-                            ['id' => ['$gte' => [4], '$lte' => [6, 8]]],
+                            ['age' => 1],
+                            ['age' => ['$gte' => [4], '$lte' => [6, 8]]],
                         ],
                     ],
                     [], // options
                 ],
             ],
             fn (Builder $builder) => $builder
-                ->where('id', '=', 1)
-                ->orWhereBetween('id', [[4], [6, 8]]),
+                ->where('age', '=', 1)
+                ->orWhereBetween('age', [[4], [6, 8]]),
         ];
 
         yield 'orWhereBetween collection' => [
@@ -624,16 +630,16 @@ class BuilderTest extends TestCase
                 'find' => [
                     [
                         '$or' => [
-                            ['id' => 1],
-                            ['id' => ['$gte' => 3, '$lte' => 4]],
+                            ['age' => 1],
+                            ['age' => ['$gte' => 3, '$lte' => 4]],
                         ],
                     ],
                     [], // options
                 ],
             ],
             fn (Builder $builder) => $builder
-                ->where('id', '=', 1)
-                ->orWhereBetween('id', collect([3, 4])),
+                ->where('age', '=', 1)
+                ->orWhereBetween('age', collect([3, 4])),
         ];
 
         yield 'whereNotBetween array of numbers' => [
@@ -641,14 +647,14 @@ class BuilderTest extends TestCase
                 'find' => [
                     [
                         '$or' => [
-                            ['id' => ['$lte' => 1]],
-                            ['id' => ['$gte' => 2]],
+                            ['age' => ['$lte' => 1]],
+                            ['age' => ['$gte' => 2]],
                         ],
                     ],
                     [], // options
                 ],
             ],
-            fn (Builder $builder) => $builder->whereNotBetween('id', [1, 2]),
+            fn (Builder $builder) => $builder->whereNotBetween('age', [1, 2]),
         ];
 
         /** @see DatabaseQueryBuilderTest::testOrWhereNotBetween() */
@@ -657,11 +663,11 @@ class BuilderTest extends TestCase
                 'find' => [
                     [
                         '$or' => [
-                            ['id' => 1],
+                            ['age' => 1],
                             [
                                 '$or' => [
-                                    ['id' => ['$lte' => 3]],
-                                    ['id' => ['$gte' => 5]],
+                                    ['age' => ['$lte' => 3]],
+                                    ['age' => ['$gte' => 5]],
                                 ],
                             ],
                         ],
@@ -670,8 +676,8 @@ class BuilderTest extends TestCase
                 ],
             ],
             fn (Builder $builder) => $builder
-                ->where('id', '=', 1)
-                ->orWhereNotBetween('id', [3, 5]),
+                ->where('age', '=', 1)
+                ->orWhereNotBetween('age', [3, 5]),
         ];
 
         yield 'orWhereNotBetween nested array of numbers' => [
@@ -679,11 +685,11 @@ class BuilderTest extends TestCase
                 'find' => [
                     [
                         '$or' => [
-                            ['id' => 1],
+                            ['age' => 1],
                             [
                                 '$or' => [
-                                    ['id' => ['$lte' => [2, 3]]],
-                                    ['id' => ['$gte' => [5]]],
+                                    ['age' => ['$lte' => [2, 3]]],
+                                    ['age' => ['$gte' => [5]]],
                                 ],
                             ],
                         ],
@@ -692,8 +698,8 @@ class BuilderTest extends TestCase
                 ],
             ],
             fn (Builder $builder) => $builder
-                ->where('id', '=', 1)
-                ->orWhereNotBetween('id', [[2, 3], [5]]),
+                ->where('age', '=', 1)
+                ->orWhereNotBetween('age', [[2, 3], [5]]),
         ];
 
         yield 'orWhereNotBetween collection' => [
@@ -701,11 +707,11 @@ class BuilderTest extends TestCase
                 'find' => [
                     [
                         '$or' => [
-                            ['id' => 1],
+                            ['age' => 1],
                             [
                                 '$or' => [
-                                    ['id' => ['$lte' => 3]],
-                                    ['id' => ['$gte' => 4]],
+                                    ['age' => ['$lte' => 3]],
+                                    ['age' => ['$gte' => 4]],
                                 ],
                             ],
                         ],
@@ -714,8 +720,8 @@ class BuilderTest extends TestCase
                 ],
             ],
             fn (Builder $builder) => $builder
-                ->where('id', '=', 1)
-                ->orWhereNotBetween('id', collect([3, 4])),
+                ->where('age', '=', 1)
+                ->orWhereNotBetween('age', collect([3, 4])),
         ];
 
         yield 'where like' => [
@@ -1158,6 +1164,21 @@ class BuilderTest extends TestCase
                     $elemMatchQuery->where([ 'search_by' => 'by search', 'value' => 'foo' ]);
                 },
             ),
+        ];
+
+        yield 'id alias for _id' => [
+            ['find' => [['_id' => 1], []]],
+            fn (Builder $builder) => $builder->where('id', 1),
+        ];
+
+        yield 'id alias for _id with $or' => [
+            ['find' => [['$or' => [['_id' => 1], ['_id' => 2]]], []]],
+            fn (Builder $builder) => $builder->where('id', 1)->orWhere('id', 2),
+        ];
+
+        yield 'select colums with id alias' => [
+            ['find' => [[], ['projection' => ['name' => 1, 'email' => 1, '_id' => 1]]]],
+            fn (Builder $builder) => $builder->select('name', 'email', 'id'),
         ];
 
         // Method added in Laravel v10.47.0

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -124,10 +124,9 @@ class BuilderTest extends TestCase
         ];
 
         // Nested array are not flattened like in the Eloquent builder. MongoDB can compare objects.
-        $array = [['issue' => 45582], ['id' => 2], [3]];
         yield 'whereIn nested array' => [
-            ['find' => [['_id' => ['$in' => $array]], []]],
-            fn (Builder $builder) => $builder->whereIn('id', $array),
+            ['find' => [['_id' => ['$in' => [['issue' => 45582], ['_id' => 2], [3]]]], []]],
+            fn (Builder $builder) => $builder->whereIn('id', [['issue' => 45582], ['id' => 2], [3]]),
         ];
 
         yield 'orWhereIn' => [

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -1058,7 +1058,7 @@ class QueryBuilderTest extends TestCase
         DB::collection('items')->insert([$insertId => 'abc', 'name' => 'Karting']);
         $item = DB::collection('items')->where($queryId, '=', 'abc')->first();
         $this->assertNotNull($item);
-        $this->assertSame('abc', $item['_id']);
+        $this->assertSame('abc', $item['id']);
         $this->assertSame('Karting', $item['name']);
 
         DB::collection('items')->where($insertId, '=', 'abc')->update(['name' => 'Bike']);

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -60,7 +60,7 @@ class QueryBuilderTest extends TestCase
 
         $product = DB::table('items')->first();
 
-        $pid = (string) ($product['_id']);
+        $pid = (string) ($product['id']);
 
         DB::table('items')->where('user_id', $userId)->delete($pid);
 
@@ -68,7 +68,7 @@ class QueryBuilderTest extends TestCase
 
         $product = DB::table('items')->first();
 
-        $pid = $product['_id'];
+        $pid = $product['id'];
 
         DB::table('items')->where('user_id', $userId)->delete($pid);
 
@@ -101,7 +101,7 @@ class QueryBuilderTest extends TestCase
         $item = DB::table('items')->where('name', 'nothing')->first();
         $this->assertNull($item);
 
-        $item = DB::table('items')->where('_id', '51c33d8981fec6813e00000a')->first();
+        $item = DB::table('items')->where('id', '51c33d8981fec6813e00000a')->first();
         $this->assertNull($item);
     }
 
@@ -340,37 +340,37 @@ class QueryBuilderTest extends TestCase
             'messages' => [],
         ]);
 
-        DB::table('users')->where('_id', $id)->push('tags', 'tag1');
+        DB::table('users')->where('id', $id)->push('tags', 'tag1');
 
         $user = DB::table('users')->find($id);
         $this->assertIsArray($user['tags']);
         $this->assertCount(1, $user['tags']);
         $this->assertEquals('tag1', $user['tags'][0]);
 
-        DB::table('users')->where('_id', $id)->push('tags', 'tag2');
+        DB::table('users')->where('id', $id)->push('tags', 'tag2');
         $user = DB::table('users')->find($id);
         $this->assertCount(2, $user['tags']);
         $this->assertEquals('tag2', $user['tags'][1]);
 
         // Add duplicate
-        DB::table('users')->where('_id', $id)->push('tags', 'tag2');
+        DB::table('users')->where('id', $id)->push('tags', 'tag2');
         $user = DB::table('users')->find($id);
         $this->assertCount(3, $user['tags']);
 
         // Add unique
-        DB::table('users')->where('_id', $id)->push('tags', 'tag1', true);
+        DB::table('users')->where('id', $id)->push('tags', 'tag1', true);
         $user = DB::table('users')->find($id);
         $this->assertCount(3, $user['tags']);
 
         $message = ['from' => 'Jane', 'body' => 'Hi John'];
-        DB::table('users')->where('_id', $id)->push('messages', $message);
+        DB::table('users')->where('id', $id)->push('messages', $message);
         $user = DB::table('users')->find($id);
         $this->assertIsArray($user['messages']);
         $this->assertCount(1, $user['messages']);
         $this->assertEquals($message, $user['messages'][0]);
 
         // Raw
-        DB::table('users')->where('_id', $id)->push([
+        DB::table('users')->where('id', $id)->push([
             'tags' => 'tag3',
             'messages' => ['from' => 'Mark', 'body' => 'Hi John'],
         ]);
@@ -378,7 +378,7 @@ class QueryBuilderTest extends TestCase
         $this->assertCount(4, $user['tags']);
         $this->assertCount(2, $user['messages']);
 
-        DB::table('users')->where('_id', $id)->push([
+        DB::table('users')->where('id', $id)->push([
             'messages' => [
                 'date' => new DateTime(),
                 'body' => 'Hi John',
@@ -407,21 +407,21 @@ class QueryBuilderTest extends TestCase
             'messages' => [$message1, $message2],
         ]);
 
-        DB::table('users')->where('_id', $id)->pull('tags', 'tag3');
+        DB::table('users')->where('id', $id)->pull('tags', 'tag3');
 
         $user = DB::table('users')->find($id);
         $this->assertIsArray($user['tags']);
         $this->assertCount(3, $user['tags']);
         $this->assertEquals('tag4', $user['tags'][2]);
 
-        DB::table('users')->where('_id', $id)->pull('messages', $message1);
+        DB::table('users')->where('id', $id)->pull('messages', $message1);
 
         $user = DB::table('users')->find($id);
         $this->assertIsArray($user['messages']);
         $this->assertCount(1, $user['messages']);
 
         // Raw
-        DB::table('users')->where('_id', $id)->pull(['tags' => 'tag2', 'messages' => $message2]);
+        DB::table('users')->where('id', $id)->pull(['tags' => 'tag2', 'messages' => $message2]);
         $user = DB::table('users')->find($id);
         $this->assertCount(2, $user['tags']);
         $this->assertCount(0, $user['messages']);
@@ -450,24 +450,24 @@ class QueryBuilderTest extends TestCase
     public function testCustomId()
     {
         DB::table('items')->insert([
-            ['_id' => 'knife', 'type' => 'sharp', 'amount' => 34],
-            ['_id' => 'fork', 'type' => 'sharp', 'amount' => 20],
-            ['_id' => 'spoon', 'type' => 'round', 'amount' => 3],
+            ['id' => 'knife', 'type' => 'sharp', 'amount' => 34],
+            ['id' => 'fork', 'type' => 'sharp', 'amount' => 20],
+            ['id' => 'spoon', 'type' => 'round', 'amount' => 3],
         ]);
 
         $item = DB::table('items')->find('knife');
-        $this->assertEquals('knife', $item['_id']);
+        $this->assertEquals('knife', $item['id']);
 
-        $item = DB::table('items')->where('_id', 'fork')->first();
-        $this->assertEquals('fork', $item['_id']);
+        $item = DB::table('items')->where('id', 'fork')->first();
+        $this->assertEquals('fork', $item['id']);
 
         DB::table('users')->insert([
-            ['_id' => 1, 'name' => 'Jane Doe'],
-            ['_id' => 2, 'name' => 'John Doe'],
+            ['id' => 1, 'name' => 'Jane Doe'],
+            ['id' => 2, 'name' => 'John Doe'],
         ]);
 
         $item = DB::table('users')->find(1);
-        $this->assertEquals(1, $item['_id']);
+        $this->assertEquals(1, $item['id']);
     }
 
     public function testTake()
@@ -527,7 +527,7 @@ class QueryBuilderTest extends TestCase
         $this->assertCount(3, $list);
         $this->assertEquals(['knife' => 'sharp', 'fork' => 'sharp', 'spoon' => 'round'], $list);
 
-        $list = DB::table('items')->pluck('name', '_id')->toArray();
+        $list = DB::table('items')->pluck('name', 'id')->toArray();
         $this->assertCount(4, $list);
         $this->assertEquals(24, strlen(key($list)));
     }
@@ -668,7 +668,7 @@ class QueryBuilderTest extends TestCase
     {
         $id = DB::table('users')->insertGetId(['name' => 'John Doe', 'address' => ['country' => 'Belgium']]);
 
-        DB::table('users')->where('_id', $id)->update(['address.country' => 'England']);
+        DB::table('users')->where('id', $id)->update(['address.country' => 'England']);
 
         $check = DB::table('users')->find($id);
         $this->assertEquals('England', $check['address']['country']);
@@ -933,7 +933,7 @@ class QueryBuilderTest extends TestCase
         ];
         DB::table('items')->insert($data);
 
-        $results = DB::table('items')->orderBy('_id', 'asc')->cursor();
+        $results = DB::table('items')->orderBy('id', 'asc')->cursor();
 
         $this->assertInstanceOf(LazyCollection::class, $results);
         foreach ($results as $i => $result) {

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -25,6 +25,7 @@ use MongoDB\Laravel\Collection;
 use MongoDB\Laravel\Query\Builder;
 use MongoDB\Laravel\Tests\Models\Item;
 use MongoDB\Laravel\Tests\Models\User;
+use PHPUnit\Framework\Attributes\TestWith;
 use Stringable;
 
 use function count;
@@ -1047,5 +1048,21 @@ class QueryBuilderTest extends TestCase
         $this->assertEquals(30, $user['age']);
         $this->assertEquals(5, $user['note']);
         $this->assertEquals('foo', $user['extra']);
+    }
+
+    #[TestWith(['id', 'id'])]
+    #[TestWith(['id', '_id'])]
+    #[TestWith(['_id', 'id'])]
+    public function testIdAlias($insertId, $queryId): void
+    {
+        DB::collection('items')->insert([$insertId => 'abc', 'name' => 'Karting']);
+        $item = DB::collection('items')->where($queryId, '=', 'abc')->first();
+        $this->assertNotNull($item);
+        $this->assertSame('abc', $item['_id']);
+        $this->assertSame('Karting', $item['name']);
+
+        DB::collection('items')->where($insertId, '=', 'abc')->update(['name' => 'Bike']);
+        $item = DB::collection('items')->where($queryId, '=', 'abc')->first();
+        $this->assertSame('Bike', $item['name']);
     }
 }

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -405,7 +405,7 @@ class QueryTest extends TestCase
         $this->assertEquals(6, $count);
 
         // Test for issue #165
-        $count = User::select('_id', 'age', 'title')->where('age', '<>', 35)->count();
+        $count = User::select('id', 'age', 'title')->where('age', '<>', 35)->count();
         $this->assertEquals(6, $count);
     }
 

--- a/tests/QueueTest.php
+++ b/tests/QueueTest.php
@@ -71,7 +71,7 @@ class QueueTest extends TestCase
         $expiry = Carbon::now()->subSeconds(Config::get('queue.connections.database.expire'))->getTimestamp();
         Queue::getDatabase()
             ->table(Config::get('queue.connections.database.table'))
-            ->where('_id', $id)
+            ->where('id', $id)
             ->update(['reserved' => 1, 'reserved_at' => $expiry]);
 
         // Expect an attempted older job in the queue
@@ -158,7 +158,7 @@ class QueueTest extends TestCase
 
         $releasedJob = Queue::getDatabase()
             ->table(Config::get('queue.connections.database.table'))
-            ->where('_id', $releasedJobId)
+            ->where('id', $releasedJobId)
             ->first();
 
         $this->assertEquals($queue, $releasedJob['queue']);

--- a/tests/RelationsTest.php
+++ b/tests/RelationsTest.php
@@ -40,16 +40,16 @@ class RelationsTest extends TestCase
     public function testHasMany(): void
     {
         $author = User::create(['name' => 'George R. R. Martin']);
-        Book::create(['title' => 'A Game of Thrones', 'author_id' => $author->_id]);
-        Book::create(['title' => 'A Clash of Kings', 'author_id' => $author->_id]);
+        Book::create(['title' => 'A Game of Thrones', 'author_id' => $author->id]);
+        Book::create(['title' => 'A Clash of Kings', 'author_id' => $author->id]);
 
         $books = $author->books;
         $this->assertCount(2, $books);
 
         $user = User::create(['name' => 'John Doe']);
-        Item::create(['type' => 'knife', 'user_id' => $user->_id]);
-        Item::create(['type' => 'shield', 'user_id' => $user->_id]);
-        Item::create(['type' => 'sword', 'user_id' => $user->_id]);
+        Item::create(['type' => 'knife', 'user_id' => $user->id]);
+        Item::create(['type' => 'shield', 'user_id' => $user->id]);
+        Item::create(['type' => 'sword', 'user_id' => $user->id]);
         Item::create(['type' => 'bag', 'user_id' => null]);
 
         $items = $user->items;
@@ -59,32 +59,32 @@ class RelationsTest extends TestCase
     public function testHasManyWithTrashed(): void
     {
         $user   = User::create(['name' => 'George R. R. Martin']);
-        $first  = Soft::create(['title' => 'A Game of Thrones', 'user_id' => $user->_id]);
-        $second = Soft::create(['title' => 'The Witcher', 'user_id' => $user->_id]);
+        $first  = Soft::create(['title' => 'A Game of Thrones', 'user_id' => $user->id]);
+        $second = Soft::create(['title' => 'The Witcher', 'user_id' => $user->id]);
 
         self::assertNull($first->deleted_at);
-        self::assertEquals($user->_id, $first->user->_id);
-        self::assertEquals([$first->_id, $second->_id], $user->softs->pluck('_id')->toArray());
+        self::assertEquals($user->id, $first->user->id);
+        self::assertEquals([$first->id, $second->id], $user->softs->pluck('id')->toArray());
 
         $first->delete();
         $user->refresh();
 
         self::assertNotNull($first->deleted_at);
-        self::assertEquals([$second->_id], $user->softs->pluck('_id')->toArray());
-        self::assertEquals([$first->_id, $second->_id], $user->softsWithTrashed->pluck('_id')->toArray());
+        self::assertEquals([$second->id], $user->softs->pluck('id')->toArray());
+        self::assertEquals([$first->id, $second->id], $user->softsWithTrashed->pluck('id')->toArray());
     }
 
     public function testBelongsTo(): void
     {
         $user = User::create(['name' => 'George R. R. Martin']);
-        Book::create(['title' => 'A Game of Thrones', 'author_id' => $user->_id]);
-        $book = Book::create(['title' => 'A Clash of Kings', 'author_id' => $user->_id]);
+        Book::create(['title' => 'A Game of Thrones', 'author_id' => $user->id]);
+        $book = Book::create(['title' => 'A Clash of Kings', 'author_id' => $user->id]);
 
         $author = $book->author;
         $this->assertEquals('George R. R. Martin', $author->name);
 
         $user = User::create(['name' => 'John Doe']);
-        $item = Item::create(['type' => 'sword', 'user_id' => $user->_id]);
+        $item = Item::create(['type' => 'sword', 'user_id' => $user->id]);
 
         $owner = $item->user;
         $this->assertEquals('John Doe', $owner->name);
@@ -96,11 +96,11 @@ class RelationsTest extends TestCase
     public function testHasOne(): void
     {
         $user = User::create(['name' => 'John Doe']);
-        Role::create(['type' => 'admin', 'user_id' => $user->_id]);
+        Role::create(['type' => 'admin', 'user_id' => $user->id]);
 
         $role = $user->role;
         $this->assertEquals('admin', $role->type);
-        $this->assertEquals($user->_id, $role->user_id);
+        $this->assertEquals($user->id, $role->user_id);
 
         $user = User::create(['name' => 'Jane Doe']);
         $role = new Role(['type' => 'user']);
@@ -108,20 +108,20 @@ class RelationsTest extends TestCase
 
         $role = $user->role;
         $this->assertEquals('user', $role->type);
-        $this->assertEquals($user->_id, $role->user_id);
+        $this->assertEquals($user->id, $role->user_id);
 
         $user = User::where('name', 'Jane Doe')->first();
         $role = $user->role;
         $this->assertEquals('user', $role->type);
-        $this->assertEquals($user->_id, $role->user_id);
+        $this->assertEquals($user->id, $role->user_id);
     }
 
     public function testWithBelongsTo(): void
     {
         $user = User::create(['name' => 'John Doe']);
-        Item::create(['type' => 'knife', 'user_id' => $user->_id]);
-        Item::create(['type' => 'shield', 'user_id' => $user->_id]);
-        Item::create(['type' => 'sword', 'user_id' => $user->_id]);
+        Item::create(['type' => 'knife', 'user_id' => $user->id]);
+        Item::create(['type' => 'shield', 'user_id' => $user->id]);
+        Item::create(['type' => 'sword', 'user_id' => $user->id]);
         Item::create(['type' => 'bag', 'user_id' => null]);
 
         $items = Item::with('user')->orderBy('user_id', 'desc')->get();
@@ -136,12 +136,12 @@ class RelationsTest extends TestCase
     public function testWithHashMany(): void
     {
         $user = User::create(['name' => 'John Doe']);
-        Item::create(['type' => 'knife', 'user_id' => $user->_id]);
-        Item::create(['type' => 'shield', 'user_id' => $user->_id]);
-        Item::create(['type' => 'sword', 'user_id' => $user->_id]);
+        Item::create(['type' => 'knife', 'user_id' => $user->id]);
+        Item::create(['type' => 'shield', 'user_id' => $user->id]);
+        Item::create(['type' => 'sword', 'user_id' => $user->id]);
         Item::create(['type' => 'bag', 'user_id' => null]);
 
-        $user = User::with('items')->find($user->_id);
+        $user = User::with('items')->find($user->id);
 
         $items = $user->getRelation('items');
         $this->assertCount(3, $items);
@@ -151,10 +151,10 @@ class RelationsTest extends TestCase
     public function testWithHasOne(): void
     {
         $user = User::create(['name' => 'John Doe']);
-        Role::create(['type' => 'admin', 'user_id' => $user->_id]);
-        Role::create(['type' => 'guest', 'user_id' => $user->_id]);
+        Role::create(['type' => 'admin', 'user_id' => $user->id]);
+        Role::create(['type' => 'guest', 'user_id' => $user->id]);
 
-        $user = User::with('role')->find($user->_id);
+        $user = User::with('role')->find($user->id);
 
         $role = $user->getRelation('role');
         $this->assertInstanceOf(Role::class, $role);
@@ -168,22 +168,22 @@ class RelationsTest extends TestCase
         $item = Item::create(['type' => 'knife']);
         $user->items()->save($item);
 
-        $user  = User::find($user->_id);
+        $user  = User::find($user->id);
         $items = $user->items;
         $this->assertCount(1, $items);
         $this->assertInstanceOf(Item::class, $items[0]);
-        $this->assertEquals($user->_id, $items[0]->user_id);
+        $this->assertEquals($user->id, $items[0]->user_id);
 
         // Has one
         $user = User::create(['name' => 'John Doe']);
         $role = Role::create(['type' => 'admin']);
         $user->role()->save($role);
 
-        $user = User::find($user->_id);
+        $user = User::find($user->id);
         $role = $user->role;
         $this->assertInstanceOf(Role::class, $role);
         $this->assertEquals('admin', $role->type);
-        $this->assertEquals($user->_id, $role->user_id);
+        $this->assertEquals($user->id, $role->user_id);
     }
 
     public function testBelongsToMany(): void
@@ -195,7 +195,7 @@ class RelationsTest extends TestCase
         $user->clients()->create(['name' => 'Buffet Bar Inc.']);
 
         // Refetch
-        $user   = User::with('clients')->find($user->_id);
+        $user   = User::with('clients')->find($user->id);
         $client = Client::with('users')->first();
 
         // Check for relation attributes
@@ -228,8 +228,8 @@ class RelationsTest extends TestCase
         $this->assertInstanceOf(User::class, $user);
 
         // Assert they are not attached
-        $this->assertNotContains($client->_id, $user->client_ids);
-        $this->assertNotContains($user->_id, $client->user_ids);
+        $this->assertNotContains($client->id, $user->client_ids);
+        $this->assertNotContains($user->id, $client->user_ids);
         $this->assertCount(1, $user->clients);
         $this->assertCount(1, $client->users);
 
@@ -241,8 +241,8 @@ class RelationsTest extends TestCase
         $client = Client::Where('name', '=', 'Buffet Bar Inc.')->first();
 
         // Assert they are attached
-        $this->assertContains($client->_id, $user->client_ids);
-        $this->assertContains($user->_id, $client->user_ids);
+        $this->assertContains($client->id, $user->client_ids);
+        $this->assertContains($user->id, $client->user_ids);
         $this->assertCount(2, $user->clients);
         $this->assertCount(2, $client->users);
 
@@ -254,8 +254,8 @@ class RelationsTest extends TestCase
         $client = Client::Where('name', '=', 'Buffet Bar Inc.')->first();
 
         // Assert they are not attached
-        $this->assertNotContains($client->_id, $user->client_ids);
-        $this->assertNotContains($user->_id, $client->user_ids);
+        $this->assertNotContains($client->id, $user->client_ids);
+        $this->assertNotContains($user->id, $client->user_ids);
         $this->assertCount(0, $user->clients);
         $this->assertCount(1, $client->users);
     }
@@ -265,19 +265,19 @@ class RelationsTest extends TestCase
         $user = User::create(['name' => 'John Doe', 'client_ids' => ['1234523']]);
 
         $clients = [
-            Client::create(['name' => 'Pork Pies Ltd.'])->_id,
-            Client::create(['name' => 'Buffet Bar Inc.'])->_id,
+            Client::create(['name' => 'Pork Pies Ltd.'])->id,
+            Client::create(['name' => 'Buffet Bar Inc.'])->id,
         ];
 
         $moreClients = [
-            Client::create(['name' => 'synced Boloni Ltd.'])->_id,
-            Client::create(['name' => 'synced Meatballs Inc.'])->_id,
+            Client::create(['name' => 'synced Boloni Ltd.'])->id,
+            Client::create(['name' => 'synced Meatballs Inc.'])->id,
         ];
 
         // Sync multiple records
         $user->clients()->sync($clients);
 
-        $user = User::with('clients')->find($user->_id);
+        $user = User::with('clients')->find($user->id);
 
         // Assert non attached ID's are detached successfully
         $this->assertNotContains('1234523', $user->client_ids);
@@ -289,7 +289,7 @@ class RelationsTest extends TestCase
         $user->clients()->sync($moreClients);
 
         // Refetch
-        $user = User::with('clients')->find($user->_id);
+        $user = User::with('clients')->find($user->id);
 
         // Assert there are now still 2 client objects in the relationship
         $this->assertCount(2, $user->clients);
@@ -307,11 +307,11 @@ class RelationsTest extends TestCase
         $client2 = Client::create(['name' => 'Buffet Bar Inc.']);
 
         // Sync multiple
-        $user->clients()->sync([$client1->_id, $client2->_id]);
+        $user->clients()->sync([$client1->id, $client2->id]);
         $this->assertCount(2, $user->clients);
 
         // Sync single wrapped by an array
-        $user->clients()->sync([$client1->_id]);
+        $user->clients()->sync([$client1->id]);
         $user->load('clients');
 
         $this->assertCount(1, $user->clients);
@@ -328,8 +328,8 @@ class RelationsTest extends TestCase
     public function testBelongsToManyAttachArray(): void
     {
         $user    = User::create(['name' => 'John Doe']);
-        $client1 = Client::create(['name' => 'Test 1'])->_id;
-        $client2 = Client::create(['name' => 'Test 2'])->_id;
+        $client1 = Client::create(['name' => 'Test 1'])->id;
+        $client2 = Client::create(['name' => 'Test 2'])->id;
 
         $user->clients()->attach([$client1, $client2]);
         $this->assertCount(2, $user->clients);
@@ -353,27 +353,27 @@ class RelationsTest extends TestCase
         $skill1    = Skill::create(['cskill_id' => (string) (new ObjectId()), 'name' => 'PHP']);
         $skill2    = Skill::create(['cskill_id' => (string) (new ObjectId()), 'name' => 'Laravel']);
 
-        $client = Client::query()->find($client->_id);
+        $client = Client::query()->find($client->id);
         $client->skillsWithCustomKeys()->sync([$skill1->cskill_id, $skill2->cskill_id]);
         $this->assertCount(2, $client->skillsWithCustomKeys);
 
         self::assertIsString($skill1->cskill_id);
         self::assertContains($skill1->cskill_id, $client->skillsWithCustomKeys->pluck('cskill_id'));
-        self::assertNotContains($skill1->_id, $client->skillsWithCustomKeys->pluck('cskill_id'));
+        self::assertNotContains($skill1->id, $client->skillsWithCustomKeys->pluck('cskill_id'));
 
         self::assertIsString($skill2->cskill_id);
         self::assertContains($skill2->cskill_id, $client->skillsWithCustomKeys->pluck('cskill_id'));
-        self::assertNotContains($skill2->_id, $client->skillsWithCustomKeys->pluck('cskill_id'));
+        self::assertNotContains($skill2->id, $client->skillsWithCustomKeys->pluck('cskill_id'));
 
-        $check = Skill::query()->find($skill1->_id);
+        $check = Skill::query()->find($skill1->id);
         self::assertIsString($check->cskill_id);
         self::assertContains($check->cskill_id, $client->skillsWithCustomKeys->pluck('cskill_id'));
-        self::assertNotContains($check->_id, $client->skillsWithCustomKeys->pluck('cskill_id'));
+        self::assertNotContains($check->id, $client->skillsWithCustomKeys->pluck('cskill_id'));
 
-        $check = Skill::query()->find($skill2->_id);
+        $check = Skill::query()->find($skill2->id);
         self::assertIsString($check->cskill_id);
         self::assertContains($check->cskill_id, $client->skillsWithCustomKeys->pluck('cskill_id'));
-        self::assertNotContains($check->_id, $client->skillsWithCustomKeys->pluck('cskill_id'));
+        self::assertNotContains($check->id, $client->skillsWithCustomKeys->pluck('cskill_id'));
     }
 
     public function testBelongsToManySyncModelWithCustomKeys(): void
@@ -381,18 +381,18 @@ class RelationsTest extends TestCase
         $client = Client::create(['cclient_id' => (string) (new ObjectId()), 'years' => '5']);
         $skill1    = Skill::create(['cskill_id' => (string) (new ObjectId()), 'name' => 'PHP']);
 
-        $client = Client::query()->find($client->_id);
+        $client = Client::query()->find($client->id);
         $client->skillsWithCustomKeys()->sync($skill1);
         $this->assertCount(1, $client->skillsWithCustomKeys);
 
         self::assertIsString($skill1->cskill_id);
         self::assertContains($skill1->cskill_id, $client->skillsWithCustomKeys->pluck('cskill_id'));
-        self::assertNotContains($skill1->_id, $client->skillsWithCustomKeys->pluck('cskill_id'));
+        self::assertNotContains($skill1->id, $client->skillsWithCustomKeys->pluck('cskill_id'));
 
-        $check = Skill::query()->find($skill1->_id);
-        self::assertIsString($check->_id);
+        $check = Skill::query()->find($skill1->id);
+        self::assertIsString($check->id);
         self::assertContains($check->cskill_id, $client->skillsWithCustomKeys->pluck('cskill_id'));
-        self::assertNotContains($check->_id, $client->skillsWithCustomKeys->pluck('cskill_id'));
+        self::assertNotContains($check->id, $client->skillsWithCustomKeys->pluck('cskill_id'));
     }
 
     public function testBelongsToManySyncEloquentCollectionWithCustomKeys(): void
@@ -402,27 +402,27 @@ class RelationsTest extends TestCase
         $skill2    = Skill::create(['cskill_id' => (string) (new ObjectId()), 'name' => 'Laravel']);
         $collection = new Collection([$skill1, $skill2]);
 
-        $client = Client::query()->find($client->_id);
+        $client = Client::query()->find($client->id);
         $client->skillsWithCustomKeys()->sync($collection);
         $this->assertCount(2, $client->skillsWithCustomKeys);
 
         self::assertIsString($skill1->cskill_id);
         self::assertContains($skill1->cskill_id, $client->skillsWithCustomKeys->pluck('cskill_id'));
-        self::assertNotContains($skill1->_id, $client->skillsWithCustomKeys->pluck('cskill_id'));
+        self::assertNotContains($skill1->id, $client->skillsWithCustomKeys->pluck('cskill_id'));
 
         self::assertIsString($skill2->cskill_id);
         self::assertContains($skill2->cskill_id, $client->skillsWithCustomKeys->pluck('cskill_id'));
-        self::assertNotContains($skill2->_id, $client->skillsWithCustomKeys->pluck('cskill_id'));
+        self::assertNotContains($skill2->id, $client->skillsWithCustomKeys->pluck('cskill_id'));
 
-        $check = Skill::query()->find($skill1->_id);
+        $check = Skill::query()->find($skill1->id);
         self::assertIsString($check->cskill_id);
         self::assertContains($check->cskill_id, $client->skillsWithCustomKeys->pluck('cskill_id'));
-        self::assertNotContains($check->_id, $client->skillsWithCustomKeys->pluck('cskill_id'));
+        self::assertNotContains($check->id, $client->skillsWithCustomKeys->pluck('cskill_id'));
 
-        $check = Skill::query()->find($skill2->_id);
+        $check = Skill::query()->find($skill2->id);
         self::assertIsString($check->cskill_id);
         self::assertContains($check->cskill_id, $client->skillsWithCustomKeys->pluck('cskill_id'));
-        self::assertNotContains($check->_id, $client->skillsWithCustomKeys->pluck('cskill_id'));
+        self::assertNotContains($check->id, $client->skillsWithCustomKeys->pluck('cskill_id'));
     }
 
     public function testBelongsToManyAttachWithCustomKeys(): void
@@ -431,27 +431,27 @@ class RelationsTest extends TestCase
         $skill1    = Skill::create(['cskill_id' => (string) (new ObjectId()), 'name' => 'PHP']);
         $skill2    = Skill::create(['cskill_id' => (string) (new ObjectId()), 'name' => 'Laravel']);
 
-        $client = Client::query()->find($client->_id);
+        $client = Client::query()->find($client->id);
         $client->skillsWithCustomKeys()->attach([$skill1->cskill_id, $skill2->cskill_id]);
         $this->assertCount(2, $client->skillsWithCustomKeys);
 
         self::assertIsString($skill1->cskill_id);
         self::assertContains($skill1->cskill_id, $client->skillsWithCustomKeys->pluck('cskill_id'));
-        self::assertNotContains($skill1->_id, $client->skillsWithCustomKeys->pluck('cskill_id'));
+        self::assertNotContains($skill1->id, $client->skillsWithCustomKeys->pluck('cskill_id'));
 
         self::assertIsString($skill2->cskill_id);
         self::assertContains($skill2->cskill_id, $client->skillsWithCustomKeys->pluck('cskill_id'));
-        self::assertNotContains($skill2->_id, $client->skillsWithCustomKeys->pluck('cskill_id'));
+        self::assertNotContains($skill2->id, $client->skillsWithCustomKeys->pluck('cskill_id'));
 
-        $check = Skill::query()->find($skill1->_id);
+        $check = Skill::query()->find($skill1->id);
         self::assertIsString($check->cskill_id);
         self::assertContains($check->cskill_id, $client->skillsWithCustomKeys->pluck('cskill_id'));
-        self::assertNotContains($check->_id, $client->skillsWithCustomKeys->pluck('cskill_id'));
+        self::assertNotContains($check->id, $client->skillsWithCustomKeys->pluck('cskill_id'));
 
-        $check = Skill::query()->find($skill2->_id);
+        $check = Skill::query()->find($skill2->id);
         self::assertIsString($check->cskill_id);
         self::assertContains($check->cskill_id, $client->skillsWithCustomKeys->pluck('cskill_id'));
-        self::assertNotContains($check->_id, $client->skillsWithCustomKeys->pluck('cskill_id'));
+        self::assertNotContains($check->id, $client->skillsWithCustomKeys->pluck('cskill_id'));
     }
 
     public function testBelongsToManyAttachModelWithCustomKeys(): void
@@ -459,18 +459,18 @@ class RelationsTest extends TestCase
         $client = Client::create(['cclient_id' => (string) (new ObjectId()), 'years' => '5']);
         $skill1    = Skill::create(['cskill_id' => (string) (new ObjectId()), 'name' => 'PHP']);
 
-        $client = Client::query()->find($client->_id);
+        $client = Client::query()->find($client->id);
         $client->skillsWithCustomKeys()->attach($skill1);
         $this->assertCount(1, $client->skillsWithCustomKeys);
 
         self::assertIsString($skill1->cskill_id);
         self::assertContains($skill1->cskill_id, $client->skillsWithCustomKeys->pluck('cskill_id'));
-        self::assertNotContains($skill1->_id, $client->skillsWithCustomKeys->pluck('cskill_id'));
+        self::assertNotContains($skill1->id, $client->skillsWithCustomKeys->pluck('cskill_id'));
 
-        $check = Skill::query()->find($skill1->_id);
-        self::assertIsString($check->_id);
+        $check = Skill::query()->find($skill1->id);
+        self::assertIsString($check->id);
         self::assertContains($check->cskill_id, $client->skillsWithCustomKeys->pluck('cskill_id'));
-        self::assertNotContains($check->_id, $client->skillsWithCustomKeys->pluck('cskill_id'));
+        self::assertNotContains($check->id, $client->skillsWithCustomKeys->pluck('cskill_id'));
     }
 
     public function testBelongsToManyAttachEloquentCollectionWithCustomKeys(): void
@@ -480,27 +480,27 @@ class RelationsTest extends TestCase
         $skill2    = Skill::create(['cskill_id' => (string) (new ObjectId()), 'name' => 'Laravel']);
         $collection = new Collection([$skill1, $skill2]);
 
-        $client = Client::query()->find($client->_id);
+        $client = Client::query()->find($client->id);
         $client->skillsWithCustomKeys()->attach($collection);
         $this->assertCount(2, $client->skillsWithCustomKeys);
 
         self::assertIsString($skill1->cskill_id);
         self::assertContains($skill1->cskill_id, $client->skillsWithCustomKeys->pluck('cskill_id'));
-        self::assertNotContains($skill1->_id, $client->skillsWithCustomKeys->pluck('cskill_id'));
+        self::assertNotContains($skill1->id, $client->skillsWithCustomKeys->pluck('cskill_id'));
 
         self::assertIsString($skill2->cskill_id);
         self::assertContains($skill2->cskill_id, $client->skillsWithCustomKeys->pluck('cskill_id'));
-        self::assertNotContains($skill2->_id, $client->skillsWithCustomKeys->pluck('cskill_id'));
+        self::assertNotContains($skill2->id, $client->skillsWithCustomKeys->pluck('cskill_id'));
 
-        $check = Skill::query()->find($skill1->_id);
+        $check = Skill::query()->find($skill1->id);
         self::assertIsString($check->cskill_id);
         self::assertContains($check->cskill_id, $client->skillsWithCustomKeys->pluck('cskill_id'));
-        self::assertNotContains($check->_id, $client->skillsWithCustomKeys->pluck('cskill_id'));
+        self::assertNotContains($check->id, $client->skillsWithCustomKeys->pluck('cskill_id'));
 
-        $check = Skill::query()->find($skill2->_id);
+        $check = Skill::query()->find($skill2->id);
         self::assertIsString($check->cskill_id);
         self::assertContains($check->cskill_id, $client->skillsWithCustomKeys->pluck('cskill_id'));
-        self::assertNotContains($check->_id, $client->skillsWithCustomKeys->pluck('cskill_id'));
+        self::assertNotContains($check->id, $client->skillsWithCustomKeys->pluck('cskill_id'));
     }
 
     public function testBelongsToManyDetachWithCustomKeys(): void
@@ -509,7 +509,7 @@ class RelationsTest extends TestCase
         $skill1    = Skill::create(['cskill_id' => (string) (new ObjectId()), 'name' => 'PHP']);
         $skill2    = Skill::create(['cskill_id' => (string) (new ObjectId()), 'name' => 'Laravel']);
 
-        $client = Client::query()->find($client->_id);
+        $client = Client::query()->find($client->id);
         $client->skillsWithCustomKeys()->sync([$skill1->cskill_id, $skill2->cskill_id]);
         $this->assertCount(2, $client->skillsWithCustomKeys);
 
@@ -519,21 +519,21 @@ class RelationsTest extends TestCase
 
         self::assertIsString($skill1->cskill_id);
         self::assertNotContains($skill1->cskill_id, $client->skillsWithCustomKeys->pluck('cskill_id'));
-        self::assertNotContains($skill1->_id, $client->skillsWithCustomKeys->pluck('cskill_id'));
+        self::assertNotContains($skill1->id, $client->skillsWithCustomKeys->pluck('cskill_id'));
 
         self::assertIsString($skill2->cskill_id);
         self::assertContains($skill2->cskill_id, $client->skillsWithCustomKeys->pluck('cskill_id'));
-        self::assertNotContains($skill2->_id, $client->skillsWithCustomKeys->pluck('cskill_id'));
+        self::assertNotContains($skill2->id, $client->skillsWithCustomKeys->pluck('cskill_id'));
 
-        $check = Skill::query()->find($skill1->_id);
+        $check = Skill::query()->find($skill1->id);
         self::assertIsString($check->cskill_id);
         self::assertNotContains($check->cskill_id, $client->skillsWithCustomKeys->pluck('cskill_id'));
-        self::assertNotContains($check->_id, $client->skillsWithCustomKeys->pluck('cskill_id'));
+        self::assertNotContains($check->id, $client->skillsWithCustomKeys->pluck('cskill_id'));
 
-        $check = Skill::query()->find($skill2->_id);
+        $check = Skill::query()->find($skill2->id);
         self::assertIsString($check->cskill_id);
         self::assertContains($check->cskill_id, $client->skillsWithCustomKeys->pluck('cskill_id'));
-        self::assertNotContains($check->_id, $client->skillsWithCustomKeys->pluck('cskill_id'));
+        self::assertNotContains($check->id, $client->skillsWithCustomKeys->pluck('cskill_id'));
     }
 
     public function testBelongsToManyDetachModelWithCustomKeys(): void
@@ -542,7 +542,7 @@ class RelationsTest extends TestCase
         $skill1    = Skill::create(['cskill_id' => (string) (new ObjectId()), 'name' => 'PHP']);
         $skill2    = Skill::create(['cskill_id' => (string) (new ObjectId()), 'name' => 'Laravel']);
 
-        $client = Client::query()->find($client->_id);
+        $client = Client::query()->find($client->id);
         $client->skillsWithCustomKeys()->sync([$skill1->cskill_id, $skill2->cskill_id]);
         $this->assertCount(2, $client->skillsWithCustomKeys);
 
@@ -552,28 +552,28 @@ class RelationsTest extends TestCase
 
         self::assertIsString($skill1->cskill_id);
         self::assertNotContains($skill1->cskill_id, $client->skillsWithCustomKeys->pluck('cskill_id'));
-        self::assertNotContains($skill1->_id, $client->skillsWithCustomKeys->pluck('cskill_id'));
+        self::assertNotContains($skill1->id, $client->skillsWithCustomKeys->pluck('cskill_id'));
 
         self::assertIsString($skill2->cskill_id);
         self::assertContains($skill2->cskill_id, $client->skillsWithCustomKeys->pluck('cskill_id'));
-        self::assertNotContains($skill2->_id, $client->skillsWithCustomKeys->pluck('cskill_id'));
+        self::assertNotContains($skill2->id, $client->skillsWithCustomKeys->pluck('cskill_id'));
 
-        $check = Skill::query()->find($skill1->_id);
+        $check = Skill::query()->find($skill1->id);
         self::assertIsString($check->cskill_id);
         self::assertNotContains($check->cskill_id, $client->skillsWithCustomKeys->pluck('cskill_id'));
-        self::assertNotContains($check->_id, $client->skillsWithCustomKeys->pluck('cskill_id'));
+        self::assertNotContains($check->id, $client->skillsWithCustomKeys->pluck('cskill_id'));
 
-        $check = Skill::query()->find($skill2->_id);
+        $check = Skill::query()->find($skill2->id);
         self::assertIsString($check->cskill_id);
         self::assertContains($check->cskill_id, $client->skillsWithCustomKeys->pluck('cskill_id'));
-        self::assertNotContains($check->_id, $client->skillsWithCustomKeys->pluck('cskill_id'));
+        self::assertNotContains($check->id, $client->skillsWithCustomKeys->pluck('cskill_id'));
     }
 
     public function testBelongsToManySyncAlreadyPresent(): void
     {
         $user    = User::create(['name' => 'John Doe']);
-        $client1 = Client::create(['name' => 'Test 1'])->_id;
-        $client2 = Client::create(['name' => 'Test 2'])->_id;
+        $client1 = Client::create(['name' => 'Test 1'])->id;
+        $client2 = Client::create(['name' => 'Test 2'])->id;
 
         $user->clients()->sync([$client1, $client2]);
         $this->assertCount(2, $user->clients);
@@ -592,18 +592,18 @@ class RelationsTest extends TestCase
         $group = $user->groups()->create(['name' => 'Admins']);
 
         // Refetch
-        $user  = User::find($user->_id);
-        $group = Group::find($group->_id);
+        $user  = User::find($user->id);
+        $group = Group::find($group->id);
 
         // Check for custom relation attributes
         $this->assertArrayHasKey('users', $group->getAttributes());
         $this->assertArrayHasKey('groups', $user->getAttributes());
 
         // Assert they are attached
-        $this->assertContains($group->_id, $user->groups->pluck('_id')->toArray());
-        $this->assertContains($user->_id, $group->users->pluck('_id')->toArray());
-        $this->assertEquals($group->_id, $user->groups()->first()->_id);
-        $this->assertEquals($user->_id, $group->users()->first()->_id);
+        $this->assertContains($group->id, $user->groups->pluck('id')->toArray());
+        $this->assertContains($user->id, $group->users->pluck('id')->toArray());
+        $this->assertEquals($group->id, $user->groups()->first()->id);
+        $this->assertEquals($user->id, $group->users()->first()->id);
     }
 
     public function testMorph(): void
@@ -617,7 +617,7 @@ class RelationsTest extends TestCase
         $this->assertEquals(1, $user->photos->count());
         $this->assertEquals($photo->id, $user->photos->first()->id);
 
-        $user = User::find($user->_id);
+        $user = User::find($user->id);
         $this->assertEquals(1, $user->photos->count());
         $this->assertEquals($photo->id, $user->photos->first()->id);
 
@@ -627,14 +627,14 @@ class RelationsTest extends TestCase
         $this->assertNotNull($client->photo);
         $this->assertEquals($photo->id, $client->photo->id);
 
-        $client = Client::find($client->_id);
+        $client = Client::find($client->id);
         $this->assertNotNull($client->photo);
         $this->assertEquals($photo->id, $client->photo->id);
 
         $photo = Photo::first();
         $this->assertEquals($photo->hasImage->name, $user->name);
 
-        $user      = User::with('photos')->find($user->_id);
+        $user      = User::with('photos')->find($user->id);
         $relations = $user->getRelations();
         $this->assertArrayHasKey('photos', $relations);
         $this->assertEquals(1, $relations['photos']->count());
@@ -655,7 +655,7 @@ class RelationsTest extends TestCase
 
         $this->assertCount(1, $photo->hasImage()->get());
         $this->assertInstanceOf(Client::class, $photo->hasImage);
-        $this->assertEquals($client->_id, $photo->hasImage->_id);
+        $this->assertEquals($client->id, $photo->hasImage->id);
 
         // inverse with custom ownerKey
         $photo = Photo::query()->create(['url' => 'https://graph.facebook.com/young.gerald/picture']);
@@ -665,7 +665,7 @@ class RelationsTest extends TestCase
         $this->assertCount(1, $photo->hasImageWithCustomOwnerKey()->get());
         $this->assertInstanceOf(Client::class, $photo->hasImageWithCustomOwnerKey);
         $this->assertEquals($client->cclient_id, $photo->has_image_with_custom_owner_key_id);
-        $this->assertEquals($client->_id, $photo->hasImageWithCustomOwnerKey->_id);
+        $this->assertEquals($client->id, $photo->hasImageWithCustomOwnerKey->id);
     }
 
     public function testMorphToMany(): void
@@ -679,10 +679,10 @@ class RelationsTest extends TestCase
         $client->labels()->attach($label);
 
         $this->assertEquals(1, $user->labels->count());
-        $this->assertContains($label->_id, $user->labels->pluck('_id'));
+        $this->assertContains($label->id, $user->labels->pluck('id'));
 
         $this->assertEquals(1, $client->labels->count());
-        $this->assertContains($label->_id, $user->labels->pluck('_id'));
+        $this->assertContains($label->id, $user->labels->pluck('id'));
     }
 
     public function testMorphToManyAttachEloquentCollection(): void
@@ -695,8 +695,8 @@ class RelationsTest extends TestCase
         $client->labels()->attach(new Collection([$label1, $label2]));
 
         $this->assertEquals(2, $client->labels->count());
-        $this->assertContains($label1->_id, $client->labels->pluck('_id'));
-        $this->assertContains($label2->_id, $client->labels->pluck('_id'));
+        $this->assertContains($label1->id, $client->labels->pluck('id'));
+        $this->assertContains($label2->id, $client->labels->pluck('id'));
     }
 
     public function testMorphToManyAttachMultipleIds(): void
@@ -706,11 +706,11 @@ class RelationsTest extends TestCase
         $label1  = Label::query()->create(['name' => 'stayed solid i never fled']);
         $label2  = Label::query()->create(['name' => "I've got a lane and I'm in gear"]);
 
-        $client->labels()->attach([$label1->_id, $label2->_id]);
+        $client->labels()->attach([$label1->id, $label2->id]);
 
         $this->assertEquals(2, $client->labels->count());
-        $this->assertContains($label1->_id, $client->labels->pluck('_id'));
-        $this->assertContains($label2->_id, $client->labels->pluck('_id'));
+        $this->assertContains($label1->id, $client->labels->pluck('id'));
+        $this->assertContains($label2->id, $client->labels->pluck('id'));
     }
 
     public function testMorphToManyDetaching(): void
@@ -720,7 +720,7 @@ class RelationsTest extends TestCase
         $label1  = Label::query()->create(['name' => "I'll never love again"]);
         $label2  = Label::query()->create(['name' => 'The way I loved you']);
 
-        $client->labels()->attach([$label1->_id, $label2->_id]);
+        $client->labels()->attach([$label1->id, $label2->id]);
 
         $this->assertEquals(2, $client->labels->count());
 
@@ -728,7 +728,7 @@ class RelationsTest extends TestCase
         $check = $client->withoutRelations();
 
         $this->assertEquals(1, $check->labels->count());
-        $this->assertContains($label2->_id, $client->labels->pluck('_id'));
+        $this->assertContains($label2->id, $client->labels->pluck('id'));
     }
 
     public function testMorphToManyDetachingMultipleIds(): void
@@ -739,15 +739,15 @@ class RelationsTest extends TestCase
         $label2  = Label::query()->create(['name' => "My skin's thick, but I'm not bulletproof"]);
         $label3  = Label::query()->create(['name' => 'All I can be is myself, go, and tell the truth']);
 
-        $client->labels()->attach([$label1->_id, $label2->_id, $label3->_id]);
+        $client->labels()->attach([$label1->id, $label2->id, $label3->id]);
 
         $this->assertEquals(3, $client->labels->count());
 
-        $client->labels()->detach([$label1->_id, $label2->_id]);
+        $client->labels()->detach([$label1->id, $label2->id]);
         $client->refresh();
 
         $this->assertEquals(1, $client->labels->count());
-        $this->assertContains($label3->_id, $client->labels->pluck('_id'));
+        $this->assertContains($label3->id, $client->labels->pluck('id'));
     }
 
     public function testMorphToManySyncing(): void
@@ -763,12 +763,12 @@ class RelationsTest extends TestCase
         $client->labels()->sync($label2, false);
 
         $this->assertEquals(1, $user->labels->count());
-        $this->assertContains($label->_id, $user->labels->pluck('_id'));
-        $this->assertNotContains($label2->_id, $user->labels->pluck('_id'));
+        $this->assertContains($label->id, $user->labels->pluck('id'));
+        $this->assertNotContains($label2->id, $user->labels->pluck('id'));
 
         $this->assertEquals(2, $client->labels->count());
-        $this->assertContains($label->_id, $client->labels->pluck('_id'));
-        $this->assertContains($label2->_id, $client->labels->pluck('_id'));
+        $this->assertContains($label->id, $client->labels->pluck('id'));
+        $this->assertContains($label2->id, $client->labels->pluck('id'));
     }
 
     public function testMorphToManySyncingEloquentCollection(): void
@@ -781,8 +781,8 @@ class RelationsTest extends TestCase
         $client->labels()->sync(new Collection([$label, $label2]));
 
         $this->assertEquals(2, $client->labels->count());
-        $this->assertContains($label->_id, $client->labels->pluck('_id'));
-        $this->assertContains($label2->_id, $client->labels->pluck('_id'));
+        $this->assertContains($label->id, $client->labels->pluck('id'));
+        $this->assertContains($label2->id, $client->labels->pluck('id'));
     }
 
     public function testMorphToManySyncingMultipleIds(): void
@@ -792,11 +792,11 @@ class RelationsTest extends TestCase
         $label  = Label::query()->create(['name' => 'They all talk about karma, how it slowly comes']);
         $label2  = Label::query()->create(['name' => "But life is short, enjoy it while you're young"]);
 
-        $client->labels()->sync([$label->_id, $label2->_id]);
+        $client->labels()->sync([$label->id, $label2->id]);
 
         $this->assertEquals(2, $client->labels->count());
-        $this->assertContains($label->_id, $client->labels->pluck('_id'));
-        $this->assertContains($label2->_id, $client->labels->pluck('_id'));
+        $this->assertContains($label->id, $client->labels->pluck('id'));
+        $this->assertContains($label2->id, $client->labels->pluck('id'));
     }
 
     public function testMorphToManySyncingWithCustomKeys(): void
@@ -809,15 +809,15 @@ class RelationsTest extends TestCase
         $client->labelsWithCustomKeys()->sync([$label->clabel_id, $label2->clabel_id]);
 
         $this->assertEquals(2, $client->labelsWithCustomKeys->count());
-        $this->assertContains($label->_id, $client->labelsWithCustomKeys->pluck('_id'));
-        $this->assertContains($label2->_id, $client->labelsWithCustomKeys->pluck('_id'));
+        $this->assertContains($label->id, $client->labelsWithCustomKeys->pluck('id'));
+        $this->assertContains($label2->id, $client->labelsWithCustomKeys->pluck('id'));
 
         $client->labelsWithCustomKeys()->sync($label);
         $client->load('labelsWithCustomKeys');
 
         $this->assertEquals(1, $client->labelsWithCustomKeys->count());
-        $this->assertContains($label->_id, $client->labelsWithCustomKeys->pluck('_id'));
-        $this->assertNotContains($label2->_id, $client->labelsWithCustomKeys->pluck('_id'));
+        $this->assertContains($label->id, $client->labelsWithCustomKeys->pluck('id'));
+        $this->assertNotContains($label2->id, $client->labelsWithCustomKeys->pluck('id'));
     }
 
     public function testMorphToManyLoadAndRefreshing(): void
@@ -829,7 +829,7 @@ class RelationsTest extends TestCase
         $label  = Label::query()->create(['name' => 'The greatest gift is knowledge itself']);
         $label2  = Label::query()->create(['name' => "I made it here all by my lonely, no askin' for help"]);
 
-        $client->labels()->sync([$label->_id, $label2->_id]);
+        $client->labels()->sync([$label->id, $label2->id]);
         $client->users()->sync($user);
 
         $this->assertEquals(2, $client->labels->count());
@@ -842,11 +842,11 @@ class RelationsTest extends TestCase
 
         $this->assertEquals(2, $client->labels->count());
 
-        $check = Client::query()->find($client->_id);
+        $check = Client::query()->find($client->id);
 
         $this->assertEquals(2, $check->labels->count());
 
-        $check = Client::query()->with('labels')->find($client->_id);
+        $check = Client::query()->with('labels')->find($client->id);
 
         $this->assertEquals(2, $check->labels->count());
     }
@@ -860,7 +860,7 @@ class RelationsTest extends TestCase
         $label  = Label::query()->create(['name' => "I've been digging myself down deeper"]);
         $label2  = Label::query()->create(['name' => "I won't stop 'til I get where you are"]);
 
-        $client->labels()->sync([$label->_id, $label2->_id]);
+        $client->labels()->sync([$label->id, $label2->id]);
         $client2->labels()->sync($label);
 
         $this->assertEquals(2, $client->labels->count());
@@ -871,12 +871,12 @@ class RelationsTest extends TestCase
 
         $check = Client::query()->has('labels', '>', 1)->get();
         $this->assertCount(1, $check);
-        $this->assertContains($client->_id, $check->pluck('_id'));
+        $this->assertContains($client->id, $check->pluck('id'));
 
         $check = Client::query()->has('labels', '<', 2)->get();
         $this->assertCount(2, $check);
-        $this->assertContains($client2->_id, $check->pluck('_id'));
-        $this->assertContains($client3->_id, $check->pluck('_id'));
+        $this->assertContains($client2->id, $check->pluck('id'));
+        $this->assertContains($client3->id, $check->pluck('id'));
     }
 
     public function testMorphedByMany(): void
@@ -891,10 +891,10 @@ class RelationsTest extends TestCase
         $label->clients()->attach($client);
 
         $this->assertEquals(1, $label->users->count());
-        $this->assertContains($user->_id, $label->users->pluck('_id'));
+        $this->assertContains($user->id, $label->users->pluck('id'));
 
         $this->assertEquals(1, $label->clients->count());
-        $this->assertContains($client->_id, $label->clients->pluck('_id'));
+        $this->assertContains($client->id, $label->clients->pluck('id'));
     }
 
     public function testMorphedByManyAttachEloquentCollection(): void
@@ -908,8 +908,8 @@ class RelationsTest extends TestCase
         $label->clients()->attach(new Collection([$client1, $client2]));
 
         $this->assertEquals(2, $label->clients->count());
-        $this->assertContains($client1->_id, $label->clients->pluck('_id'));
-        $this->assertContains($client2->_id, $label->clients->pluck('_id'));
+        $this->assertContains($client1->id, $label->clients->pluck('id'));
+        $this->assertContains($client2->id, $label->clients->pluck('id'));
 
         $client1->refresh();
         $this->assertEquals(1, $client1->labels->count());
@@ -923,11 +923,11 @@ class RelationsTest extends TestCase
 
         $label  = Label::query()->create(['name' => 'Always in the game and never played by the rules']);
 
-        $label->clients()->attach([$client1->_id, $client2->_id]);
+        $label->clients()->attach([$client1->id, $client2->id]);
 
         $this->assertEquals(2, $label->clients->count());
-        $this->assertContains($client1->_id, $label->clients->pluck('_id'));
-        $this->assertContains($client2->_id, $label->clients->pluck('_id'));
+        $this->assertContains($client1->id, $label->clients->pluck('id'));
+        $this->assertContains($client2->id, $label->clients->pluck('id'));
 
         $client1->refresh();
         $this->assertEquals(1, $client1->labels->count());
@@ -941,15 +941,15 @@ class RelationsTest extends TestCase
 
         $label  = Label::query()->create(['name' => 'Seasons change and our love went cold']);
 
-        $label->clients()->attach([$client1->_id, $client2->_id]);
+        $label->clients()->attach([$client1->id, $client2->id]);
 
         $this->assertEquals(2, $label->clients->count());
 
-        $label->clients()->detach($client1->_id);
+        $label->clients()->detach($client1->id);
         $check = $label->withoutRelations();
 
         $this->assertEquals(1, $check->clients->count());
-        $this->assertContains($client2->_id, $check->clients->pluck('_id'));
+        $this->assertContains($client2->id, $check->clients->pluck('id'));
     }
 
     public function testMorphedByManyDetachingMultipleIds(): void
@@ -960,15 +960,15 @@ class RelationsTest extends TestCase
 
         $label  = Label::query()->create(['name' => "Run away, but we're running in circles"]);
 
-        $label->clients()->attach([$client1->_id, $client2->_id, $client3->_id]);
+        $label->clients()->attach([$client1->id, $client2->id, $client3->id]);
 
         $this->assertEquals(3, $label->clients->count());
 
-        $label->clients()->detach([$client1->_id, $client2->_id]);
+        $label->clients()->detach([$client1->id, $client2->id]);
         $label->load('clients');
 
         $this->assertEquals(1, $label->clients->count());
-        $this->assertContains($client3->_id, $label->clients->pluck('_id'));
+        $this->assertContains($client3->id, $label->clients->pluck('id'));
     }
 
     public function testMorphedByManySyncing(): void
@@ -984,9 +984,9 @@ class RelationsTest extends TestCase
         $label->clients()->sync($client3, false);
 
         $this->assertEquals(3, $label->clients->count());
-        $this->assertContains($client1->_id, $label->clients->pluck('_id'));
-        $this->assertContains($client2->_id, $label->clients->pluck('_id'));
-        $this->assertContains($client3->_id, $label->clients->pluck('_id'));
+        $this->assertContains($client1->id, $label->clients->pluck('id'));
+        $this->assertContains($client2->id, $label->clients->pluck('id'));
+        $this->assertContains($client3->id, $label->clients->pluck('id'));
     }
 
     public function testMorphedByManySyncingEloquentCollection(): void
@@ -1000,10 +1000,10 @@ class RelationsTest extends TestCase
         $label->clients()->sync(new Collection([$client1, $client2]));
 
         $this->assertEquals(2, $label->clients->count());
-        $this->assertContains($client1->_id, $label->clients->pluck('_id'));
-        $this->assertContains($client2->_id, $label->clients->pluck('_id'));
+        $this->assertContains($client1->id, $label->clients->pluck('id'));
+        $this->assertContains($client2->id, $label->clients->pluck('id'));
 
-        $this->assertNotContains($extra->_id, $label->clients->pluck('_id'));
+        $this->assertNotContains($extra->id, $label->clients->pluck('id'));
     }
 
     public function testMorphedByManySyncingMultipleIds(): void
@@ -1014,13 +1014,13 @@ class RelationsTest extends TestCase
 
         $label  = Label::query()->create(['name' => "Love ain't patient, it's not kind. true love waits to rob you blind"]);
 
-        $label->clients()->sync([$client1->_id, $client2->_id]);
+        $label->clients()->sync([$client1->id, $client2->id]);
 
         $this->assertEquals(2, $label->clients->count());
-        $this->assertContains($client1->_id, $label->clients->pluck('_id'));
-        $this->assertContains($client2->_id, $label->clients->pluck('_id'));
+        $this->assertContains($client1->id, $label->clients->pluck('id'));
+        $this->assertContains($client2->id, $label->clients->pluck('id'));
 
-        $this->assertNotContains($extra->_id, $label->clients->pluck('_id'));
+        $this->assertNotContains($extra->id, $label->clients->pluck('id'));
     }
 
     public function testMorphedByManySyncingWithCustomKeys(): void
@@ -1034,19 +1034,19 @@ class RelationsTest extends TestCase
         $label->clientsWithCustomKeys()->sync([$client1->cclient_id, $client2->cclient_id]);
 
         $this->assertEquals(2, $label->clientsWithCustomKeys->count());
-        $this->assertContains($client1->_id, $label->clientsWithCustomKeys->pluck('_id'));
-        $this->assertContains($client2->_id, $label->clientsWithCustomKeys->pluck('_id'));
+        $this->assertContains($client1->id, $label->clientsWithCustomKeys->pluck('id'));
+        $this->assertContains($client2->id, $label->clientsWithCustomKeys->pluck('id'));
 
-        $this->assertNotContains($client3->_id, $label->clientsWithCustomKeys->pluck('_id'));
+        $this->assertNotContains($client3->id, $label->clientsWithCustomKeys->pluck('id'));
 
         $label->clientsWithCustomKeys()->sync($client3);
         $label->load('clientsWithCustomKeys');
 
         $this->assertEquals(1, $label->clientsWithCustomKeys->count());
-        $this->assertNotContains($client1->_id, $label->clientsWithCustomKeys->pluck('_id'));
-        $this->assertNotContains($client2->_id, $label->clientsWithCustomKeys->pluck('_id'));
+        $this->assertNotContains($client1->id, $label->clientsWithCustomKeys->pluck('id'));
+        $this->assertNotContains($client2->id, $label->clientsWithCustomKeys->pluck('id'));
 
-        $this->assertContains($client3->_id, $label->clientsWithCustomKeys->pluck('_id'));
+        $this->assertContains($client3->id, $label->clientsWithCustomKeys->pluck('id'));
     }
 
     public function testMorphedByManyLoadAndRefreshing(): void
@@ -1072,11 +1072,11 @@ class RelationsTest extends TestCase
 
         $this->assertEquals(3, $label->clients->count());
 
-        $check = Label::query()->find($label->_id);
+        $check = Label::query()->find($label->id);
 
         $this->assertEquals(3, $check->clients->count());
 
-        $check = Label::query()->with('clients')->find($label->_id);
+        $check = Label::query()->with('clients')->find($label->id);
 
         $this->assertEquals(3, $check->clients->count());
     }
@@ -1100,16 +1100,16 @@ class RelationsTest extends TestCase
 
         $check = Label::query()->has('clients')->get();
         $this->assertCount(2, $check);
-        $this->assertContains($label->_id, $check->pluck('_id'));
-        $this->assertContains($label2->_id, $check->pluck('_id'));
+        $this->assertContains($label->id, $check->pluck('id'));
+        $this->assertContains($label2->id, $check->pluck('id'));
 
         $check = Label::query()->has('users')->get();
         $this->assertCount(1, $check);
-        $this->assertContains($label3->_id, $check->pluck('_id'));
+        $this->assertContains($label3->id, $check->pluck('id'));
 
         $check = Label::query()->has('clients', '>', 1)->get();
         $this->assertCount(1, $check);
-        $this->assertContains($label->_id, $check->pluck('_id'));
+        $this->assertContains($label->id, $check->pluck('id'));
     }
 
     public function testHasManyHas(): void
@@ -1219,18 +1219,18 @@ class RelationsTest extends TestCase
         $author->books()->save($book);
         $author->save();
         $this->assertEquals(1, $author->books()->count());
-        $this->assertEquals($author->_id, $book->author_id);
+        $this->assertEquals($author->id, $book->author_id);
 
         $author = User::where('name', 'George R. R. Martin')->first();
         $book   = Book::where('title', 'A Game of Thrones')->first();
         $this->assertEquals(1, $author->books()->count());
-        $this->assertEquals($author->_id, $book->author_id);
+        $this->assertEquals($author->id, $book->author_id);
 
         $author->books()->save($book);
         $author->books()->save($book);
         $author->save();
         $this->assertEquals(1, $author->books()->count());
-        $this->assertEquals($author->_id, $book->author_id);
+        $this->assertEquals($author->id, $book->author_id);
     }
 
     public function testDoubleSaveManyToMany(): void
@@ -1243,29 +1243,29 @@ class RelationsTest extends TestCase
         $user->save();
 
         $this->assertEquals(1, $user->clients()->count());
-        $this->assertEquals([$user->_id], $client->user_ids);
-        $this->assertEquals([$client->_id], $user->client_ids);
+        $this->assertEquals([$user->id], $client->user_ids);
+        $this->assertEquals([$client->id], $user->client_ids);
 
         $user   = User::where('name', 'John Doe')->first();
         $client = Client::where('name', 'Admins')->first();
         $this->assertEquals(1, $user->clients()->count());
-        $this->assertEquals([$user->_id], $client->user_ids);
-        $this->assertEquals([$client->_id], $user->client_ids);
+        $this->assertEquals([$user->id], $client->user_ids);
+        $this->assertEquals([$client->id], $user->client_ids);
 
         $user->clients()->save($client);
         $user->clients()->save($client);
         $user->save();
         $this->assertEquals(1, $user->clients()->count());
-        $this->assertEquals([$user->_id], $client->user_ids);
-        $this->assertEquals([$client->_id], $user->client_ids);
+        $this->assertEquals([$user->id], $client->user_ids);
+        $this->assertEquals([$client->id], $user->client_ids);
     }
 
     public function testWhereBelongsTo()
     {
         $user = User::create(['name' => 'John Doe']);
-        Item::create(['user_id' => $user->_id]);
-        Item::create(['user_id' => $user->_id]);
-        Item::create(['user_id' => $user->_id]);
+        Item::create(['user_id' => $user->id]);
+        Item::create(['user_id' => $user->id]);
+        Item::create(['user_id' => $user->id]);
         Item::create(['user_id' => null]);
 
         $items = Item::whereBelongsTo($user)->get();

--- a/tests/SessionTest.php
+++ b/tests/SessionTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace MongoDB\Laravel\Tests;
+
+use Illuminate\Session\DatabaseSessionHandler;
+use Illuminate\Support\Facades\DB;
+
+class SessionTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        DB::connection('mongodb')->getCollection('sessions')->drop();
+
+        parent::tearDown();
+    }
+
+    public function testDatabaseSessionHandler()
+    {
+        $sessionId = '123';
+
+        $handler = new DatabaseSessionHandler(
+            $this->app['db']->connection('mongodb'),
+            'sessions',
+            10,
+        );
+
+        $handler->write($sessionId, 'foo');
+        $this->assertEquals('foo', $handler->read($sessionId));
+
+        $handler->write($sessionId, 'bar');
+        $this->assertEquals('bar', $handler->read($sessionId));
+    }
+}

--- a/tests/Ticket/GH2489Test.php
+++ b/tests/Ticket/GH2489Test.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Laravel\Tests\Ticket;
+
+use MongoDB\Laravel\Tests\Models\Location;
+use MongoDB\Laravel\Tests\TestCase;
+
+/** @see https://github.com/mongodb/laravel-mongodb/issues/2783 */
+class GH2489Test extends TestCase
+{
+    public function tearDown(): void
+    {
+        Location::truncate();
+    }
+
+    public function testQuerySubdocumentsUsingWhereInId()
+    {
+        Location::insert([
+            [
+                'name' => 'Location 1',
+                'images' => [
+                    ['_id' => 1, 'uri' => 'image1.jpg'],
+                    ['_id' => 2, 'uri' => 'image2.jpg'],
+                ],
+            ],
+            [
+                'name' => 'Location 2',
+                'images' => [
+                    ['_id' => 3, 'uri' => 'image3.jpg'],
+                    ['_id' => 4, 'uri' => 'image4.jpg'],
+                ],
+            ],
+        ]);
+
+        // With _id
+        $results = Location::whereIn('images._id', [1])->get();
+
+        $this->assertCount(1, $results);
+        $this->assertSame('Location 1', $results->first()->name);
+
+        // With id
+        $results = Location::whereIn('images.id', [1])->get();
+
+        $this->assertCount(1, $results);
+        $this->assertSame('Location 1', $results->first()->name);
+    }
+}

--- a/tests/Ticket/GH2783Test.php
+++ b/tests/Ticket/GH2783Test.php
@@ -32,7 +32,7 @@ class GH2783Test extends TestCase
 
         $queriedImageWithPost = GH2783Image::with('imageable')->find($imageWithPost->getKey());
         $this->assertInstanceOf(GH2783Post::class, $queriedImageWithPost->imageable);
-        $this->assertEquals($post->_id, $queriedImageWithPost->imageable->getKey());
+        $this->assertEquals($post->id, $queriedImageWithPost->imageable->getKey());
 
         $queriedImageWithUser = GH2783Image::with('imageable')->find($imageWithUser->getKey());
         $this->assertInstanceOf(GH2783User::class, $queriedImageWithUser->imageable);

--- a/tests/TransactionTest.php
+++ b/tests/TransactionTest.php
@@ -44,7 +44,7 @@ class TransactionTest extends TestCase
         $this->assertTrue($klinson->exists);
         $this->assertEquals('klinson', $klinson->name);
 
-        $check = User::find($klinson->_id);
+        $check = User::find($klinson->id);
         $this->assertInstanceOf(User::class, $check);
         $this->assertEquals($klinson->name, $check->name);
     }
@@ -60,7 +60,7 @@ class TransactionTest extends TestCase
         $this->assertTrue($klinson->exists);
         $this->assertEquals('klinson', $klinson->name);
 
-        $this->assertFalse(User::where('_id', $klinson->_id)->exists());
+        $this->assertFalse(User::where('id', $klinson->id)->exists());
     }
 
     public function testInsertWithCommit(): void
@@ -93,7 +93,7 @@ class TransactionTest extends TestCase
         $this->assertTrue($klinson->exists);
         $this->assertNotNull($klinson->getIdAttribute());
 
-        $check = User::find($klinson->_id);
+        $check = User::find($klinson->id);
         $this->assertInstanceOf(User::class, $check);
         $this->assertEquals($check->name, $klinson->name);
     }
@@ -110,7 +110,7 @@ class TransactionTest extends TestCase
         $this->assertTrue($klinson->exists);
         $this->assertNotNull($klinson->getIdAttribute());
 
-        $this->assertFalse(User::where('_id', $klinson->_id)->exists());
+        $this->assertFalse(User::where('id', $klinson->id)->exists());
     }
 
     public function testInsertGetIdWithCommit(): void
@@ -132,7 +132,7 @@ class TransactionTest extends TestCase
         DB::rollBack();
 
         $this->assertInstanceOf(ObjectId::class, $userId);
-        $this->assertFalse(DB::table('users')->where('_id', (string) $userId)->exists());
+        $this->assertFalse(DB::table('users')->where('id', (string) $userId)->exists());
     }
 
     public function testUpdateWithCommit(): void
@@ -176,8 +176,8 @@ class TransactionTest extends TestCase
         $this->assertEquals(21, $klinson->age);
         $this->assertEquals(39, $alcaeus->age);
 
-        $this->assertTrue(User::where('_id', $klinson->_id)->where('age', 21)->exists());
-        $this->assertTrue(User::where('_id', $alcaeus->_id)->where('age', 39)->exists());
+        $this->assertTrue(User::where('id', $klinson->id)->where('age', 21)->exists());
+        $this->assertTrue(User::where('id', $alcaeus->id)->where('age', 39)->exists());
     }
 
     public function testEloquentUpdateWithRollBack(): void
@@ -197,8 +197,8 @@ class TransactionTest extends TestCase
         $this->assertEquals(21, $klinson->age);
         $this->assertEquals(39, $alcaeus->age);
 
-        $this->assertFalse(User::where('_id', $klinson->_id)->where('age', 21)->exists());
-        $this->assertFalse(User::where('_id', $alcaeus->_id)->where('age', 39)->exists());
+        $this->assertFalse(User::where('id', $klinson->id)->where('age', 21)->exists());
+        $this->assertFalse(User::where('id', $alcaeus->id)->where('age', 39)->exists());
     }
 
     public function testDeleteWithCommit(): void
@@ -234,7 +234,7 @@ class TransactionTest extends TestCase
         $klinson->delete();
         DB::commit();
 
-        $this->assertFalse(User::where('_id', $klinson->_id)->exists());
+        $this->assertFalse(User::where('id', $klinson->id)->exists());
     }
 
     public function testEloquentDeleteWithRollBack(): void
@@ -246,7 +246,7 @@ class TransactionTest extends TestCase
         $klinson->delete();
         DB::rollBack();
 
-        $this->assertTrue(User::where('_id', $klinson->_id)->exists());
+        $this->assertTrue(User::where('id', $klinson->id)->exists());
     }
 
     public function testIncrementWithCommit(): void
@@ -390,7 +390,7 @@ class TransactionTest extends TestCase
 
         $this->assertSame(2, $timesRun);
 
-        $check = User::find($klinson->_id);
+        $check = User::find($klinson->id);
         $this->assertInstanceOf(User::class, $check);
 
         // Age is expected to be 24: the callback is executed twice, incrementing age by 2 every time


### PR DESCRIPTION
Fix PHPORM-147
Fix https://github.com/mongodb/laravel-mongodb/issues/3022 (PHPORM-201)
Fix https://github.com/mongodb/laravel-mongodb/issues/2489

Laravel and Eloquent uses `id` as conventional field name for models and various queries. MongoDB's primary key is called `_id`. The name is source of various issues with Laravel packages:

- `DatabaseSessionHandler` https://github.com/mongodb/laravel-mongodb/issues/3022#issuecomment-2220068550
- User email validation https://github.com/laravel/breeze/pull/357

Breaking change: it is no longer possible to set a different value for `id` and `_id`. If you need a distinct ID field, use an other name.

### Checklist

- [x] Add tests and ensure they pass
- [x] Add an entry to the CHANGELOG.md file
- [ ] Update documentation for new features
