### PR TITLE
DOCSP-41472: txn learning byte link

### DIFF
--- a/docs/transactions.txt
+++ b/docs/transactions.txt
@@ -46,6 +46,12 @@ Learn how to perform transactions in the following sections of this guide:
 - :ref:`laravel-transaction-commit`
 - :ref:`laravel-transaction-rollback`
 
+.. tip:: Transactions Learning Byte
+
+   You practice using {+odm-short+} to perform transactions
+   in the `Laravel Transactions Learning Byte
+   <https://learn.mongodb.com/courses/laravel-transactions>`__.
+
 .. tip::
 
    To learn more about transactions in MongoDB, see :manual:`Transactions </core/transactions/>`
@@ -156,4 +162,3 @@ transaction is rolled back, and none of the models are updated:
    :emphasize-lines: 1,18,20
    :start-after: begin rollback transaction
    :end-before: end rollback transaction
-

--- a/docs/transactions.txt
+++ b/docs/transactions.txt
@@ -51,7 +51,7 @@ This guide contains the following sections:
 
 .. tip:: Transactions Learning Byte
 
-   You practice using {+odm-short+} to perform transactions
+   Practice using {+odm-short+} to perform transactions
    in the `Laravel Transactions Learning Byte
    <https://learn.mongodb.com/courses/laravel-transactions>`__.
 

--- a/docs/transactions.txt
+++ b/docs/transactions.txt
@@ -39,7 +39,10 @@ Multi-document transactions are **ACID compliant** because MongoDB
 guarantees that the data in your transaction operations remains consistent,
 even if the driver encounters unexpected errors.
 
-Learn how to perform transactions in the following sections of this guide:
+To learn more about transactions in MongoDB, see :manual:`Transactions </core/transactions/>`
+in the {+server-docs-name+}.
+
+This guide contains the following sections:
 
 - :ref:`laravel-transaction-requirements`
 - :ref:`laravel-transaction-callback`
@@ -51,11 +54,6 @@ Learn how to perform transactions in the following sections of this guide:
    You practice using {+odm-short+} to perform transactions
    in the `Laravel Transactions Learning Byte
    <https://learn.mongodb.com/courses/laravel-transactions>`__.
-
-.. tip::
-
-   To learn more about transactions in MongoDB, see :manual:`Transactions </core/transactions/>`
-   in the {+server-docs-name+}.
 
 .. _laravel-transaction-requirements:
 


### PR DESCRIPTION
**Adds a link to the Laravel Txn learning byte**
https://jira.mongodb.org/browse/DOCSP-41472

[STAGING](https://preview-mongodbrustagir.gatsbyjs.io/laravel/DOCSP-41472-txn-learning-byte/transactions/)

### Checklist

- [ ] Add tests and ensure they pass (not needed)
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Update documentation for new features
