### PR TITLE
PHPORM-157 Remove `Blueprint::background()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 * **BREAKING CHANGE** Make Query\Builder return objects instead of array to match Laravel behavior by @GromNaN in [#3107](https://github.com/mongodb/laravel-mongodb/pull/3107)
 * **BREAKING CHANGE** In DB query results, convert BSON `UTCDateTime` objects into `Carbon` date with the default timezone by @GromNaN in [#3119](https://github.com/mongodb/laravel-mongodb/pull/3119)
 * Remove `MongoFailedJobProvider`, replaced by Laravel `DatabaseFailedJobProvider` by @GromNaN in [#3122](https://github.com/mongodb/laravel-mongodb/pull/3122)
+* Remove `Blueprint::background()` method by @GromNaN in [#3132](https://github.com/mongodb/laravel-mongodb/pull/3132)
 
 ## [4.8.0] - 2024-08-27
 

--- a/src/Schema/Blueprint.php
+++ b/src/Schema/Blueprint.php
@@ -178,22 +178,6 @@ class Blueprint extends SchemaBlueprint
     }
 
     /**
-     * Specify a non blocking index for the collection.
-     *
-     * @param string|array $columns
-     *
-     * @return Blueprint
-     */
-    public function background($columns = null)
-    {
-        $columns = $this->fluent($columns);
-
-        $this->index($columns, null, null, ['background' => true]);
-
-        return $this;
-    }
-
-    /**
      * Specify a sparse index for the collection.
      *
      * @param string|array $columns

--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -245,16 +245,6 @@ class SchemaTest extends TestCase
         });
     }
 
-    public function testBackground(): void
-    {
-        Schema::table('newcollection', function ($collection) {
-            $collection->background('backgroundkey');
-        });
-
-        $index = $this->getIndex('newcollection', 'backgroundkey');
-        $this->assertEquals(1, $index['background']);
-    }
-
     public function testSparse(): void
     {
         Schema::table('newcollection', function ($collection) {


### PR DESCRIPTION
Fix PHPORM-157

This index option was removed since MongoDB 4.2

### Checklist

- [ ] Add tests and ensure they pass
- [x] Add an entry to the CHANGELOG.md file
