### PR TITLE
PHPORM-114 Implement `Builder::upsert`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,11 @@ All notable changes to this project will be documented in this file.
 
 ## [4.7.0] - coming soon
 
+* Add `Query\Builder::upsert()` method by @GromNaN in [#3052](https://github.com/mongodb/laravel-mongodb/pull/3052)
 * Add `Connection::getServerVersion()` by @GromNaN in [#3043](https://github.com/mongodb/laravel-mongodb/pull/3043)
 * Add `Schema\Builder::getTables()` and `getTableListing()` by @GromNaN in [#3044](https://github.com/mongodb/laravel-mongodb/pull/3044)
 * Add `Schema\Builder::getColumns()` and `getIndexes()` by @GromNaN in [#3045](https://github.com/mongodb/laravel-mongodb/pull/3045)
-* Add `Schema\Builder::hasColumn` and `hasColumns` method by @Alex-Belyi in [#3002](https://github.com/mongodb/laravel-mongodb/pull/3001)
+* Add `Schema\Builder::hasColumn` and `hasColumns` method by @Alex-Belyi in [#3001](https://github.com/mongodb/laravel-mongodb/pull/3001)
 
 ## [4.6.0] - 2024-07-09
 

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -735,7 +735,6 @@ class Builder extends BaseBuilder
         $this->applyBeforeQueryCallbacks();
 
         $options = $this->inheritConnectionOptions();
-        $options['upsert'] = true;
         $uniqueBy = array_fill_keys((array) $uniqueBy, 1);
 
         // If no update fields are specified, all fields are updated

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -752,7 +752,7 @@ class Builder extends BaseBuilder
                     $filter[$key] = $val;
                 }
 
-                if ($update === null || isset($update[$key])) {
+                if ($update === null || array_key_exists($key, $update)) {
                     $operation['$set'][$key] = $val;
                 } else {
                     $operation['$setOnInsert'][$key] = $val;

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -145,7 +145,6 @@ class ModelTest extends TestCase
 
     public function testUpsert()
     {
-
         $result = User::upsert([
             ['email' => 'foo', 'name' => 'bar'],
             ['name' => 'bar2', 'email' => 'foo2'],

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -145,7 +145,6 @@ class ModelTest extends TestCase
 
     public function testUpsert()
     {
-        //$user = User::upsert(['name' => 'John Doe'], ['name' => 'John Doe', 'title' => 'admin', 'age' => 35]);
 
         $result = User::upsert([
             ['email' => 'foo', 'name' => 'bar'],

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -143,6 +143,42 @@ class ModelTest extends TestCase
         $this->assertEquals('Hans Thomas', $check->fullname);
     }
 
+    public function testUpsert()
+    {
+        //$user = User::upsert(['name' => 'John Doe'], ['name' => 'John Doe', 'title' => 'admin', 'age' => 35]);
+
+        $result = User::upsert([
+            ['email' => 'foo', 'name' => 'bar'],
+            ['name' => 'bar2', 'email' => 'foo2'],
+        ], ['email']);
+
+        $this->assertSame(2, $result);
+
+        $this->assertSame(2, $result);
+        $this->assertSame(2, User::count());
+        $this->assertSame('bar', User::where('email', 'foo')->first()->name);
+
+        // Update 1 document
+        $result = User::upsert([
+            ['email' => 'foo', 'name' => 'bar2'],
+            ['name' => 'bar2', 'email' => 'foo2'],
+        ], 'email', ['name']);
+
+        // Even if the same value is set for the 2nd document, the "updated_at" field is updated
+        $this->assertSame(2, $result);
+        $this->assertSame(2, User::count());
+        $this->assertSame('bar2', User::where('email', 'foo')->first()->name);
+
+        // If no update fields are specified, all fields are updated
+        $result = User::upsert([
+            ['email' => 'foo', 'name' => 'bar3'],
+        ], 'email');
+
+        $this->assertSame(1, $result);
+        $this->assertSame(2, User::count());
+        $this->assertSame('bar3', User::where('email', 'foo')->first()->name);
+    }
+
     public function testManualStringId(): void
     {
         $user        = new User();


### PR DESCRIPTION
Fix PHPORM-114

Laravel documentation for this method: https://laravel.com/docs/11.x/eloquent#upserts

Unlike `createOrFirst` and `firstOrCreate`, there is no event triggered on the model by this operation. So we can use MongoDB's bulk write operation to perform multiple upserts in a single command.

### Checklist

- [x] Add tests and ensure they pass
- [x] Add an entry to the CHANGELOG.md file
- [ ] Update documentation for new features
