### PR TITLE
PHPORM-230 Convert DateTimeInterface to UTCDateTime in queries

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -1060,12 +1060,7 @@ class Builder extends BaseBuilder
             $options['multiple'] = true;
         }
 
-        // Since "id" is an alias for "_id", we prevent updating it
-        foreach ($update as $operator => $fields) {
-            if (array_key_exists('id', $fields)) {
-                throw new InvalidArgumentException('Cannot update "id" field.');
-            }
-        }
+        $update = $this->aliasIdForQuery($update);
 
         $options = $this->inheritConnectionOptions($options);
 

--- a/tests/Query/AggregationBuilderTest.php
+++ b/tests/Query/AggregationBuilderTest.php
@@ -11,7 +11,6 @@ use Illuminate\Support\LazyCollection;
 use InvalidArgumentException;
 use MongoDB\BSON\Document;
 use MongoDB\BSON\ObjectId;
-use MongoDB\BSON\UTCDateTime;
 use MongoDB\Builder\BuilderEncoder;
 use MongoDB\Builder\Expression;
 use MongoDB\Builder\Pipeline;
@@ -33,8 +32,8 @@ class AggregationBuilderTest extends TestCase
     public function testCreateAggregationBuilder(): void
     {
         User::insert([
-            ['name' => 'John Doe', 'birthday' => new UTCDateTime(new DateTimeImmutable('1989-01-01'))],
-            ['name' => 'Jane Doe', 'birthday' => new UTCDateTime(new DateTimeImmutable('1990-01-01'))],
+            ['name' => 'John Doe', 'birthday' => new DateTimeImmutable('1989-01-01')],
+            ['name' => 'Jane Doe', 'birthday' => new DateTimeImmutable('1990-01-01')],
         ]);
 
         // Create the aggregation pipeline from the query builder

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -566,6 +566,12 @@ class BuilderTest extends TestCase
             fn (Builder $builder) => $builder->whereBetween('id', [[1], [2, 3]]),
         ];
 
+        $date = new DateTimeImmutable('2018-09-30 15:00:00 +02:00');
+        yield 'where $lt DateTimeInterface' => [
+            ['find' => [['created_at' => ['$lt' => new UTCDateTime($date)]], []]],
+            fn (Builder $builder) => $builder->where('created_at', '<', $date),
+        ];
+
         $period = now()->toPeriod(now()->addMonth());
         yield 'whereBetween CarbonPeriod' => [
             [

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -1053,16 +1053,20 @@ class QueryBuilderTest extends TestCase
     #[TestWith(['id', 'id'])]
     #[TestWith(['id', '_id'])]
     #[TestWith(['_id', 'id'])]
+    #[TestWith(['_id', '_id'])]
     public function testIdAlias($insertId, $queryId): void
     {
-        DB::collection('items')->insert([$insertId => 'abc', 'name' => 'Karting']);
-        $item = DB::collection('items')->where($queryId, '=', 'abc')->first();
+        DB::table('items')->insert([$insertId => 'abc', 'name' => 'Karting']);
+        $item = DB::table('items')->where($queryId, '=', 'abc')->first();
         $this->assertNotNull($item);
         $this->assertSame('abc', $item['id']);
         $this->assertSame('Karting', $item['name']);
 
-        DB::collection('items')->where($insertId, '=', 'abc')->update(['name' => 'Bike']);
-        $item = DB::collection('items')->where($queryId, '=', 'abc')->first();
+        DB::table('items')->where($insertId, '=', 'abc')->update(['name' => 'Bike']);
+        $item = DB::table('items')->where($queryId, '=', 'abc')->first();
         $this->assertSame('Bike', $item['name']);
+
+        $result = DB::table('items')->where($queryId, '=', 'abc')->delete();
+        $this->assertSame(1, $result);
     }
 }


### PR DESCRIPTION
Fix PHPORM-230

By default, `DateTimeInterface` objects are converted to empty objects by the PHP driver. In this package, they are already explicitly converted to `MongoDB\BSON\UTCDateTime` objects in Eloquent models (depending on cast) and DB queries.

This PR generalize this transformation by applying the conversion to every command: including `DB::insert` and `DB::update` values.

### Checklist

- [x] Add tests and ensure they pass
- [ ] Add an entry to the CHANGELOG.md file
- [ ] Update documentation for new features
