### PR TITLE
Fix wrong name for driver options in docs

### DIFF
--- a/docs/fundamentals/connection/connect-to-mongodb.txt
+++ b/docs/fundamentals/connection/connect-to-mongodb.txt
@@ -157,7 +157,7 @@ For a MongoDB database connection, you can specify the following details:
        connection behavior. To learn more about connection options, see
        :ref:`laravel-connection-auth-options`.
 
-   * - ``driverOptions``
+   * - ``driver_options``
      - Specifies options specific to pass to the {+php-library+} that
        determine the driver behavior for that connection. To learn more about
        driver options, see :ref:`laravel-driver-options`.
@@ -170,7 +170,7 @@ For a MongoDB database connection, you can specify the following details:
    - ``host``
    - ``username``
    - ``password``
-   - ``options`` and ``driverOptions``, which are specified by the option name
+   - ``options`` and ``driver_options``, which are specified by the option name
 
 The following example shows how you can specify your MongoDB connection details
 in the ``connections`` array item:
@@ -187,7 +187,7 @@ in the ``connections`` array item:
                'maxPoolSize' => 20,
                'w' => 'majority',
            ],
-           'driverOptions' => [
+           'driver_options' => [
                'serverApi' => 1,
            ],
        ],

--- a/docs/fundamentals/connection/connection-options.txt
+++ b/docs/fundamentals/connection/connection-options.txt
@@ -9,7 +9,7 @@ Connection Options
    :values: reference
 
 .. meta::
-   :keywords: code example, data source name, dsn, authentication, configuration, options, driverOptions
+   :keywords: code example, data source name, dsn, authentication, configuration, options, driver_options
 
 .. contents:: On this page
    :local:
@@ -329,7 +329,7 @@ connections and all operations between a Laravel application and MongoDB.
 
 You can specify driver options in your Laravel web application's
 ``config/database.php`` configuration file. To add driver options,
-add the setting and value as an array item in the ``driverOptions`` array
+add the setting and value as an array item in the ``driver_options`` array
 item, as shown in the following example:
 
 .. code-block:: php
@@ -340,7 +340,7 @@ item, as shown in the following example:
            'dsn' => 'mongodb+srv://mongodb0.example.com/',
            'driver' => 'mongodb',
            'database' => 'sample_mflix',
-           'driverOptions' => [
+           'driver_options' => [
                'serverApi' => 1,
                'allow_invalid_hostname' => false,
            ],


### PR DESCRIPTION
The docs use `driverOptions` as key in the connection config, but the connection class actually checks the `driver_options` key. Since the latter name has been in use for a while, I figured that the docs were wrong and updated the documentation so that the configuration is properly accepted.