### PR TITLE
PHPORM-221 Convert `$near` into `$geoWithin` for count used by pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 * Add `Query\Builder::incrementEach()` and `decrementEach()` methods by @SmallRuralDog in [#2550](https://github.com/mongodb/laravel-mongodb/pull/2550)
 * Deprecate `Connection::collection()` and `Schema\Builder::collection()` methods by @GromNaN in [#3062](https://github.com/mongodb/laravel-mongodb/pull/3062)
 * Deprecate `Model::$collection` property to customize collection name. Use `$table` instead by @GromNaN in [#3064](https://github.com/mongodb/laravel-mongodb/pull/3064)
+* Convert `$near` to `$geoWithin` in queries using aggregation by @GromNaN in [#3073](https://github.com/mongodb/laravel-mongodb/pull/3073)
 
 ## [4.7.0] - 2024-07-19
 

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -574,6 +574,27 @@ class QueryTest extends TestCase
         User::distinct('age')->paginate(2);
     }
 
+    public function testPaginateNear(): void
+    {
+        User::insert([
+            ['name' => 'Store A', 'position' => [9.224596977233887, 52.03082275390625]],
+            ['name' => 'Store B', 'position' => [9.224596977233887, 52.03082275390625]],
+            ['name' => 'Store C', 'position' => [9.3731451034548, 52.10194]],
+        ]);
+
+        $query = User::where('position', 'near', [
+            '$geometry' => [
+                'type' => 'Point',
+                'coordinates' => [9.3731451034546, 52.1019308],
+            ],
+            '$maxDistance' => 50,
+        ]);
+        $result = $query->paginate();
+
+        $this->assertCount(1, $result->items());
+        $this->assertSame('Store C', $result->first()->name);
+    }
+
     public function testUpdate(): void
     {
         $this->assertEquals(1, User::where(['name' => 'John Doe'])->update(['name' => 'Jim Morrison']));

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -6,6 +6,7 @@ namespace MongoDB\Laravel\Tests;
 
 use BadMethodCallException;
 use DateTimeImmutable;
+use Illuminate\Support\Facades\Schema;
 use LogicException;
 use MongoDB\BSON\Regex;
 use MongoDB\Laravel\Eloquent\Builder;
@@ -44,7 +45,9 @@ class QueryTest extends TestCase
 
     public function tearDown(): void
     {
-        User::truncate();
+        Schema::table('users', function ($table) {
+            $table->drop();
+        });
         Scoped::truncate();
         Birthday::truncate();
 
@@ -576,6 +579,9 @@ class QueryTest extends TestCase
 
     public function testPaginateNear(): void
     {
+        Schema::table('users', function ($table) {
+            $table->geospatial('position', '2dsphere');
+        });
         User::insert([
             ['name' => 'Store A', 'position' => [9.224596977233887, 52.03082275390625]],
             ['name' => 'Store B', 'position' => [9.224596977233887, 52.03082275390625]],


### PR DESCRIPTION
Fix PHPORM-221
Fix #3063

The sorting provided by `$near` is not important for counting, but is useful when getting paginated results. So we can convert the operation to `$geoWithin` when in an aggregation.

If can try to add other unsupported operators (`$geoNear` and `$nearSphere`).

### Checklist

- [x] Add tests and ensure they pass
- [x] Add an entry to the CHANGELOG.md file
- [ ] Update documentation for new features
