### PR TITLE
PHPORM-214 Implement `Schema\Builder::getTables`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [4.9.0] - coming soon
 
 * Add `Connection::getServerVersion()` by @GromNaN in [#3043](https://github.com/mongodb/laravel-mongodb/pull/3043)
+* Add `Schema\Builder::getTables()` and `getTableListing` by @GromNaN in [#3044](https://github.com/mongodb/laravel-mongodb/pull/3044)
 
 ## [4.6.0] - 2024-07-09
 

--- a/src/Schema/Builder.php
+++ b/src/Schema/Builder.php
@@ -114,14 +114,14 @@ class Builder extends \Illuminate\Database\Schema\Builder
         $db = $this->connection->getMongoDB();
         $collections = [];
 
-        foreach ($db->listCollections() as $collectionInfos) {
-            $stats = $db->selectCollection($collectionInfos->getName())->aggregate([
+        foreach ($db->listCollectionNames() as $collectionName) {
+            $stats = $db->selectCollection($collectionName)->aggregate([
                 ['$collStats' => ['storageStats' => ['scale' => 1]]],
                 ['$project' => ['storageStats.totalSize' => 1]],
             ])->toArray();
 
             $collections[] = [
-                'name' => $collectionInfos->getName(),
+                'name' => $collectionName,
                 'schema' => null,
                 'size' => $stats[0]?->storageStats?->totalSize ?? null,
                 'comment' => null,
@@ -139,12 +139,7 @@ class Builder extends \Illuminate\Database\Schema\Builder
 
     public function getTableListing()
     {
-        $db = $this->connection->getMongoDB();
-        $collections = [];
-
-        foreach ($db->listCollections() as $collectionInfos) {
-            $collections[] = $collectionInfos->getName();
-        }
+        $collections = iterator_to_array($this->connection->getMongoDB()->listCollectionNames());
 
         sort($collections);
 


### PR DESCRIPTION
Fix [PHPORM-214](https://jira.mongodb.org/browse/PHPORM-214)

This method is used by the [command db:show](https://github.com/laravel/framework/blob/60d780f3aa96e28a4a1cbeb75c6514eb6bc58871/src/Illuminate/Database/Console/ShowCommand.php#L77).

Example of output:
```
 php artisan db:show -vvv

   .............................................................................................. 7.0.11  
  Database ..................................................................................... laravel  
  Host .................................................................................................  
  Port .................................................................................................  
  Username .............................................................................................  
  URL ..................................................................................................  
  Open Connections .....................................................................................  
  Tables ............................................................................................ 19  
  Total Size ................................................................................. 268.00 KB  

  Table ........................................................................................... Size  
  admin_menu  .................................................................................. 8.00 KB  
  admin_operation_log  ........................................................................ 12.00 KB  
  admin_permissions  .......................................................................... 16.00 KB  
  admin_role_menu  ............................................................................ 12.00 KB  
  admin_role_permissions  ..................................................................... 12.00 KB  
  admin_role_users  ........................................................................... 12.00 KB  
  admin_roles  ................................................................................ 16.00 KB  
  admin_user_permissions  ..................................................................... 12.00 KB  
  admin_users  ................................................................................ 12.00 KB  
  cache  ...................................................................................... 12.00 KB  
  cache_locks  ................................................................................ 12.00 KB  
  failed_jobs  ................................................................................ 12.00 KB  
  job_batches  ................................................................................ 12.00 KB  
  jobs  ....................................................................................... 12.00 KB  
  migrations  ................................................................................. 40.00 KB  
  password_reset_tokens  ...................................................................... 12.00 KB  
  personal_access_tokens  ..................................................................... 16.00 KB  
  sessions  ................................................................................... 16.00 KB  
  users  ...................................................................................... 12.00 KB  


```

### Checklist

- [x] Add tests and ensure they pass
- [x] Add an entry to the CHANGELOG.md file
- [ ] Update documentation for new features
