### PR TITLE
Added ability to use owner key if provided to the morph relation

### DIFF
--- a/src/Relations/MorphTo.php
+++ b/src/Relations/MorphTo.php
@@ -29,11 +29,11 @@ class MorphTo extends EloquentMorphTo
     {
         $instance = $this->createModelByType($type);
 
-        $key = $instance->getKeyName();
+        $ownerKey = $this->ownerKey ?? $instance->getKeyName();
 
         $query = $instance->newQuery();
 
-        return $query->whereIn($key, $this->gatherKeysByType($type, $instance->getKeyType()))->get();
+        return $query->whereIn($ownerKey, $this->gatherKeysByType($type, $instance->getKeyType()))->get();
     }
 
     /**


### PR DESCRIPTION
In Laravel Polymorphic relations, you can specify the owner key to the relation

```php
protected function getResultsByType($type)
{
    $instance = $this->createModelByType($type);

    $key = $instance->getKeyName(); // <--- Before the change
    $ownerKey = $this->ownerKey ?? $instance->getKeyName(); // <---- After the change

    $query = $instance->newQuery();

    return $query->whereIn($ownerKey, $this->gatherKeysByType($type, $instance->getKeyType()))->get();
}
``` 

### Checklist

- [ ] Add tests and ensure they pass
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Update documentation for new features
