### PR TITLE
Update merge-up config for new branch pattern

### DIFF
--- a/.github/workflows/merge-up.yml
+++ b/.github/workflows/merge-up.yml
@@ -3,7 +3,7 @@ name: Merge up
 on:
   push:
     branches:
-      - "[0-9]+.[0-9]+"
+      - "[0-9]+.[0-9x]+"
 
 env:
   GH_TOKEN: ${{ secrets.MERGE_UP_TOKEN }}
@@ -27,5 +27,5 @@ jobs:
         uses: alcaeus/automatic-merge-up-action@main
         with:
           ref: ${{ github.ref_name }}
-          branchNamePattern: '<major>.<minor>'
+          branchNamePattern: '<major>.x'
           enableAutoMerge: true

--- a/.github/workflows/merge-up.yml
+++ b/.github/workflows/merge-up.yml
@@ -27,5 +27,6 @@ jobs:
         uses: alcaeus/automatic-merge-up-action@main
         with:
           ref: ${{ github.ref_name }}
-          branchNamePattern: '<major>.x'
+          branchNamePattern: '<major>.<minor>'
+          devBranchNamePattern: '<major>.x'
           enableAutoMerge: true


### PR DESCRIPTION
This PR updates the configuration for the merge-up workflow. The new `devBranchNamePattern` set to `<major>.x` to keep a single working branch `5.x`.

Related to https://github.com/alcaeus/automatic-merge-up-action/pull/41