### PR TITLE
PHPORM-219 Deprecate `Connection::collection()` and `Schema::collection()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [4.8.0] - next
 
 * Add `Query\Builder::incrementEach()` and `decrementEach()` methods by @SmallRuralDog in [#2550](https://github.com/mongodb/laravel-mongodb/pull/2550)
+* Deprecate `Connection::collection()` and `Schema\Builder::collection()` methods by @GromNaN in [#3062](https://github.com/mongodb/laravel-mongodb/pull/3062)
 
 ## [4.7.0] - 2024-07-19
 

--- a/docs/fundamentals/database-collection.txt
+++ b/docs/fundamentals/database-collection.txt
@@ -56,7 +56,7 @@ create a database connection to the ``animals`` database in the
 
 .. code-block:: php
    :emphasize-lines: 1,8
-   
+
    'default' => 'mongodb',
 
    'connections' => [
@@ -77,7 +77,7 @@ The following example shows how to specify multiple database connections
 ``plants`` databases:
 
 .. code-block:: php
-   
+
    'connections' => [
 
        'mongodb' => [
@@ -149,19 +149,19 @@ If you are unable to accomplish your operation by using an Eloquent
 model, you can access the query builder by calling the ``collection()``
 method on the ``DB`` facade. The following example shows the same query
 as in the preceding example, but the query is constructed by using the
-``DB::collection()`` method:
+``DB::table()`` method:
 
 .. code-block:: php
 
    DB::connection('mongodb')
-       ->collection('flowers')
+       ->table('flowers')
        ->where('name', 'Water Lily')
        ->get()
 
 List Collections
 ----------------
 
-To see information about each of the collections in a database, call the 
+To see information about each of the collections in a database, call the
 ``listCollections()`` method.
 
 The following example accesses a database connection, then

--- a/docs/fundamentals/database-collection.txt
+++ b/docs/fundamentals/database-collection.txt
@@ -145,8 +145,14 @@ Laravel retrieves results from the ``flowers`` collection:
 
    Flower::where('name', 'Water Lily')->get()
 
+.. note::
+
+   Starting in {+odm-short+} v4.8, the ``DB::collection()`` method
+   is deprecated. As shown in the following example, you can use the ``DB::table()``
+   method to access a MongoDB collection.
+
 If you are unable to accomplish your operation by using an Eloquent
-model, you can access the query builder by calling the ``collection()``
+model, you can access the query builder by calling the ``table()``
 method on the ``DB`` facade. The following example shows the same query
 as in the preceding example, but the query is constructed by using the
 ``DB::table()`` method:

--- a/docs/includes/query-builder/QueryBuilderTest.php
+++ b/docs/includes/query-builder/QueryBuilderTest.php
@@ -21,7 +21,7 @@ class QueryBuilderTest extends TestCase
         parent::setUp();
 
         $db = DB::connection('mongodb');
-        $db->collection('movies')
+        $db->table('movies')
             ->insert(json_decode(file_get_contents(__DIR__ . '/sample_mflix.movies.json'), true));
     }
 
@@ -29,10 +29,10 @@ class QueryBuilderTest extends TestCase
     {
         $db = DB::connection('mongodb');
 
-        $db->collection('theaters')
+        $db->table('theaters')
             ->insert(json_decode(file_get_contents(__DIR__ . '/sample_mflix.theaters.json'), true));
 
-        $db->collection('theaters')
+        $db->table('theaters')
             ->raw()
             ->createIndex(['location.geo' => '2dsphere']);
     }
@@ -40,8 +40,8 @@ class QueryBuilderTest extends TestCase
     protected function tearDown(): void
     {
         $db = DB::connection('mongodb');
-        $db->collection('movies')->raw()->drop();
-        $db->collection('theaters')->raw()->drop();
+        $db->table('movies')->raw()->drop();
+        $db->table('theaters')->raw()->drop();
 
         parent::tearDown();
     }
@@ -50,7 +50,7 @@ class QueryBuilderTest extends TestCase
     {
         // begin query where
         $result = DB::connection('mongodb')
-            ->collection('movies')
+            ->table('movies')
             ->where('imdb.rating', 9.3)
             ->get();
         // end query where
@@ -62,7 +62,7 @@ class QueryBuilderTest extends TestCase
     {
         // begin query orWhere
         $result = DB::connection('mongodb')
-            ->collection('movies')
+            ->table('movies')
             ->where('year', 1955)
             ->orWhere('title', 'Back to the Future')
             ->get();
@@ -75,7 +75,7 @@ class QueryBuilderTest extends TestCase
     {
         // begin query andWhere
         $result = DB::connection('mongodb')
-            ->collection('movies')
+            ->table('movies')
             ->where('imdb.rating', '>', 8.5)
             ->where('year', '<', 1940)
             ->get();
@@ -88,7 +88,7 @@ class QueryBuilderTest extends TestCase
     {
         // begin query whereNot
         $result = DB::connection('mongodb')
-            ->collection('movies')
+            ->table('movies')
             ->whereNot('imdb.rating', '>', 2)
             ->get();
         // end query whereNot
@@ -100,7 +100,7 @@ class QueryBuilderTest extends TestCase
     {
         // begin query nestedLogical
         $result = DB::connection('mongodb')
-            ->collection('movies')
+            ->table('movies')
             ->where('imdb.rating', '>', 8.5)
             ->where(function (Builder $query) {
                 return $query
@@ -116,7 +116,7 @@ class QueryBuilderTest extends TestCase
     {
         // begin query whereBetween
         $result = DB::connection('mongodb')
-            ->collection('movies')
+            ->table('movies')
             ->whereBetween('imdb.rating', [9, 9.5])
             ->get();
         // end query whereBetween
@@ -128,7 +128,7 @@ class QueryBuilderTest extends TestCase
     {
         // begin query whereNull
         $result = DB::connection('mongodb')
-            ->collection('movies')
+            ->table('movies')
             ->whereNull('runtime')
             ->get();
         // end query whereNull
@@ -139,7 +139,7 @@ class QueryBuilderTest extends TestCase
     public function testWhereIn(): void
     {
         // begin query whereIn
-        $result = DB::collection('movies')
+        $result = DB::table('movies')
             ->whereIn('title', ['Toy Story', 'Shrek 2', 'Johnny English'])
             ->get();
         // end query whereIn
@@ -151,7 +151,7 @@ class QueryBuilderTest extends TestCase
     {
         // begin query whereDate
         $result = DB::connection('mongodb')
-            ->collection('movies')
+            ->table('movies')
             ->whereDate('released', '2010-1-15')
             ->get();
         // end query whereDate
@@ -162,7 +162,7 @@ class QueryBuilderTest extends TestCase
     public function testLike(): void
     {
         // begin query like
-        $result = DB::collection('movies')
+        $result = DB::table('movies')
             ->where('title', 'like', '%spider_man%')
             ->get();
         // end query like
@@ -173,7 +173,7 @@ class QueryBuilderTest extends TestCase
     public function testDistinct(): void
     {
         // begin query distinct
-        $result = DB::collection('movies')
+        $result = DB::table('movies')
             ->distinct('year')->get();
         // end query distinct
 
@@ -183,7 +183,7 @@ class QueryBuilderTest extends TestCase
     public function testGroupBy(): void
     {
         // begin query groupBy
-        $result = DB::collection('movies')
+        $result = DB::table('movies')
            ->where('rated', 'G')
            ->groupBy('runtime')
            ->orderBy('runtime', 'asc')
@@ -196,7 +196,7 @@ class QueryBuilderTest extends TestCase
     public function testAggCount(): void
     {
         // begin aggregation count
-        $result = DB::collection('movies')
+        $result = DB::table('movies')
             ->count();
         // end aggregation count
 
@@ -206,7 +206,7 @@ class QueryBuilderTest extends TestCase
     public function testAggMax(): void
     {
         // begin aggregation max
-        $result = DB::collection('movies')
+        $result = DB::table('movies')
             ->max('runtime');
         // end aggregation max
 
@@ -216,7 +216,7 @@ class QueryBuilderTest extends TestCase
     public function testAggMin(): void
     {
         // begin aggregation min
-        $result = DB::collection('movies')
+        $result = DB::table('movies')
             ->min('year');
         // end aggregation min
 
@@ -226,7 +226,7 @@ class QueryBuilderTest extends TestCase
     public function testAggAvg(): void
     {
         // begin aggregation avg
-        $result = DB::collection('movies')
+        $result = DB::table('movies')
             ->avg('imdb.rating');
         // end aggregation avg
 
@@ -236,7 +236,7 @@ class QueryBuilderTest extends TestCase
     public function testAggSum(): void
     {
         // begin aggregation sum
-        $result = DB::collection('movies')
+        $result = DB::table('movies')
             ->sum('imdb.votes');
         // end aggregation sum
 
@@ -246,7 +246,7 @@ class QueryBuilderTest extends TestCase
     public function testAggWithFilter(): void
     {
         // begin aggregation with filter
-        $result = DB::collection('movies')
+        $result = DB::table('movies')
             ->where('year', '>', 2000)
             ->avg('imdb.rating');
         // end aggregation with filter
@@ -257,7 +257,7 @@ class QueryBuilderTest extends TestCase
     public function testOrderBy(): void
     {
         // begin query orderBy
-        $result = DB::collection('movies')
+        $result = DB::table('movies')
             ->where('title', 'like', 'back to the future%')
             ->orderBy('imdb.rating', 'desc')
             ->get();
@@ -269,7 +269,7 @@ class QueryBuilderTest extends TestCase
     public function testSkip(): void
     {
         // begin query skip
-        $result = DB::collection('movies')
+        $result = DB::table('movies')
             ->where('title', 'like', 'star trek%')
             ->orderBy('year', 'asc')
             ->skip(4)
@@ -282,7 +282,7 @@ class QueryBuilderTest extends TestCase
     public function testProjection(): void
     {
         // begin query projection
-        $result = DB::collection('movies')
+        $result = DB::table('movies')
             ->where('imdb.rating', '>', 8.5)
             ->project([
                 'title' => 1,
@@ -300,7 +300,7 @@ class QueryBuilderTest extends TestCase
         $resultsPerPage = 15;
         $projectionFields = ['title', 'runtime', 'imdb.rating'];
 
-        $result = DB::collection('movies')
+        $result = DB::table('movies')
             ->orderBy('imdb.votes', 'desc')
             ->paginate($resultsPerPage, $projectionFields);
         // end query projection with pagination
@@ -311,7 +311,7 @@ class QueryBuilderTest extends TestCase
     public function testExists(): void
     {
         // begin query exists
-        $result = DB::collection('movies')
+        $result = DB::table('movies')
             ->exists('random_review', true);
         // end query exists
 
@@ -321,7 +321,7 @@ class QueryBuilderTest extends TestCase
     public function testAll(): void
     {
         // begin query all
-        $result = DB::collection('movies')
+        $result = DB::table('movies')
             ->where('movies', 'all', ['title', 'rated', 'imdb.rating'])
             ->get();
         // end query all
@@ -332,7 +332,7 @@ class QueryBuilderTest extends TestCase
     public function testSize(): void
     {
         // begin query size
-        $result = DB::collection('movies')
+        $result = DB::table('movies')
             ->where('directors', 'size', 5)
             ->get();
         // end query size
@@ -343,7 +343,7 @@ class QueryBuilderTest extends TestCase
     public function testType(): void
     {
         // begin query type
-        $result = DB::collection('movies')
+        $result = DB::table('movies')
             ->where('released', 'type', 4)
             ->get();
         // end query type
@@ -354,7 +354,7 @@ class QueryBuilderTest extends TestCase
     public function testMod(): void
     {
         // begin query modulo
-        $result = DB::collection('movies')
+        $result = DB::table('movies')
             ->where('year', 'mod', [2, 0])
             ->get();
         // end query modulo
@@ -366,7 +366,7 @@ class QueryBuilderTest extends TestCase
     {
         // begin query whereRegex
         $result = DB::connection('mongodb')
-            ->collection('movies')
+            ->table('movies')
             ->where('title', 'REGEX', new Regex('^the lord of .*', 'i'))
             ->get();
         // end query whereRegex
@@ -377,7 +377,7 @@ class QueryBuilderTest extends TestCase
     public function testWhereRaw(): void
     {
         // begin query raw
-        $result = DB::collection('movies')
+        $result = DB::table('movies')
             ->whereRaw([
                 'imdb.votes' => ['$gte' => 1000 ],
                 '$or' => [
@@ -393,7 +393,7 @@ class QueryBuilderTest extends TestCase
     public function testElemMatch(): void
     {
         // begin query elemMatch
-        $result = DB::collection('movies')
+        $result = DB::table('movies')
             ->where('writers', 'elemMatch', ['$in' => ['Maya Forbes', 'Eric Roth']])
             ->get();
         // end query elemMatch
@@ -404,7 +404,7 @@ class QueryBuilderTest extends TestCase
     public function testCursorTimeout(): void
     {
         // begin query cursor timeout
-        $result = DB::collection('movies')
+        $result = DB::table('movies')
             ->timeout(2) // value in seconds
             ->where('year', 2001)
             ->get();
@@ -418,7 +418,7 @@ class QueryBuilderTest extends TestCase
         $this->importTheaters();
 
        // begin query near
-        $results = DB::collection('theaters')
+        $results = DB::table('theaters')
             ->where('location.geo', 'near', [
                 '$geometry' => [
                     'type' => 'Point',
@@ -437,7 +437,7 @@ class QueryBuilderTest extends TestCase
     public function testGeoWithin(): void
     {
         // begin query geoWithin
-        $results = DB::collection('theaters')
+        $results = DB::table('theaters')
             ->where('location.geo', 'geoWithin', [
                 '$geometry' => [
                     'type' => 'Polygon',
@@ -459,7 +459,7 @@ class QueryBuilderTest extends TestCase
     public function testGeoIntersects(): void
     {
         // begin query geoIntersects
-        $results = DB::collection('theaters')
+        $results = DB::table('theaters')
             ->where('location.geo', 'geoIntersects', [
                 '$geometry' => [
                     'type' => 'LineString',
@@ -479,7 +479,7 @@ class QueryBuilderTest extends TestCase
         $this->importTheaters();
 
         // begin query geoNear
-        $results = DB::collection('theaters')->raw(
+        $results = DB::table('theaters')->raw(
             function (Collection $collection) {
                 return $collection->aggregate([
                     [
@@ -506,7 +506,7 @@ class QueryBuilderTest extends TestCase
     public function testUpsert(): void
     {
         // begin upsert
-        $result = DB::collection('movies')
+        $result = DB::table('movies')
             ->where('title', 'Will Hunting')
             ->update(
                 [
@@ -524,7 +524,7 @@ class QueryBuilderTest extends TestCase
     public function testIncrement(): void
     {
         // begin increment
-        $result = DB::collection('movies')
+        $result = DB::table('movies')
             ->where('title', 'Field of Dreams')
             ->increment('imdb.votes', 3000);
         // end increment
@@ -535,7 +535,7 @@ class QueryBuilderTest extends TestCase
     public function testDecrement(): void
     {
         // begin decrement
-        $result = DB::collection('movies')
+        $result = DB::table('movies')
             ->where('title', 'Sharknado')
             ->decrement('imdb.rating', 0.2);
         // end decrement
@@ -546,7 +546,7 @@ class QueryBuilderTest extends TestCase
     public function testPush(): void
     {
         // begin push
-        $result = DB::collection('movies')
+        $result = DB::table('movies')
             ->where('title', 'Office Space')
             ->push('cast', 'Gary Cole');
         // end push
@@ -557,7 +557,7 @@ class QueryBuilderTest extends TestCase
     public function testPull(): void
     {
         // begin pull
-        $result = DB::collection('movies')
+        $result = DB::table('movies')
             ->where('title', 'Iron Man')
             ->pull('genres', 'Adventure');
         // end pull
@@ -568,7 +568,7 @@ class QueryBuilderTest extends TestCase
     public function testUnset(): void
     {
         // begin unset
-        $result = DB::collection('movies')
+        $result = DB::table('movies')
             ->where('title', 'Final Accord')
             ->unset('tomatoes.viewer');
         // end unset

--- a/docs/query-builder.txt
+++ b/docs/query-builder.txt
@@ -36,8 +36,8 @@ lets you perform database operations. Facades, which are static interfaces to
 classes, make the syntax more concise, avoid runtime errors, and improve
 testability.
 
-{+odm-short+} aliases the ``DB`` method ``table()`` as the ``collection()``
-method. Chain methods to specify commands and any constraints. Then, chain
+{+odm-short+} provides the ``DB`` method ``table()`` to access a collection.
+Chain methods to specify commands and any constraints. Then, chain
 the ``get()`` method at the end to run the methods and retrieve the results.
 The following example shows the syntax of a query builder call:
 

--- a/docs/query-builder.txt
+++ b/docs/query-builder.txt
@@ -43,21 +43,21 @@ The following example shows the syntax of a query builder call:
 
 .. code-block:: php
 
-   DB::collection('<collection name>')
+   DB::table('<collection name>')
        // chain methods by using the "->" object operator
        ->get();
 .. tip::
 
-   Before using the ``DB::collection()`` method, ensure that you specify MongoDB as your application's
+   Before using the ``DB::table()`` method, ensure that you specify MongoDB as your application's
    default database connection. For instructions on setting the database connection,
    see the :ref:`laravel-quick-start-connect-to-mongodb` step in the Quick Start.
 
    If MongoDB is not your application's default database, you can use the ``DB::connection()`` method
    to specify a MongoDB connection. Pass the name of the connection to the ``connection()`` method,
    as shown in the following code:
-   
+
    .. code-block:: php
-   
+
       $connection = DB::connection('mongodb');
 
 This guide provides examples of the following types of query builder operations:

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -88,7 +88,7 @@ class Connection extends BaseConnection
      */
     public function collection($collection)
     {
-        @trigger_error('Since mongodb/laravel-mongodb 4.8, the method Connection::collection() is deprecated and will be removed in version 5.0. Use the function table() instead.', E_USER_DEPRECATED);
+        @trigger_error('Since mongodb/laravel-mongodb 4.8, the method Connection::collection() is deprecated and will be removed in version 5.0. Use the table() method instead.', E_USER_DEPRECATED);
 
         return $this->table($collection);
     }

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -22,7 +22,9 @@ use function implode;
 use function is_array;
 use function preg_match;
 use function str_contains;
+use function trigger_error;
 
+use const E_USER_DEPRECATED;
 use const FILTER_FLAG_IPV6;
 use const FILTER_VALIDATE_IP;
 
@@ -78,28 +80,32 @@ class Connection extends BaseConnection
     /**
      * Begin a fluent query against a database collection.
      *
+     * @deprecated since mongodb/laravel-mongodb 4.8, use the function table() instead
+     *
      * @param  string $collection
      *
      * @return Query\Builder
      */
     public function collection($collection)
     {
-        $query = new Query\Builder($this, $this->getQueryGrammar(), $this->getPostProcessor());
+        @trigger_error('Since mongodb/laravel-mongodb 4.8, the method Connection::collection() is deprecated and will be removed in version 5.0. Use the function table() instead.', E_USER_DEPRECATED);
 
-        return $query->from($collection);
+        return $this->table($collection);
     }
 
     /**
      * Begin a fluent query against a database collection.
      *
-     * @param  string      $table
-     * @param  string|null $as
+     * @param  string      $table The name of the MongoDB collection
+     * @param  string|null $as    Ignored. Not supported by MongoDB
      *
      * @return Query\Builder
      */
     public function table($table, $as = null)
     {
-        return $this->collection($table);
+        $query = new Query\Builder($this, $this->getQueryGrammar(), $this->getPostProcessor());
+
+        return $query->from($table);
     }
 
     /**

--- a/src/Queue/MongoQueue.php
+++ b/src/Queue/MongoQueue.php
@@ -109,7 +109,7 @@ class MongoQueue extends DatabaseQueue
     {
         $expiration = Carbon::now()->subSeconds($this->retryAfter)->getTimestamp();
 
-        $reserved = $this->database->collection($this->table)
+        $reserved = $this->database->table($this->table)
             ->where('queue', $this->getQueue($queue))
             ->whereNotNull('reserved_at')
             ->where('reserved_at', '<=', $expiration)
@@ -140,7 +140,7 @@ class MongoQueue extends DatabaseQueue
     /** @inheritdoc */
     public function deleteReserved($queue, $id)
     {
-        $this->database->collection($this->table)->where('_id', $id)->delete();
+        $this->database->table($this->table)->where('_id', $id)->delete();
     }
 
     /** @inheritdoc */

--- a/src/Schema/Builder.php
+++ b/src/Schema/Builder.php
@@ -17,7 +17,10 @@ use function implode;
 use function iterator_to_array;
 use function sort;
 use function sprintf;
+use function trigger_error;
 use function usort;
+
+use const E_USER_DEPRECATED;
 
 class Builder extends \Illuminate\Database\Schema\Builder
 {
@@ -75,23 +78,27 @@ class Builder extends \Illuminate\Database\Schema\Builder
     /**
      * Modify a collection on the schema.
      *
+     * @deprecated since mongodb/laravel-mongodb 4.8, use the function table() instead
+     *
      * @param string $collection
      *
      * @return void
      */
     public function collection($collection, Closure $callback)
     {
-        $blueprint = $this->createBlueprint($collection);
+        @trigger_error('Since mongodb/laravel-mongodb 4.8, the method Schema\Builder::collection() is deprecated and will be removed in version 5.0. Use the function table() instead.', E_USER_DEPRECATED);
 
-        if ($callback) {
-            $callback($blueprint);
-        }
+        $this->table($collection, $callback);
     }
 
     /** @inheritdoc */
     public function table($table, Closure $callback)
     {
-        $this->collection($table, $callback);
+        $blueprint = $this->createBlueprint($table);
+
+        if ($callback) {
+            $callback($blueprint);
+        }
     }
 
     /** @inheritdoc */

--- a/tests/AuthTest.php
+++ b/tests/AuthTest.php
@@ -20,7 +20,7 @@ class AuthTest extends TestCase
         parent::setUp();
 
         User::truncate();
-        DB::collection('password_reset_tokens')->truncate();
+        DB::table('password_reset_tokens')->truncate();
     }
 
     public function testAuthAttempt()
@@ -59,8 +59,8 @@ class AuthTest extends TestCase
             ),
         );
 
-        $this->assertEquals(1, DB::collection('password_reset_tokens')->count());
-        $reminder = DB::collection('password_reset_tokens')->first();
+        $this->assertEquals(1, DB::table('password_reset_tokens')->count());
+        $reminder = DB::table('password_reset_tokens')->first();
         $this->assertEquals('john.doe@example.com', $reminder['email']);
         $this->assertNotNull($reminder['token']);
         $this->assertInstanceOf(UTCDateTime::class, $reminder['created_at']);
@@ -78,6 +78,6 @@ class AuthTest extends TestCase
         });
 
         $this->assertEquals('passwords.reset', $response);
-        $this->assertEquals(0, DB::collection('password_resets')->count());
+        $this->assertEquals(0, DB::table('password_resets')->count());
     }
 }

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -196,7 +196,7 @@ class ConnectionTest extends TestCase
         $this->assertSame($expectedUri, (string) $client);
         $this->assertSame($expectedDatabaseName, $connection->getMongoDB()->getDatabaseName());
         $this->assertSame('foo', $connection->getCollection('foo')->getCollectionName());
-        $this->assertSame('foo', $connection->collection('foo')->raw()->getCollectionName());
+        $this->assertSame('foo', $connection->table('foo')->raw()->getCollectionName());
     }
 
     public function testConnectionWithoutConfiguredDatabase(): void
@@ -220,7 +220,7 @@ class ConnectionTest extends TestCase
         $collection = DB::connection('mongodb')->getCollection('unittest');
         $this->assertInstanceOf(Collection::class, $collection);
 
-        $collection = DB::connection('mongodb')->collection('unittests');
+        $collection = DB::connection('mongodb')->table('unittests');
         $this->assertInstanceOf(Builder::class, $collection);
 
         $collection = DB::connection('mongodb')->table('unittests');
@@ -238,7 +238,7 @@ class ConnectionTest extends TestCase
         $connection = new Connection($config);
 
         $this->assertSame('prefix_foo', $connection->getCollection('foo')->getCollectionName());
-        $this->assertSame('prefix_foo', $connection->collection('foo')->raw()->getCollectionName());
+        $this->assertSame('prefix_foo', $connection->table('foo')->raw()->getCollectionName());
     }
 
     public function testQueryLog()
@@ -247,19 +247,19 @@ class ConnectionTest extends TestCase
 
         $this->assertCount(0, DB::getQueryLog());
 
-        DB::collection('items')->get();
+        DB::table('items')->get();
         $this->assertCount(1, DB::getQueryLog());
 
-        DB::collection('items')->insert(['name' => 'test']);
+        DB::table('items')->insert(['name' => 'test']);
         $this->assertCount(2, DB::getQueryLog());
 
-        DB::collection('items')->count();
+        DB::table('items')->count();
         $this->assertCount(3, DB::getQueryLog());
 
-        DB::collection('items')->where('name', 'test')->update(['name' => 'test']);
+        DB::table('items')->where('name', 'test')->update(['name' => 'test']);
         $this->assertCount(4, DB::getQueryLog());
 
-        DB::collection('items')->where('name', 'test')->delete();
+        DB::table('items')->where('name', 'test')->delete();
         $this->assertCount(5, DB::getQueryLog());
     }
 

--- a/tests/GeospatialTest.php
+++ b/tests/GeospatialTest.php
@@ -13,7 +13,7 @@ class GeospatialTest extends TestCase
     {
         parent::setUp();
 
-        Schema::collection('locations', function ($collection) {
+        Schema::table('locations', function ($collection) {
             $collection->geospatial('location', '2dsphere');
         });
 

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -38,80 +38,80 @@ class QueryBuilderTest extends TestCase
 {
     public function tearDown(): void
     {
-        DB::collection('users')->truncate();
-        DB::collection('items')->truncate();
+        DB::table('users')->truncate();
+        DB::table('items')->truncate();
     }
 
     public function testDeleteWithId()
     {
-        $user = DB::collection('users')->insertGetId([
+        $user = DB::table('users')->insertGetId([
             ['name' => 'Jane Doe', 'age' => 20],
         ]);
 
         $userId = (string) $user;
 
-        DB::collection('items')->insert([
+        DB::table('items')->insert([
             ['name' => 'one thing', 'user_id' => $userId],
             ['name' => 'last thing', 'user_id' => $userId],
             ['name' => 'another thing', 'user_id' => $userId],
             ['name' => 'one more thing', 'user_id' => $userId],
         ]);
 
-        $product = DB::collection('items')->first();
+        $product = DB::table('items')->first();
 
         $pid = (string) ($product['_id']);
 
-        DB::collection('items')->where('user_id', $userId)->delete($pid);
+        DB::table('items')->where('user_id', $userId)->delete($pid);
 
-        $this->assertEquals(3, DB::collection('items')->count());
+        $this->assertEquals(3, DB::table('items')->count());
 
-        $product = DB::collection('items')->first();
+        $product = DB::table('items')->first();
 
         $pid = $product['_id'];
 
-        DB::collection('items')->where('user_id', $userId)->delete($pid);
+        DB::table('items')->where('user_id', $userId)->delete($pid);
 
-        DB::collection('items')->where('user_id', $userId)->delete(md5('random-id'));
+        DB::table('items')->where('user_id', $userId)->delete(md5('random-id'));
 
-        $this->assertEquals(2, DB::collection('items')->count());
+        $this->assertEquals(2, DB::table('items')->count());
     }
 
     public function testCollection()
     {
-        $this->assertInstanceOf(Builder::class, DB::collection('users'));
+        $this->assertInstanceOf(Builder::class, DB::table('users'));
     }
 
     public function testGet()
     {
-        $users = DB::collection('users')->get();
+        $users = DB::table('users')->get();
         $this->assertCount(0, $users);
 
-        DB::collection('users')->insert(['name' => 'John Doe']);
+        DB::table('users')->insert(['name' => 'John Doe']);
 
-        $users = DB::collection('users')->get();
+        $users = DB::table('users')->get();
         $this->assertCount(1, $users);
     }
 
     public function testNoDocument()
     {
-        $items = DB::collection('items')->where('name', 'nothing')->get()->toArray();
+        $items = DB::table('items')->where('name', 'nothing')->get()->toArray();
         $this->assertEquals([], $items);
 
-        $item = DB::collection('items')->where('name', 'nothing')->first();
+        $item = DB::table('items')->where('name', 'nothing')->first();
         $this->assertNull($item);
 
-        $item = DB::collection('items')->where('_id', '51c33d8981fec6813e00000a')->first();
+        $item = DB::table('items')->where('_id', '51c33d8981fec6813e00000a')->first();
         $this->assertNull($item);
     }
 
     public function testInsert()
     {
-        DB::collection('users')->insert([
+        DB::table('users')->insert([
             'tags' => ['tag1', 'tag2'],
             'name' => 'John Doe',
         ]);
 
-        $users = DB::collection('users')->get();
+        $users = DB::table('users')->get();
         $this->assertCount(1, $users);
 
         $user = $users[0];
@@ -121,13 +121,13 @@ class QueryBuilderTest extends TestCase
 
     public function testInsertGetId()
     {
-        $id = DB::collection('users')->insertGetId(['name' => 'John Doe']);
+        $id = DB::table('users')->insertGetId(['name' => 'John Doe']);
         $this->assertInstanceOf(ObjectId::class, $id);
     }
 
     public function testBatchInsert()
     {
-        DB::collection('users')->insert([
+        DB::table('users')->insert([
             [
                 'tags' => ['tag1', 'tag2'],
                 'name' => 'Jane Doe',
@@ -138,22 +138,22 @@ class QueryBuilderTest extends TestCase
             ],
         ]);
 
-        $users = DB::collection('users')->get();
+        $users = DB::table('users')->get();
         $this->assertCount(2, $users);
         $this->assertIsArray($users[0]['tags']);
     }
 
     public function testFind()
     {
-        $id = DB::collection('users')->insertGetId(['name' => 'John Doe']);
+        $id = DB::table('users')->insertGetId(['name' => 'John Doe']);
 
-        $user = DB::collection('users')->find($id);
+        $user = DB::table('users')->find($id);
         $this->assertEquals('John Doe', $user['name']);
     }
 
     public function testFindWithTimeout()
     {
-        $id = DB::collection('users')->insertGetId(['name' => 'John Doe']);
+        $id = DB::table('users')->insertGetId(['name' => 'John Doe']);
 
         $subscriber = new class implements CommandSubscriber {
             public function commandStarted(CommandStartedEvent $event)
@@ -177,7 +177,7 @@ class QueryBuilderTest extends TestCase
 
         DB::getMongoClient()->getManager()->addSubscriber($subscriber);
         try {
-            DB::collection('users')->timeout(1)->find($id);
+            DB::table('users')->timeout(1)->find($id);
         } finally {
             DB::getMongoClient()->getManager()->removeSubscriber($subscriber);
         }
@@ -185,49 +185,49 @@ class QueryBuilderTest extends TestCase
 
     public function testFindNull()
     {
-        $user = DB::collection('users')->find(null);
+        $user = DB::table('users')->find(null);
         $this->assertNull($user);
     }
 
     public function testCount()
     {
-        DB::collection('users')->insert([
+        DB::table('users')->insert([
             ['name' => 'Jane Doe'],
             ['name' => 'John Doe'],
         ]);
 
-        $this->assertEquals(2, DB::collection('users')->count());
+        $this->assertEquals(2, DB::table('users')->count());
     }
 
     public function testUpdate()
     {
-        DB::collection('users')->insert([
+        DB::table('users')->insert([
             ['name' => 'Jane Doe', 'age' => 20],
             ['name' => 'John Doe', 'age' => 21],
         ]);
 
-        DB::collection('users')->where('name', 'John Doe')->update(['age' => 100]);
+        DB::table('users')->where('name', 'John Doe')->update(['age' => 100]);
 
-        $john = DB::collection('users')->where('name', 'John Doe')->first();
-        $jane = DB::collection('users')->where('name', 'Jane Doe')->first();
+        $john = DB::table('users')->where('name', 'John Doe')->first();
+        $jane = DB::table('users')->where('name', 'Jane Doe')->first();
         $this->assertEquals(100, $john['age']);
         $this->assertEquals(20, $jane['age']);
     }
 
     public function testUpdateOperators()
     {
-        DB::collection('users')->insert([
+        DB::table('users')->insert([
             ['name' => 'Jane Doe', 'age' => 20],
             ['name' => 'John Doe', 'age' => 19],
         ]);
 
-        DB::collection('users')->where('name', 'John Doe')->update(
+        DB::table('users')->where('name', 'John Doe')->update(
             [
                 '$unset' => ['age' => 1],
                 'ageless' => true,
             ],
         );
-        DB::collection('users')->where('name', 'Jane Doe')->update(
+        DB::table('users')->where('name', 'Jane Doe')->update(
             [
                 '$inc' => ['age' => 1],
                 '$set' => ['pronoun' => 'she'],
@@ -235,8 +235,8 @@ class QueryBuilderTest extends TestCase
             ],
         );
 
-        $john = DB::collection('users')->where('name', 'John Doe')->first();
-        $jane = DB::collection('users')->where('name', 'Jane Doe')->first();
+        $john = DB::table('users')->where('name', 'John Doe')->first();
+        $jane = DB::table('users')->where('name', 'Jane Doe')->first();
 
         $this->assertArrayNotHasKey('age', $john);
         $this->assertTrue($john['ageless']);
@@ -248,31 +248,31 @@ class QueryBuilderTest extends TestCase
 
     public function testDelete()
     {
-        DB::collection('users')->insert([
+        DB::table('users')->insert([
             ['name' => 'Jane Doe', 'age' => 20],
             ['name' => 'John Doe', 'age' => 25],
         ]);
 
-        DB::collection('users')->where('age', '<', 10)->delete();
-        $this->assertEquals(2, DB::collection('users')->count());
+        DB::table('users')->where('age', '<', 10)->delete();
+        $this->assertEquals(2, DB::table('users')->count());
 
-        DB::collection('users')->where('age', '<', 25)->delete();
-        $this->assertEquals(1, DB::collection('users')->count());
+        DB::table('users')->where('age', '<', 25)->delete();
+        $this->assertEquals(1, DB::table('users')->count());
     }
 
     public function testTruncate()
     {
-        DB::collection('users')->insert(['name' => 'John Doe']);
-        DB::collection('users')->insert(['name' => 'John Doe']);
-        $this->assertEquals(2, DB::collection('users')->count());
-        $result = DB::collection('users')->truncate();
+        DB::table('users')->insert(['name' => 'John Doe']);
+        DB::table('users')->insert(['name' => 'John Doe']);
+        $this->assertEquals(2, DB::table('users')->count());
+        $result = DB::table('users')->truncate();
         $this->assertTrue($result);
-        $this->assertEquals(0, DB::collection('users')->count());
+        $this->assertEquals(0, DB::table('users')->count());
     }
 
     public function testSubKey()
     {
-        DB::collection('users')->insert([
+        DB::table('users')->insert([
             [
                 'name' => 'John Doe',
                 'address' => ['country' => 'Belgium', 'city' => 'Ghent'],
@@ -283,14 +283,14 @@ class QueryBuilderTest extends TestCase
             ],
         ]);
 
-        $users = DB::collection('users')->where('address.country', 'Belgium')->get();
+        $users = DB::table('users')->where('address.country', 'Belgium')->get();
         $this->assertCount(1, $users);
         $this->assertEquals('John Doe', $users[0]['name']);
     }
 
     public function testInArray()
     {
-        DB::collection('items')->insert([
+        DB::table('items')->insert([
             [
                 'tags' => ['tag1', 'tag2', 'tag3', 'tag4'],
             ],
@@ -299,91 +299,91 @@ class QueryBuilderTest extends TestCase
             ],
         ]);
 
-        $items = DB::collection('items')->where('tags', 'tag2')->get();
+        $items = DB::table('items')->where('tags', 'tag2')->get();
         $this->assertCount(2, $items);
 
-        $items = DB::collection('items')->where('tags', 'tag1')->get();
+        $items = DB::table('items')->where('tags', 'tag1')->get();
         $this->assertCount(1, $items);
     }
 
     public function testRaw()
     {
-        DB::collection('users')->insert([
+        DB::table('users')->insert([
             ['name' => 'Jane Doe', 'age' => 20],
             ['name' => 'John Doe', 'age' => 25],
         ]);
 
-        $cursor = DB::collection('users')->raw(function ($collection) {
+        $cursor = DB::table('users')->raw(function ($collection) {
             return $collection->find(['age' => 20]);
         });
 
         $this->assertInstanceOf(Cursor::class, $cursor);
         $this->assertCount(1, $cursor->toArray());
 
-        $collection = DB::collection('users')->raw();
+        $collection = DB::table('users')->raw();
         $this->assertInstanceOf(Collection::class, $collection);
 
         $collection = User::raw();
         $this->assertInstanceOf(Collection::class, $collection);
 
-        $results = DB::collection('users')->whereRaw(['age' => 20])->get();
+        $results = DB::table('users')->whereRaw(['age' => 20])->get();
         $this->assertCount(1, $results);
         $this->assertEquals('Jane Doe', $results[0]['name']);
     }
 
     public function testPush()
     {
-        $id = DB::collection('users')->insertGetId([
+        $id = DB::table('users')->insertGetId([
             'name' => 'John Doe',
             'tags' => [],
             'messages' => [],
         ]);
 
-        DB::collection('users')->where('_id', $id)->push('tags', 'tag1');
+        DB::table('users')->where('_id', $id)->push('tags', 'tag1');
 
-        $user = DB::collection('users')->find($id);
+        $user = DB::table('users')->find($id);
         $this->assertIsArray($user['tags']);
         $this->assertCount(1, $user['tags']);
         $this->assertEquals('tag1', $user['tags'][0]);
 
-        DB::collection('users')->where('_id', $id)->push('tags', 'tag2');
-        $user = DB::collection('users')->find($id);
+        DB::table('users')->where('_id', $id)->push('tags', 'tag2');
+        $user = DB::table('users')->find($id);
         $this->assertCount(2, $user['tags']);
         $this->assertEquals('tag2', $user['tags'][1]);
 
         // Add duplicate
-        DB::collection('users')->where('_id', $id)->push('tags', 'tag2');
-        $user = DB::collection('users')->find($id);
+        DB::table('users')->where('_id', $id)->push('tags', 'tag2');
+        $user = DB::table('users')->find($id);
         $this->assertCount(3, $user['tags']);
 
         // Add unique
-        DB::collection('users')->where('_id', $id)->push('tags', 'tag1', true);
-        $user = DB::collection('users')->find($id);
+        DB::table('users')->where('_id', $id)->push('tags', 'tag1', true);
+        $user = DB::table('users')->find($id);
         $this->assertCount(3, $user['tags']);
 
         $message = ['from' => 'Jane', 'body' => 'Hi John'];
-        DB::collection('users')->where('_id', $id)->push('messages', $message);
-        $user = DB::collection('users')->find($id);
+        DB::table('users')->where('_id', $id)->push('messages', $message);
+        $user = DB::table('users')->find($id);
         $this->assertIsArray($user['messages']);
         $this->assertCount(1, $user['messages']);
         $this->assertEquals($message, $user['messages'][0]);
 
         // Raw
-        DB::collection('users')->where('_id', $id)->push([
+        DB::table('users')->where('_id', $id)->push([
             'tags' => 'tag3',
             'messages' => ['from' => 'Mark', 'body' => 'Hi John'],
         ]);
-        $user = DB::collection('users')->find($id);
+        $user = DB::table('users')->find($id);
         $this->assertCount(4, $user['tags']);
         $this->assertCount(2, $user['messages']);
 
-        DB::collection('users')->where('_id', $id)->push([
+        DB::table('users')->where('_id', $id)->push([
             'messages' => [
                 'date' => new DateTime(),
                 'body' => 'Hi John',
             ],
         ]);
-        $user = DB::collection('users')->find($id);
+        $user = DB::table('users')->find($id);
         $this->assertCount(3, $user['messages']);
     }
 
@@ -392,7 +392,7 @@ class QueryBuilderTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('2nd argument of MongoDB\Laravel\Query\Builder::push() must be "null" when 1st argument is an array. Got "string" instead.');
 
-        DB::collection('users')->push(['tags' => 'tag1'], 'tag2');
+        DB::table('users')->push(['tags' => 'tag1'], 'tag2');
     }
 
     public function testPull()
@@ -400,47 +400,47 @@ class QueryBuilderTest extends TestCase
         $message1 = ['from' => 'Jane', 'body' => 'Hi John'];
         $message2 = ['from' => 'Mark', 'body' => 'Hi John'];
 
-        $id = DB::collection('users')->insertGetId([
+        $id = DB::table('users')->insertGetId([
             'name' => 'John Doe',
             'tags' => ['tag1', 'tag2', 'tag3', 'tag4'],
             'messages' => [$message1, $message2],
         ]);
 
-        DB::collection('users')->where('_id', $id)->pull('tags', 'tag3');
+        DB::table('users')->where('_id', $id)->pull('tags', 'tag3');
 
-        $user = DB::collection('users')->find($id);
+        $user = DB::table('users')->find($id);
         $this->assertIsArray($user['tags']);
         $this->assertCount(3, $user['tags']);
         $this->assertEquals('tag4', $user['tags'][2]);
 
-        DB::collection('users')->where('_id', $id)->pull('messages', $message1);
+        DB::table('users')->where('_id', $id)->pull('messages', $message1);
 
-        $user = DB::collection('users')->find($id);
+        $user = DB::table('users')->find($id);
         $this->assertIsArray($user['messages']);
         $this->assertCount(1, $user['messages']);
 
         // Raw
-        DB::collection('users')->where('_id', $id)->pull(['tags' => 'tag2', 'messages' => $message2]);
-        $user = DB::collection('users')->find($id);
+        DB::table('users')->where('_id', $id)->pull(['tags' => 'tag2', 'messages' => $message2]);
+        $user = DB::table('users')->find($id);
         $this->assertCount(2, $user['tags']);
         $this->assertCount(0, $user['messages']);
     }
 
     public function testDistinct()
     {
-        DB::collection('items')->insert([
+        DB::table('items')->insert([
             ['name' => 'knife', 'type' => 'sharp'],
             ['name' => 'fork', 'type' => 'sharp'],
             ['name' => 'spoon', 'type' => 'round'],
             ['name' => 'spoon', 'type' => 'round'],
         ]);
 
-        $items = DB::collection('items')->distinct('name')->get()->toArray();
+        $items = DB::table('items')->distinct('name')->get()->toArray();
         sort($items);
         $this->assertCount(3, $items);
         $this->assertEquals(['fork', 'knife', 'spoon'], $items);
 
-        $types = DB::collection('items')->distinct('type')->get()->toArray();
+        $types = DB::table('items')->distinct('type')->get()->toArray();
         sort($types);
         $this->assertCount(2, $types);
         $this->assertEquals(['round', 'sharp'], $types);
@@ -448,127 +448,127 @@ class QueryBuilderTest extends TestCase
 
     public function testCustomId()
     {
-        DB::collection('items')->insert([
+        DB::table('items')->insert([
             ['_id' => 'knife', 'type' => 'sharp', 'amount' => 34],
             ['_id' => 'fork', 'type' => 'sharp', 'amount' => 20],
             ['_id' => 'spoon', 'type' => 'round', 'amount' => 3],
         ]);
 
-        $item = DB::collection('items')->find('knife');
+        $item = DB::table('items')->find('knife');
         $this->assertEquals('knife', $item['_id']);
 
-        $item = DB::collection('items')->where('_id', 'fork')->first();
+        $item = DB::table('items')->where('_id', 'fork')->first();
         $this->assertEquals('fork', $item['_id']);
 
-        DB::collection('users')->insert([
+        DB::table('users')->insert([
             ['_id' => 1, 'name' => 'Jane Doe'],
             ['_id' => 2, 'name' => 'John Doe'],
         ]);
 
-        $item = DB::collection('users')->find(1);
+        $item = DB::table('users')->find(1);
         $this->assertEquals(1, $item['_id']);
     }
 
     public function testTake()
     {
-        DB::collection('items')->insert([
+        DB::table('items')->insert([
             ['name' => 'knife', 'type' => 'sharp', 'amount' => 34],
             ['name' => 'fork', 'type' => 'sharp', 'amount' => 20],
             ['name' => 'spoon', 'type' => 'round', 'amount' => 3],
             ['name' => 'spoon', 'type' => 'round', 'amount' => 14],
         ]);
 
-        $items = DB::collection('items')->orderBy('name')->take(2)->get();
+        $items = DB::table('items')->orderBy('name')->take(2)->get();
         $this->assertCount(2, $items);
         $this->assertEquals('fork', $items[0]['name']);
     }
 
     public function testSkip()
     {
-        DB::collection('items')->insert([
+        DB::table('items')->insert([
             ['name' => 'knife', 'type' => 'sharp', 'amount' => 34],
             ['name' => 'fork', 'type' => 'sharp', 'amount' => 20],
             ['name' => 'spoon', 'type' => 'round', 'amount' => 3],
             ['name' => 'spoon', 'type' => 'round', 'amount' => 14],
         ]);
 
-        $items = DB::collection('items')->orderBy('name')->skip(2)->get();
+        $items = DB::table('items')->orderBy('name')->skip(2)->get();
         $this->assertCount(2, $items);
         $this->assertEquals('spoon', $items[0]['name']);
     }
 
     public function testPluck()
     {
-        DB::collection('users')->insert([
+        DB::table('users')->insert([
             ['name' => 'Jane Doe', 'age' => 20],
             ['name' => 'John Doe', 'age' => 25],
         ]);
 
-        $age = DB::collection('users')->where('name', 'John Doe')->pluck('age')->toArray();
+        $age = DB::table('users')->where('name', 'John Doe')->pluck('age')->toArray();
         $this->assertEquals([25], $age);
     }
 
     public function testList()
     {
-        DB::collection('items')->insert([
+        DB::table('items')->insert([
             ['name' => 'knife', 'type' => 'sharp', 'amount' => 34],
             ['name' => 'fork', 'type' => 'sharp', 'amount' => 20],
             ['name' => 'spoon', 'type' => 'round', 'amount' => 3],
             ['name' => 'spoon', 'type' => 'round', 'amount' => 14],
         ]);
 
-        $list = DB::collection('items')->pluck('name')->toArray();
+        $list = DB::table('items')->pluck('name')->toArray();
         sort($list);
         $this->assertCount(4, $list);
         $this->assertEquals(['fork', 'knife', 'spoon', 'spoon'], $list);
 
-        $list = DB::collection('items')->pluck('type', 'name')->toArray();
+        $list = DB::table('items')->pluck('type', 'name')->toArray();
         $this->assertCount(3, $list);
         $this->assertEquals(['knife' => 'sharp', 'fork' => 'sharp', 'spoon' => 'round'], $list);
 
-        $list = DB::collection('items')->pluck('name', '_id')->toArray();
+        $list = DB::table('items')->pluck('name', '_id')->toArray();
         $this->assertCount(4, $list);
         $this->assertEquals(24, strlen(key($list)));
     }
 
     public function testAggregate()
     {
-        DB::collection('items')->insert([
+        DB::table('items')->insert([
             ['name' => 'knife', 'type' => 'sharp', 'amount' => 34],
             ['name' => 'fork', 'type' => 'sharp', 'amount' => 20],
             ['name' => 'spoon', 'type' => 'round', 'amount' => 3],
             ['name' => 'spoon', 'type' => 'round', 'amount' => 14],
         ]);
 
-        $this->assertEquals(71, DB::collection('items')->sum('amount'));
-        $this->assertEquals(4, DB::collection('items')->count('amount'));
-        $this->assertEquals(3, DB::collection('items')->min('amount'));
-        $this->assertEquals(34, DB::collection('items')->max('amount'));
-        $this->assertEquals(17.75, DB::collection('items')->avg('amount'));
+        $this->assertEquals(71, DB::table('items')->sum('amount'));
+        $this->assertEquals(4, DB::table('items')->count('amount'));
+        $this->assertEquals(3, DB::table('items')->min('amount'));
+        $this->assertEquals(34, DB::table('items')->max('amount'));
+        $this->assertEquals(17.75, DB::table('items')->avg('amount'));
 
-        $this->assertEquals(2, DB::collection('items')->where('name', 'spoon')->count('amount'));
-        $this->assertEquals(14, DB::collection('items')->where('name', 'spoon')->max('amount'));
+        $this->assertEquals(2, DB::table('items')->where('name', 'spoon')->count('amount'));
+        $this->assertEquals(14, DB::table('items')->where('name', 'spoon')->max('amount'));
     }
 
     public function testSubdocumentAggregate()
     {
-        DB::collection('items')->insert([
+        DB::table('items')->insert([
             ['name' => 'knife', 'amount' => ['hidden' => 10, 'found' => 3]],
             ['name' => 'fork', 'amount' => ['hidden' => 35, 'found' => 12]],
             ['name' => 'spoon', 'amount' => ['hidden' => 14, 'found' => 21]],
             ['name' => 'spoon', 'amount' => ['hidden' => 6, 'found' => 4]],
         ]);
 
-        $this->assertEquals(65, DB::collection('items')->sum('amount.hidden'));
-        $this->assertEquals(4, DB::collection('items')->count('amount.hidden'));
-        $this->assertEquals(6, DB::collection('items')->min('amount.hidden'));
-        $this->assertEquals(35, DB::collection('items')->max('amount.hidden'));
-        $this->assertEquals(16.25, DB::collection('items')->avg('amount.hidden'));
+        $this->assertEquals(65, DB::table('items')->sum('amount.hidden'));
+        $this->assertEquals(4, DB::table('items')->count('amount.hidden'));
+        $this->assertEquals(6, DB::table('items')->min('amount.hidden'));
+        $this->assertEquals(35, DB::table('items')->max('amount.hidden'));
+        $this->assertEquals(16.25, DB::table('items')->avg('amount.hidden'));
     }
 
     public function testSubdocumentArrayAggregate()
     {
-        DB::collection('items')->insert([
+        DB::table('items')->insert([
             ['name' => 'knife', 'amount' => [['hidden' => 10, 'found' => 3], ['hidden' => 5, 'found' => 2]]],
             [
                 'name' => 'fork',
@@ -582,22 +582,22 @@ class QueryBuilderTest extends TestCase
             ['name' => 'teaspoon', 'amount' => []],
         ]);
 
-        $this->assertEquals(72, DB::collection('items')->sum('amount.*.hidden'));
-        $this->assertEquals(6, DB::collection('items')->count('amount.*.hidden'));
-        $this->assertEquals(1, DB::collection('items')->min('amount.*.hidden'));
-        $this->assertEquals(35, DB::collection('items')->max('amount.*.hidden'));
-        $this->assertEquals(12, DB::collection('items')->avg('amount.*.hidden'));
+        $this->assertEquals(72, DB::table('items')->sum('amount.*.hidden'));
+        $this->assertEquals(6, DB::table('items')->count('amount.*.hidden'));
+        $this->assertEquals(1, DB::table('items')->min('amount.*.hidden'));
+        $this->assertEquals(35, DB::table('items')->max('amount.*.hidden'));
+        $this->assertEquals(12, DB::table('items')->avg('amount.*.hidden'));
     }
 
     public function testUpdateWithUpsert()
     {
-        DB::collection('items')->where('name', 'knife')
+        DB::table('items')->where('name', 'knife')
             ->update(
                 ['amount' => 1],
                 ['upsert' => true],
             );
 
-        $this->assertEquals(1, DB::collection('items')->count());
+        $this->assertEquals(1, DB::table('items')->count());
 
         Item::where('name', 'spoon')
             ->update(
@@ -605,123 +605,123 @@ class QueryBuilderTest extends TestCase
                 ['upsert' => true],
             );
 
-        $this->assertEquals(2, DB::collection('items')->count());
+        $this->assertEquals(2, DB::table('items')->count());
     }
 
     public function testUpsert()
     {
         /** @see DatabaseQueryBuilderTest::testUpsertMethod() */
         // Insert 2 documents
-        $result = DB::collection('users')->upsert([
+        $result = DB::table('users')->upsert([
             ['email' => 'foo', 'name' => 'bar'],
             ['name' => 'bar2', 'email' => 'foo2'],
         ], 'email', 'name');
 
         $this->assertSame(2, $result);
-        $this->assertSame(2, DB::collection('users')->count());
-        $this->assertSame('bar', DB::collection('users')->where('email', 'foo')->first()['name']);
+        $this->assertSame(2, DB::table('users')->count());
+        $this->assertSame('bar', DB::table('users')->where('email', 'foo')->first()['name']);
 
         // Update 1 document
-        $result = DB::collection('users')->upsert([
+        $result = DB::table('users')->upsert([
             ['email' => 'foo', 'name' => 'bar2'],
             ['name' => 'bar2', 'email' => 'foo2'],
         ], 'email', 'name');
 
         $this->assertSame(1, $result);
-        $this->assertSame(2, DB::collection('users')->count());
-        $this->assertSame('bar2', DB::collection('users')->where('email', 'foo')->first()['name']);
+        $this->assertSame(2, DB::table('users')->count());
+        $this->assertSame('bar2', DB::table('users')->where('email', 'foo')->first()['name']);
 
         // If no update fields are specified, all fields are updated
-        $result = DB::collection('users')->upsert([
+        $result = DB::table('users')->upsert([
             ['email' => 'foo', 'name' => 'bar3'],
         ], 'email');
 
         $this->assertSame(1, $result);
-        $this->assertSame(2, DB::collection('users')->count());
-        $this->assertSame('bar3', DB::collection('users')->where('email', 'foo')->first()['name']);
+        $this->assertSame(2, DB::table('users')->count());
+        $this->assertSame('bar3', DB::table('users')->where('email', 'foo')->first()['name']);
     }
 
     public function testUnset()
     {
-        $id1 = DB::collection('users')->insertGetId(['name' => 'John Doe', 'note1' => 'ABC', 'note2' => 'DEF']);
-        $id2 = DB::collection('users')->insertGetId(['name' => 'Jane Doe', 'note1' => 'ABC', 'note2' => 'DEF']);
+        $id1 = DB::table('users')->insertGetId(['name' => 'John Doe', 'note1' => 'ABC', 'note2' => 'DEF']);
+        $id2 = DB::table('users')->insertGetId(['name' => 'Jane Doe', 'note1' => 'ABC', 'note2' => 'DEF']);
 
-        DB::collection('users')->where('name', 'John Doe')->unset('note1');
+        DB::table('users')->where('name', 'John Doe')->unset('note1');
 
-        $user1 = DB::collection('users')->find($id1);
-        $user2 = DB::collection('users')->find($id2);
+        $user1 = DB::table('users')->find($id1);
+        $user2 = DB::table('users')->find($id2);
 
         $this->assertArrayNotHasKey('note1', $user1);
         $this->assertArrayHasKey('note2', $user1);
         $this->assertArrayHasKey('note1', $user2);
         $this->assertArrayHasKey('note2', $user2);
 
-        DB::collection('users')->where('name', 'Jane Doe')->unset(['note1', 'note2']);
+        DB::table('users')->where('name', 'Jane Doe')->unset(['note1', 'note2']);
 
-        $user2 = DB::collection('users')->find($id2);
+        $user2 = DB::table('users')->find($id2);
         $this->assertArrayNotHasKey('note1', $user2);
         $this->assertArrayNotHasKey('note2', $user2);
     }
 
     public function testUpdateSubdocument()
     {
-        $id = DB::collection('users')->insertGetId(['name' => 'John Doe', 'address' => ['country' => 'Belgium']]);
+        $id = DB::table('users')->insertGetId(['name' => 'John Doe', 'address' => ['country' => 'Belgium']]);
 
-        DB::collection('users')->where('_id', $id)->update(['address.country' => 'England']);
+        DB::table('users')->where('_id', $id)->update(['address.country' => 'England']);
 
-        $check = DB::collection('users')->find($id);
+        $check = DB::table('users')->find($id);
         $this->assertEquals('England', $check['address']['country']);
     }
 
     public function testDates()
     {
-        DB::collection('users')->insert([
+        DB::table('users')->insert([
             ['name' => 'John Doe', 'birthday' => new UTCDateTime(Date::parse('1980-01-01 00:00:00'))],
             ['name' => 'Robert Roe', 'birthday' => new UTCDateTime(Date::parse('1982-01-01 00:00:00'))],
             ['name' => 'Mark Moe', 'birthday' => new UTCDateTime(Date::parse('1983-01-01 00:00:00.1'))],
             ['name' => 'Frank White', 'birthday' => new UTCDateTime(Date::parse('1960-01-01 12:12:12.1'))],
         ]);
 
-        $user = DB::collection('users')
+        $user = DB::table('users')
             ->where('birthday', new UTCDateTime(Date::parse('1980-01-01 00:00:00')))
             ->first();
         $this->assertEquals('John Doe', $user['name']);
 
-        $user = DB::collection('users')
+        $user = DB::table('users')
             ->where('birthday', new UTCDateTime(Date::parse('1960-01-01 12:12:12.1')))
             ->first();
         $this->assertEquals('Frank White', $user['name']);
 
-        $user = DB::collection('users')->where('birthday', '=', new DateTime('1980-01-01 00:00:00'))->first();
+        $user = DB::table('users')->where('birthday', '=', new DateTime('1980-01-01 00:00:00'))->first();
         $this->assertEquals('John Doe', $user['name']);
 
         $start = new UTCDateTime(1000 * strtotime('1950-01-01 00:00:00'));
         $stop  = new UTCDateTime(1000 * strtotime('1981-01-01 00:00:00'));
 
-        $users = DB::collection('users')->whereBetween('birthday', [$start, $stop])->get();
+        $users = DB::table('users')->whereBetween('birthday', [$start, $stop])->get();
         $this->assertCount(2, $users);
     }
 
     public function testImmutableDates()
     {
-        DB::collection('users')->insert([
+        DB::table('users')->insert([
             ['name' => 'John Doe', 'birthday' => new UTCDateTime(Date::parse('1980-01-01 00:00:00'))],
             ['name' => 'Robert Roe', 'birthday' => new UTCDateTime(Date::parse('1982-01-01 00:00:00'))],
         ]);
 
-        $users = DB::collection('users')->where('birthday', '=', new DateTimeImmutable('1980-01-01 00:00:00'))->get();
+        $users = DB::table('users')->where('birthday', '=', new DateTimeImmutable('1980-01-01 00:00:00'))->get();
         $this->assertCount(1, $users);
 
-        $users = DB::collection('users')->where('birthday', new DateTimeImmutable('1980-01-01 00:00:00'))->get();
+        $users = DB::table('users')->where('birthday', new DateTimeImmutable('1980-01-01 00:00:00'))->get();
         $this->assertCount(1, $users);
 
-        $users = DB::collection('users')->whereIn('birthday', [
+        $users = DB::table('users')->whereIn('birthday', [
             new DateTimeImmutable('1980-01-01 00:00:00'),
             new DateTimeImmutable('1982-01-01 00:00:00'),
         ])->get();
         $this->assertCount(2, $users);
 
-        $users = DB::collection('users')->whereBetween('birthday', [
+        $users = DB::table('users')->whereBetween('birthday', [
             new DateTimeImmutable('1979-01-01 00:00:00'),
             new DateTimeImmutable('1983-01-01 00:00:00'),
         ])->get();
@@ -731,79 +731,79 @@ class QueryBuilderTest extends TestCase
 
     public function testOperators()
     {
-        DB::collection('users')->insert([
+        DB::table('users')->insert([
             ['name' => 'John Doe', 'age' => 30],
             ['name' => 'Jane Doe'],
             ['name' => 'Robert Roe', 'age' => 'thirty-one'],
         ]);
 
-        $results = DB::collection('users')->where('age', 'exists', true)->get();
+        $results = DB::table('users')->where('age', 'exists', true)->get();
         $this->assertCount(2, $results);
         $resultsNames = [$results[0]['name'], $results[1]['name']];
         $this->assertContains('John Doe', $resultsNames);
         $this->assertContains('Robert Roe', $resultsNames);
 
-        $results = DB::collection('users')->where('age', 'exists', false)->get();
+        $results = DB::table('users')->where('age', 'exists', false)->get();
         $this->assertCount(1, $results);
         $this->assertEquals('Jane Doe', $results[0]['name']);
 
-        $results = DB::collection('users')->where('age', 'type', 2)->get();
+        $results = DB::table('users')->where('age', 'type', 2)->get();
         $this->assertCount(1, $results);
         $this->assertEquals('Robert Roe', $results[0]['name']);
 
-        $results = DB::collection('users')->where('age', 'mod', [15, 0])->get();
+        $results = DB::table('users')->where('age', 'mod', [15, 0])->get();
         $this->assertCount(1, $results);
         $this->assertEquals('John Doe', $results[0]['name']);
 
-        $results = DB::collection('users')->where('age', 'mod', [29, 1])->get();
+        $results = DB::table('users')->where('age', 'mod', [29, 1])->get();
         $this->assertCount(1, $results);
         $this->assertEquals('John Doe', $results[0]['name']);
 
-        $results = DB::collection('users')->where('age', 'mod', [14, 0])->get();
+        $results = DB::table('users')->where('age', 'mod', [14, 0])->get();
         $this->assertCount(0, $results);
 
-        DB::collection('items')->insert([
+        DB::table('items')->insert([
             ['name' => 'fork', 'tags' => ['sharp', 'pointy']],
             ['name' => 'spork', 'tags' => ['sharp', 'pointy', 'round', 'bowl']],
             ['name' => 'spoon', 'tags' => ['round', 'bowl']],
         ]);
 
-        $results = DB::collection('items')->where('tags', 'all', ['sharp', 'pointy'])->get();
+        $results = DB::table('items')->where('tags', 'all', ['sharp', 'pointy'])->get();
         $this->assertCount(2, $results);
 
-        $results = DB::collection('items')->where('tags', 'all', ['sharp', 'round'])->get();
+        $results = DB::table('items')->where('tags', 'all', ['sharp', 'round'])->get();
         $this->assertCount(1, $results);
 
-        $results = DB::collection('items')->where('tags', 'size', 2)->get();
+        $results = DB::table('items')->where('tags', 'size', 2)->get();
         $this->assertCount(2, $results);
 
-        $results = DB::collection('items')->where('tags', '$size', 2)->get();
+        $results = DB::table('items')->where('tags', '$size', 2)->get();
         $this->assertCount(2, $results);
 
-        $results = DB::collection('items')->where('tags', 'size', 3)->get();
+        $results = DB::table('items')->where('tags', 'size', 3)->get();
         $this->assertCount(0, $results);
 
-        $results = DB::collection('items')->where('tags', 'size', 4)->get();
+        $results = DB::table('items')->where('tags', 'size', 4)->get();
         $this->assertCount(1, $results);
 
         $regex   = new Regex('.*doe', 'i');
-        $results = DB::collection('users')->where('name', 'regex', $regex)->get();
+        $results = DB::table('users')->where('name', 'regex', $regex)->get();
         $this->assertCount(2, $results);
 
         $regex   = new Regex('.*doe', 'i');
-        $results = DB::collection('users')->where('name', 'regexp', $regex)->get();
+        $results = DB::table('users')->where('name', 'regexp', $regex)->get();
         $this->assertCount(2, $results);
 
-        $results = DB::collection('users')->where('name', 'REGEX', $regex)->get();
+        $results = DB::table('users')->where('name', 'REGEX', $regex)->get();
         $this->assertCount(2, $results);
 
-        $results = DB::collection('users')->where('name', 'regexp', '/.*doe/i')->get();
+        $results = DB::table('users')->where('name', 'regexp', '/.*doe/i')->get();
         $this->assertCount(2, $results);
 
-        $results = DB::collection('users')->where('name', 'not regexp', '/.*doe/i')->get();
+        $results = DB::table('users')->where('name', 'not regexp', '/.*doe/i')->get();
         $this->assertCount(1, $results);
 
-        DB::collection('users')->insert([
+        DB::table('users')->insert([
             [
                 'name' => 'John Doe',
                 'addresses' => [
@@ -820,69 +820,69 @@ class QueryBuilderTest extends TestCase
             ],
         ]);
 
-        $users = DB::collection('users')->where('addresses', 'elemMatch', ['city' => 'Brussels'])->get();
+        $users = DB::table('users')->where('addresses', 'elemMatch', ['city' => 'Brussels'])->get();
         $this->assertCount(1, $users);
         $this->assertEquals('Jane Doe', $users[0]['name']);
     }
 
     public function testIncrement()
     {
-        DB::collection('users')->insert([
+        DB::table('users')->insert([
             ['name' => 'John Doe', 'age' => 30, 'note' => 'adult'],
             ['name' => 'Jane Doe', 'age' => 10, 'note' => 'minor'],
             ['name' => 'Robert Roe', 'age' => null],
             ['name' => 'Mark Moe'],
         ]);
 
-        $user = DB::collection('users')->where('name', 'John Doe')->first();
+        $user = DB::table('users')->where('name', 'John Doe')->first();
         $this->assertEquals(30, $user['age']);
 
-        DB::collection('users')->where('name', 'John Doe')->increment('age');
-        $user = DB::collection('users')->where('name', 'John Doe')->first();
+        DB::table('users')->where('name', 'John Doe')->increment('age');
+        $user = DB::table('users')->where('name', 'John Doe')->first();
         $this->assertEquals(31, $user['age']);
 
-        DB::collection('users')->where('name', 'John Doe')->decrement('age');
-        $user = DB::collection('users')->where('name', 'John Doe')->first();
+        DB::table('users')->where('name', 'John Doe')->decrement('age');
+        $user = DB::table('users')->where('name', 'John Doe')->first();
         $this->assertEquals(30, $user['age']);
 
-        DB::collection('users')->where('name', 'John Doe')->increment('age', 5);
-        $user = DB::collection('users')->where('name', 'John Doe')->first();
+        DB::table('users')->where('name', 'John Doe')->increment('age', 5);
+        $user = DB::table('users')->where('name', 'John Doe')->first();
         $this->assertEquals(35, $user['age']);
 
-        DB::collection('users')->where('name', 'John Doe')->decrement('age', 5);
-        $user = DB::collection('users')->where('name', 'John Doe')->first();
+        DB::table('users')->where('name', 'John Doe')->decrement('age', 5);
+        $user = DB::table('users')->where('name', 'John Doe')->first();
         $this->assertEquals(30, $user['age']);
 
-        DB::collection('users')->where('name', 'Jane Doe')->increment('age', 10, ['note' => 'adult']);
-        $user = DB::collection('users')->where('name', 'Jane Doe')->first();
+        DB::table('users')->where('name', 'Jane Doe')->increment('age', 10, ['note' => 'adult']);
+        $user = DB::table('users')->where('name', 'Jane Doe')->first();
         $this->assertEquals(20, $user['age']);
         $this->assertEquals('adult', $user['note']);
 
-        DB::collection('users')->where('name', 'John Doe')->decrement('age', 20, ['note' => 'minor']);
-        $user = DB::collection('users')->where('name', 'John Doe')->first();
+        DB::table('users')->where('name', 'John Doe')->decrement('age', 20, ['note' => 'minor']);
+        $user = DB::table('users')->where('name', 'John Doe')->first();
         $this->assertEquals(10, $user['age']);
         $this->assertEquals('minor', $user['note']);
 
-        DB::collection('users')->increment('age');
-        $user = DB::collection('users')->where('name', 'John Doe')->first();
+        DB::table('users')->increment('age');
+        $user = DB::table('users')->where('name', 'John Doe')->first();
         $this->assertEquals(11, $user['age']);
-        $user = DB::collection('users')->where('name', 'Jane Doe')->first();
+        $user = DB::table('users')->where('name', 'Jane Doe')->first();
         $this->assertEquals(21, $user['age']);
-        $user = DB::collection('users')->where('name', 'Robert Roe')->first();
+        $user = DB::table('users')->where('name', 'Robert Roe')->first();
         $this->assertNull($user['age']);
-        $user = DB::collection('users')->where('name', 'Mark Moe')->first();
+        $user = DB::table('users')->where('name', 'Mark Moe')->first();
         $this->assertEquals(1, $user['age']);
     }
 
     public function testProjections()
     {
-        DB::collection('items')->insert([
+        DB::table('items')->insert([
             ['name' => 'fork', 'tags' => ['sharp', 'pointy']],
             ['name' => 'spork', 'tags' => ['sharp', 'pointy', 'round', 'bowl']],
             ['name' => 'spoon', 'tags' => ['round', 'bowl']],
         ]);
 
-        $results = DB::collection('items')->project(['tags' => ['$slice' => 1]])->get();
+        $results = DB::table('items')->project(['tags' => ['$slice' => 1]])->get();
 
         foreach ($results as $result) {
             $this->assertEquals(1, count($result['tags']));
@@ -891,32 +891,32 @@ class QueryBuilderTest extends TestCase
 
     public function testValue()
     {
-        DB::collection('books')->insert([
+        DB::table('books')->insert([
             ['title' => 'Moby-Dick', 'author' => ['first_name' => 'Herman', 'last_name' => 'Melville']],
         ]);
 
-        $this->assertEquals('Moby-Dick', DB::collection('books')->value('title'));
-        $this->assertEquals(['first_name' => 'Herman', 'last_name' => 'Melville'], DB::collection('books')
+        $this->assertEquals('Moby-Dick', DB::table('books')->value('title'));
+        $this->assertEquals(['first_name' => 'Herman', 'last_name' => 'Melville'], DB::table('books')
             ->value('author'));
-        $this->assertEquals('Herman', DB::collection('books')->value('author.first_name'));
-        $this->assertEquals('Melville', DB::collection('books')->value('author.last_name'));
+        $this->assertEquals('Herman', DB::table('books')->value('author.first_name'));
+        $this->assertEquals('Melville', DB::table('books')->value('author.last_name'));
     }
 
     public function testHintOptions()
     {
-        DB::collection('items')->insert([
+        DB::table('items')->insert([
             ['name' => 'fork', 'tags' => ['sharp', 'pointy']],
             ['name' => 'spork', 'tags' => ['sharp', 'pointy', 'round', 'bowl']],
             ['name' => 'spoon', 'tags' => ['round', 'bowl']],
         ]);
 
-        $results = DB::collection('items')->hint(['$natural' => -1])->get();
+        $results = DB::table('items')->hint(['$natural' => -1])->get();
 
         $this->assertEquals('spoon', $results[0]['name']);
         $this->assertEquals('spork', $results[1]['name']);
         $this->assertEquals('fork', $results[2]['name']);
 
-        $results = DB::collection('items')->hint(['$natural' => 1])->get();
+        $results = DB::table('items')->hint(['$natural' => 1])->get();
 
         $this->assertEquals('spoon', $results[2]['name']);
         $this->assertEquals('spork', $results[1]['name']);
@@ -930,9 +930,9 @@ class QueryBuilderTest extends TestCase
             ['name' => 'spork', 'tags' => ['sharp', 'pointy', 'round', 'bowl']],
             ['name' => 'spoon', 'tags' => ['round', 'bowl']],
         ];
-        DB::collection('items')->insert($data);
+        DB::table('items')->insert($data);
 
-        $results = DB::collection('items')->orderBy('_id', 'asc')->cursor();
+        $results = DB::table('items')->orderBy('_id', 'asc')->cursor();
 
         $this->assertInstanceOf(LazyCollection::class, $results);
         foreach ($results as $i => $result) {
@@ -942,7 +942,7 @@ class QueryBuilderTest extends TestCase
 
     public function testStringableColumn()
     {
-        DB::collection('users')->insert([
+        DB::table('users')->insert([
             ['name' => 'Jane Doe', 'age' => 36, 'birthday' => new UTCDateTime(new DateTime('1987-01-01 00:00:00'))],
             ['name' => 'John Doe', 'age' => 28, 'birthday' => new UTCDateTime(new DateTime('1995-01-01 00:00:00'))],
         ]);
@@ -950,100 +950,100 @@ class QueryBuilderTest extends TestCase
         $nameColumn = Str::of('name');
         $this->assertInstanceOf(Stringable::class, $nameColumn, 'Ensure we are testing the feature with a Stringable instance');
 
-        $user = DB::collection('users')->where($nameColumn, 'John Doe')->first();
+        $user = DB::table('users')->where($nameColumn, 'John Doe')->first();
         $this->assertEquals('John Doe', $user['name']);
 
         // Test this other document to be sure this is not a random success to data order
-        $user = DB::collection('users')->where($nameColumn, 'Jane Doe')->orderBy('natural')->first();
+        $user = DB::table('users')->where($nameColumn, 'Jane Doe')->orderBy('natural')->first();
         $this->assertEquals('Jane Doe', $user['name']);
 
         // With an operator
-        $user = DB::collection('users')->where($nameColumn, '!=', 'Jane Doe')->first();
+        $user = DB::table('users')->where($nameColumn, '!=', 'Jane Doe')->first();
         $this->assertEquals('John Doe', $user['name']);
 
         // whereIn and whereNotIn
-        $user = DB::collection('users')->whereIn($nameColumn, ['John Doe'])->first();
+        $user = DB::table('users')->whereIn($nameColumn, ['John Doe'])->first();
         $this->assertEquals('John Doe', $user['name']);
 
-        $user = DB::collection('users')->whereNotIn($nameColumn, ['John Doe'])->first();
+        $user = DB::table('users')->whereNotIn($nameColumn, ['John Doe'])->first();
         $this->assertEquals('Jane Doe', $user['name']);
 
         $ageColumn = Str::of('age');
         // whereBetween and whereNotBetween
-        $user = DB::collection('users')->whereBetween($ageColumn, [30, 40])->first();
+        $user = DB::table('users')->whereBetween($ageColumn, [30, 40])->first();
         $this->assertEquals('Jane Doe', $user['name']);
 
         // whereBetween and whereNotBetween
-        $user = DB::collection('users')->whereNotBetween($ageColumn, [30, 40])->first();
+        $user = DB::table('users')->whereNotBetween($ageColumn, [30, 40])->first();
         $this->assertEquals('John Doe', $user['name']);
 
         $birthdayColumn = Str::of('birthday');
         // whereDate
-        $user = DB::collection('users')->whereDate($birthdayColumn, '1995-01-01')->first();
+        $user = DB::table('users')->whereDate($birthdayColumn, '1995-01-01')->first();
         $this->assertEquals('John Doe', $user['name']);
 
-        $user = DB::collection('users')->whereDate($birthdayColumn, '<', '1990-01-01')
+        $user = DB::table('users')->whereDate($birthdayColumn, '<', '1990-01-01')
             ->orderBy($birthdayColumn, 'desc')->first();
         $this->assertEquals('Jane Doe', $user['name']);
 
-        $user = DB::collection('users')->whereDate($birthdayColumn, '>', '1990-01-01')
+        $user = DB::table('users')->whereDate($birthdayColumn, '>', '1990-01-01')
             ->orderBy($birthdayColumn, 'asc')->first();
         $this->assertEquals('John Doe', $user['name']);
 
-        $user = DB::collection('users')->whereDate($birthdayColumn, '!=', '1987-01-01')->first();
+        $user = DB::table('users')->whereDate($birthdayColumn, '!=', '1987-01-01')->first();
         $this->assertEquals('John Doe', $user['name']);
 
         // increment
-        DB::collection('users')->where($ageColumn, 28)->increment($ageColumn, 1);
-        $user = DB::collection('users')->where($ageColumn, 29)->first();
+        DB::table('users')->where($ageColumn, 28)->increment($ageColumn, 1);
+        $user = DB::table('users')->where($ageColumn, 29)->first();
         $this->assertEquals('John Doe', $user['name']);
     }
 
     public function testIncrementEach()
     {
-        DB::collection('users')->insert([
+        DB::table('users')->insert([
             ['name' => 'John Doe', 'age' => 30, 'note' => 5],
             ['name' => 'Jane Doe', 'age' => 10, 'note' => 6],
             ['name' => 'Robert Roe', 'age' => null],
         ]);
 
-        DB::collection('users')->incrementEach([
+        DB::table('users')->incrementEach([
             'age' => 1,
             'note' => 2,
         ]);
-        $user = DB::collection('users')->where('name', 'John Doe')->first();
+        $user = DB::table('users')->where('name', 'John Doe')->first();
         $this->assertEquals(31, $user['age']);
         $this->assertEquals(7, $user['note']);
 
-        $user = DB::collection('users')->where('name', 'Jane Doe')->first();
+        $user = DB::table('users')->where('name', 'Jane Doe')->first();
         $this->assertEquals(11, $user['age']);
         $this->assertEquals(8, $user['note']);
 
-        $user = DB::collection('users')->where('name', 'Robert Roe')->first();
+        $user = DB::table('users')->where('name', 'Robert Roe')->first();
         $this->assertSame(1, $user['age']);
         $this->assertSame(2, $user['note']);
 
-        DB::collection('users')->where('name', 'Jane Doe')->incrementEach([
+        DB::table('users')->where('name', 'Jane Doe')->incrementEach([
             'age' => 1,
             'note' => 2,
         ], ['extra' => 'foo']);
 
-        $user = DB::collection('users')->where('name', 'Jane Doe')->first();
+        $user = DB::table('users')->where('name', 'Jane Doe')->first();
         $this->assertEquals(12, $user['age']);
         $this->assertEquals(10, $user['note']);
         $this->assertEquals('foo', $user['extra']);
 
-        $user = DB::collection('users')->where('name', 'John Doe')->first();
+        $user = DB::table('users')->where('name', 'John Doe')->first();
         $this->assertEquals(31, $user['age']);
         $this->assertEquals(7, $user['note']);
         $this->assertArrayNotHasKey('extra', $user);
 
-        DB::collection('users')->decrementEach([
+        DB::table('users')->decrementEach([
             'age' => 1,
             'note' => 2,
         ], ['extra' => 'foo']);
 
-        $user = DB::collection('users')->where('name', 'John Doe')->first();
+        $user = DB::table('users')->where('name', 'John Doe')->first();
         $this->assertEquals(30, $user['age']);
         $this->assertEquals(5, $user['note']);
         $this->assertEquals('foo', $user['extra']);

--- a/tests/Queue/Failed/MongoFailedJobProviderTest.php
+++ b/tests/Queue/Failed/MongoFailedJobProviderTest.php
@@ -21,7 +21,7 @@ class MongoFailedJobProviderTest extends TestCase
         parent::setUp();
 
         DB::connection('mongodb')
-            ->collection('failed_jobs')
+            ->table('failed_jobs')
             ->raw()
             ->insertMany(array_map(static fn ($i) => [
                 '_id' => new ObjectId(sprintf('%024d', $i)),
@@ -34,7 +34,7 @@ class MongoFailedJobProviderTest extends TestCase
     public function tearDown(): void
     {
         DB::connection('mongodb')
-            ->collection('failed_jobs')
+            ->table('failed_jobs')
             ->raw()
             ->drop();
 

--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -344,11 +344,11 @@ class SchemaTest extends TestCase
 
     public function testRenameColumn(): void
     {
-        DB::connection()->collection('newcollection')->insert(['test' => 'value']);
-        DB::connection()->collection('newcollection')->insert(['test' => 'value 2']);
-        DB::connection()->collection('newcollection')->insert(['column' => 'column value']);
+        DB::connection()->table('newcollection')->insert(['test' => 'value']);
+        DB::connection()->table('newcollection')->insert(['test' => 'value 2']);
+        DB::connection()->table('newcollection')->insert(['column' => 'column value']);
 
-        $check = DB::connection()->collection('newcollection')->get();
+        $check = DB::connection()->table('newcollection')->get();
         $this->assertCount(3, $check);
 
         $this->assertArrayHasKey('test', $check[0]);
@@ -365,7 +365,7 @@ class SchemaTest extends TestCase
             $collection->renameColumn('test', 'newtest');
         });
 
-        $check2 = DB::connection()->collection('newcollection')->get();
+        $check2 = DB::connection()->table('newcollection')->get();
         $this->assertCount(3, $check2);
 
         $this->assertArrayHasKey('newtest', $check2[0]);
@@ -384,7 +384,7 @@ class SchemaTest extends TestCase
 
     public function testHasColumn(): void
     {
-        DB::connection()->collection('newcollection')->insert(['column1' => 'value']);
+        DB::connection()->table('newcollection')->insert(['column1' => 'value']);
 
         $this->assertTrue(Schema::hasColumn('newcollection', 'column1'));
         $this->assertFalse(Schema::hasColumn('newcollection', 'column2'));
@@ -393,7 +393,7 @@ class SchemaTest extends TestCase
     public function testHasColumns(): void
     {
         // Insert documents with both column1 and column2
-        DB::connection()->collection('newcollection')->insert([
+        DB::connection()->table('newcollection')->insert([
             ['column1' => 'value1', 'column2' => 'value2'],
             ['column1' => 'value3'],
         ]);
@@ -404,8 +404,8 @@ class SchemaTest extends TestCase
 
     public function testGetTables()
     {
-        DB::connection('mongodb')->collection('newcollection')->insert(['test' => 'value']);
-        DB::connection('mongodb')->collection('newcollection_two')->insert(['test' => 'value']);
+        DB::connection('mongodb')->table('newcollection')->insert(['test' => 'value']);
+        DB::connection('mongodb')->table('newcollection_two')->insert(['test' => 'value']);
 
         $tables = Schema::getTables();
         $this->assertIsArray($tables);
@@ -428,8 +428,8 @@ class SchemaTest extends TestCase
 
     public function testGetTableListing()
     {
-        DB::connection('mongodb')->collection('newcollection')->insert(['test' => 'value']);
-        DB::connection('mongodb')->collection('newcollection_two')->insert(['test' => 'value']);
+        DB::connection('mongodb')->table('newcollection')->insert(['test' => 'value']);
+        DB::connection('mongodb')->table('newcollection_two')->insert(['test' => 'value']);
 
         $tables = Schema::getTableListing();
 
@@ -441,7 +441,7 @@ class SchemaTest extends TestCase
 
     public function testGetColumns()
     {
-        $collection = DB::connection('mongodb')->collection('newcollection');
+        $collection = DB::connection('mongodb')->table('newcollection');
         $collection->insert(['text' => 'value', 'mixed' => ['key' => 'value']]);
         $collection->insert(['date' => new UTCDateTime(), 'binary' => new Binary('binary'), 'mixed' => true]);
 

--- a/tests/SchemaVersionTest.php
+++ b/tests/SchemaVersionTest.php
@@ -38,7 +38,7 @@ class SchemaVersionTest extends TestCase
 
         // The migrated version is saved
         $data = DB::connection('mongodb')
-            ->collection('documentVersion')
+            ->table('documentVersion')
             ->where('name', 'Vador')
             ->get();
 

--- a/tests/Seeder/UserTableSeeder.php
+++ b/tests/Seeder/UserTableSeeder.php
@@ -11,8 +11,8 @@ class UserTableSeeder extends Seeder
 {
     public function run()
     {
-        DB::collection('users')->delete();
+        DB::table('users')->delete();
 
-        DB::collection('users')->insert(['name' => 'John Doe', 'seed' => true]);
+        DB::table('users')->insert(['name' => 'John Doe', 'seed' => true]);
     }
 }

--- a/tests/TransactionTest.php
+++ b/tests/TransactionTest.php
@@ -66,19 +66,19 @@ class TransactionTest extends TestCase
     public function testInsertWithCommit(): void
     {
         DB::beginTransaction();
-        DB::collection('users')->insert(['name' => 'klinson', 'age' => 20, 'title' => 'admin']);
+        DB::table('users')->insert(['name' => 'klinson', 'age' => 20, 'title' => 'admin']);
         DB::commit();
 
-        $this->assertTrue(DB::collection('users')->where('name', 'klinson')->exists());
+        $this->assertTrue(DB::table('users')->where('name', 'klinson')->exists());
     }
 
     public function testInsertWithRollBack(): void
     {
         DB::beginTransaction();
-        DB::collection('users')->insert(['name' => 'klinson', 'age' => 20, 'title' => 'admin']);
+        DB::table('users')->insert(['name' => 'klinson', 'age' => 20, 'title' => 'admin']);
         DB::rollBack();
 
-        $this->assertFalse(DB::collection('users')->where('name', 'klinson')->exists());
+        $this->assertFalse(DB::table('users')->where('name', 'klinson')->exists());
     }
 
     public function testEloquentCreateWithCommit(): void
@@ -116,23 +116,23 @@ class TransactionTest extends TestCase
     public function testInsertGetIdWithCommit(): void
     {
         DB::beginTransaction();
-        $userId = DB::collection('users')->insertGetId(['name' => 'klinson', 'age' => 20, 'title' => 'admin']);
+        $userId = DB::table('users')->insertGetId(['name' => 'klinson', 'age' => 20, 'title' => 'admin']);
         DB::commit();
 
         $this->assertInstanceOf(ObjectId::class, $userId);
 
-        $user = DB::collection('users')->find((string) $userId);
+        $user = DB::table('users')->find((string) $userId);
         $this->assertEquals('klinson', $user['name']);
     }
 
     public function testInsertGetIdWithRollBack(): void
     {
         DB::beginTransaction();
-        $userId = DB::collection('users')->insertGetId(['name' => 'klinson', 'age' => 20, 'title' => 'admin']);
+        $userId = DB::table('users')->insertGetId(['name' => 'klinson', 'age' => 20, 'title' => 'admin']);
         DB::rollBack();
 
         $this->assertInstanceOf(ObjectId::class, $userId);
-        $this->assertFalse(DB::collection('users')->where('_id', (string) $userId)->exists());
+        $this->assertFalse(DB::table('users')->where('_id', (string) $userId)->exists());
     }
 
     public function testUpdateWithCommit(): void
@@ -140,11 +140,11 @@ class TransactionTest extends TestCase
         User::create(['name' => 'klinson', 'age' => 20, 'title' => 'admin']);
 
         DB::beginTransaction();
-        $updated = DB::collection('users')->where('name', 'klinson')->update(['age' => 21]);
+        $updated = DB::table('users')->where('name', 'klinson')->update(['age' => 21]);
         DB::commit();
 
         $this->assertEquals(1, $updated);
-        $this->assertTrue(DB::collection('users')->where('name', 'klinson')->where('age', 21)->exists());
+        $this->assertTrue(DB::table('users')->where('name', 'klinson')->where('age', 21)->exists());
     }
 
     public function testUpdateWithRollback(): void
@@ -152,11 +152,11 @@ class TransactionTest extends TestCase
         User::create(['name' => 'klinson', 'age' => 20, 'title' => 'admin']);
 
         DB::beginTransaction();
-        $updated = DB::collection('users')->where('name', 'klinson')->update(['age' => 21]);
+        $updated = DB::table('users')->where('name', 'klinson')->update(['age' => 21]);
         DB::rollBack();
 
         $this->assertEquals(1, $updated);
-        $this->assertFalse(DB::collection('users')->where('name', 'klinson')->where('age', 21)->exists());
+        $this->assertFalse(DB::table('users')->where('name', 'klinson')->where('age', 21)->exists());
     }
 
     public function testEloquentUpdateWithCommit(): void
@@ -254,10 +254,10 @@ class TransactionTest extends TestCase
         User::create(['name' => 'klinson', 'age' => 20, 'title' => 'admin']);
 
         DB::beginTransaction();
-        DB::collection('users')->where('name', 'klinson')->increment('age');
+        DB::table('users')->where('name', 'klinson')->increment('age');
         DB::commit();
 
-        $this->assertTrue(DB::collection('users')->where('name', 'klinson')->where('age', 21)->exists());
+        $this->assertTrue(DB::table('users')->where('name', 'klinson')->where('age', 21)->exists());
     }
 
     public function testIncrementWithRollBack(): void
@@ -265,10 +265,10 @@ class TransactionTest extends TestCase
         User::create(['name' => 'klinson', 'age' => 20, 'title' => 'admin']);
 
         DB::beginTransaction();
-        DB::collection('users')->where('name', 'klinson')->increment('age');
+        DB::table('users')->where('name', 'klinson')->increment('age');
         DB::rollBack();
 
-        $this->assertTrue(DB::collection('users')->where('name', 'klinson')->where('age', 20)->exists());
+        $this->assertTrue(DB::table('users')->where('name', 'klinson')->where('age', 20)->exists());
     }
 
     public function testDecrementWithCommit(): void
@@ -276,10 +276,10 @@ class TransactionTest extends TestCase
         User::create(['name' => 'klinson', 'age' => 20, 'title' => 'admin']);
 
         DB::beginTransaction();
-        DB::collection('users')->where('name', 'klinson')->decrement('age');
+        DB::table('users')->where('name', 'klinson')->decrement('age');
         DB::commit();
 
-        $this->assertTrue(DB::collection('users')->where('name', 'klinson')->where('age', 19)->exists());
+        $this->assertTrue(DB::table('users')->where('name', 'klinson')->where('age', 19)->exists());
     }
 
     public function testDecrementWithRollBack(): void
@@ -287,36 +287,36 @@ class TransactionTest extends TestCase
         User::create(['name' => 'klinson', 'age' => 20, 'title' => 'admin']);
 
         DB::beginTransaction();
-        DB::collection('users')->where('name', 'klinson')->decrement('age');
+        DB::table('users')->where('name', 'klinson')->decrement('age');
         DB::rollBack();
 
-        $this->assertTrue(DB::collection('users')->where('name', 'klinson')->where('age', 20)->exists());
+        $this->assertTrue(DB::table('users')->where('name', 'klinson')->where('age', 20)->exists());
     }
 
     public function testQuery()
     {
         /** rollback test */
         DB::beginTransaction();
-        $count = DB::collection('users')->count();
+        $count = DB::table('users')->count();
         $this->assertEquals(0, $count);
-        DB::collection('users')->insert(['name' => 'klinson', 'age' => 20, 'title' => 'admin']);
-        $count = DB::collection('users')->count();
+        DB::table('users')->insert(['name' => 'klinson', 'age' => 20, 'title' => 'admin']);
+        $count = DB::table('users')->count();
         $this->assertEquals(1, $count);
         DB::rollBack();
 
-        $count = DB::collection('users')->count();
+        $count = DB::table('users')->count();
         $this->assertEquals(0, $count);
 
         /** commit test */
         DB::beginTransaction();
-        $count = DB::collection('users')->count();
+        $count = DB::table('users')->count();
         $this->assertEquals(0, $count);
-        DB::collection('users')->insert(['name' => 'klinson', 'age' => 20, 'title' => 'admin']);
-        $count = DB::collection('users')->count();
+        DB::table('users')->insert(['name' => 'klinson', 'age' => 20, 'title' => 'admin']);
+        $count = DB::table('users')->count();
         $this->assertEquals(1, $count);
         DB::commit();
 
-        $count = DB::collection('users')->count();
+        $count = DB::table('users')->count();
         $this->assertEquals(1, $count);
     }
 


### PR DESCRIPTION
Fix PHPORM-219

`The method MongoDB\Laravel\Connection::collection()` is an alias for Laravel’s `Illuminate\Database\ConnectionInterface::table()`. I guess it was introduced when the package was created to fit [MongoDB terminology](https://www.mongodb.com/docs/manual/reference/sql-comparison/#terminology-and-concepts).

Removing this custom name fit with Laravel and remove the one of the 2 ways of doing the same thing.

### Checklist

- [x] Add tests and ensure they pass
- [x] Add an entry to the CHANGELOG.md file
- [ ] Update documentation for new features
