### PR TITLE
Add options to countDocuments method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 * Remove custom `PasswordResetServiceProvider`, use the default `DatabaseTokenRepository` by @GromNaN in [#3124](https://github.com/mongodb/laravel-mongodb/pull/3124)
 * Remove `Blueprint::background()` method by @GromNaN in [#3132](https://github.com/mongodb/laravel-mongodb/pull/3132)
 * Replace `Collection` proxy class with Driver monitoring by @GromNaN in [#3137]((https://github.com/mongodb/laravel-mongodb/pull/3137)
+* Support options in `count()` queries by @verduck in [#3142](https://github.com/mongodb/laravel-mongodb/pull/3142)
 
 ## [4.8.0] - 2024-08-27
 

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -346,7 +346,7 @@ class Builder extends BaseBuilder
                     $aggregations = blank($this->aggregate['columns']) ? [] : $this->aggregate['columns'];
 
                     if (in_array('*', $aggregations) && $function === 'count') {
-                        $options = $this->inheritConnectionOptions();
+                        $options = $this->inheritConnectionOptions($this->options);
 
                         return ['countDocuments' => [$wheres, $options]];
                     }

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -660,4 +660,13 @@ class QueryTest extends TestCase
         User::limit(null)->delete();
         $this->assertEquals(0, User::count());
     }
+
+    public function testLimitCount(): void
+    {
+        $count = User::where('age', '>=', 20)->count();
+        $this->assertEquals(7, $count);
+
+        $count = User::where('age', '>=', 20)->options(['limit' => 3])->count();
+        $this->assertEquals(3, $count);
+    }
 }


### PR DESCRIPTION
Added `$this->options` to `inheritConnectionOptions`, enabling options to be passed to the countDocuments method when calling `count()`.

### Checklist

- [X] Add tests and ensure they pass
- [x] Add an entry to the CHANGELOG.md file
