### PR TITLE
Remove MongoDBQueueServiceProvider in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,6 @@
         "laravel": {
             "providers": [
                 "MongoDB\\Laravel\\MongoDBServiceProvider",
-                "MongoDB\\Laravel\\MongoDBQueueServiceProvider",
                 "MongoDB\\Laravel\\MongoDBBusServiceProvider"
             ]
         }


### PR DESCRIPTION
Class "MongoDB\Laravel\MongoDBQueueServiceProvider" not found  due to being removed in this commit https://github.com/mongodb/laravel-mongodb/commit/a0b613498b3d7148821566d7774c0655e8629bbe

### Checklist

- [ ] Add tests and ensure they pass
- [ ] Add an entry to the CHANGELOG.md file
