### PR TITLE
Implement `Connection::getServerVersion`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [4.9.0] - coming soon
+
+* Add `Connection::getServerVersion()` by @GromNaN in [#3043](https://github.com/mongodb/laravel-mongodb/pull/3043)
+
 ## [4.6.0] - 2024-07-09
 
 * Add `DocumentModel` trait to use any 3rd party model with MongoDB @GromNaN in [#2580](https://github.com/mongodb/laravel-mongodb/pull/2580)

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -327,6 +327,11 @@ class Connection extends BaseConnection
         return $this->db->$method(...$parameters);
     }
 
+    public function getServerVersion(): string
+    {
+        return $this->db->command(['buildInfo' => 1])->toArray()[0]['version'];
+    }
+
     private static function getVersion(): string
     {
         return self::$version ?? self::lookupVersion();

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -327,6 +327,12 @@ class Connection extends BaseConnection
         return $this->db->$method(...$parameters);
     }
 
+    /**
+     * Return the server version of one of the MongoDB servers: primary for
+     * replica sets and standalone, and the selected server for sharded clusters.
+     *
+     * @internal
+     */
     public function getServerVersion(): string
     {
         return $this->db->command(['buildInfo' => 1])->toArray()[0]['version'];

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -299,4 +299,10 @@ class ConnectionTest extends TestCase
         $instance = new Connection($config);
         $instance->ping();
     }
+
+    public function testServerVersion()
+    {
+        $version = DB::connection('mongodb')->getServerVersion();
+        $this->assertIsString($version);
+    }
 }


### PR DESCRIPTION
Fix [PHPORM-213](https://jira.mongodb.org/browse/PHPORM-213)

This method is used by the [command `db:show`](https://github.com/laravel/framework/blob/60d780f3aa96e28a4a1cbeb75c6514eb6bc58871/src/Illuminate/Database/Console/ShowCommand.php#L49). It was added in Laravel 11 by https://github.com/laravel/framework/pull/48864

The value looks like `7.0.11`, similar to what is returned for SQL databases.

### Checklist

- [x] Add tests and ensure they pass
- [x] Add an entry to the CHANGELOG.md file
- [ ] Update documentation for new features
