### PR TITLE
PHPORM-239 Convert `_id` and `UTCDateTime` in results of `Model::raw()` before hydratation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [5.1.0] - next
+
+* Convert `_id` and `UTCDateTime` in results of `Model::raw()` before hydratation by @GromNaN in [#3152](https://github.com/mongodb/laravel-mongodb/pull/3152)
+
 ## [5.0.2] - 2024-09-17
 
 * Fix missing return types in CommandSubscriber by @GromNaN in [#3158](https://github.com/mongodb/laravel-mongodb/pull/3158)

--- a/src/Eloquent/Builder.php
+++ b/src/Eloquent/Builder.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace MongoDB\Laravel\Eloquent;
 
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
-use MongoDB\Driver\Cursor;
+use MongoDB\Driver\CursorInterface;
 use MongoDB\Driver\Exception\WriteException;
 use MongoDB\Laravel\Connection;
 use MongoDB\Laravel\Helpers\QueriesRelationships;
@@ -177,7 +177,7 @@ class Builder extends EloquentBuilder
         $results = $this->query->raw($value);
 
         // Convert MongoCursor results to a collection of models.
-        if ($results instanceof Cursor) {
+        if ($results instanceof CursorInterface) {
             $results = iterator_to_array($results, false);
 
             return $this->model->hydrate($results);

--- a/src/Eloquent/Builder.php
+++ b/src/Eloquent/Builder.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MongoDB\Laravel\Eloquent;
 
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use MongoDB\BSON\Document;
 use MongoDB\Driver\CursorInterface;
 use MongoDB\Driver\Exception\WriteException;
 use MongoDB\Laravel\Connection;
@@ -16,7 +17,9 @@ use function array_key_exists;
 use function array_merge;
 use function collect;
 use function is_array;
+use function is_object;
 use function iterator_to_array;
+use function property_exists;
 
 /** @method \MongoDB\Laravel\Query\Builder toBase() */
 class Builder extends EloquentBuilder
@@ -178,21 +181,26 @@ class Builder extends EloquentBuilder
 
         // Convert MongoCursor results to a collection of models.
         if ($results instanceof CursorInterface) {
-            $results = iterator_to_array($results, false);
+            $results->setTypeMap(['root' => 'array', 'document' => 'array', 'array' => 'array']);
+            $results = $this->query->aliasIdForResult(iterator_to_array($results));
 
             return $this->model->hydrate($results);
         }
 
-        // Convert MongoDB BSONDocument to a single object.
-        if ($results instanceof BSONDocument) {
-            $results = $results->getArrayCopy();
-
-            return $this->model->newFromBuilder((array) $results);
+        // Convert MongoDB Document to a single object.
+        if (is_object($results) && (property_exists($results, '_id') || property_exists($results, 'id'))) {
+            $results = (array) match (true) {
+                $results instanceof BSONDocument => $results->getArrayCopy(),
+                $results instanceof Document => $results->toPHP(['root' => 'array', 'document' => 'array', 'array' => 'array']),
+                default => $results,
+            };
         }
 
         // The result is a single object.
-        if (is_array($results) && array_key_exists('_id', $results)) {
-            return $this->model->newFromBuilder((array) $results);
+        if (is_array($results) && (array_key_exists('_id', $results) || array_key_exists('id', $results))) {
+            $results = $this->query->aliasIdForResult($results);
+
+            return $this->model->newFromBuilder($results);
         }
 
         return $results;

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -20,12 +20,12 @@ use Illuminate\Support\LazyCollection;
 use InvalidArgumentException;
 use LogicException;
 use MongoDB\BSON\Binary;
+use MongoDB\BSON\Document;
 use MongoDB\BSON\ObjectID;
 use MongoDB\BSON\Regex;
 use MongoDB\BSON\UTCDateTime;
 use MongoDB\Builder\Stage\FluentFactoryTrait;
 use MongoDB\Driver\Cursor;
-use MongoDB\Driver\CursorInterface;
 use Override;
 use RuntimeException;
 use stdClass;
@@ -935,17 +935,7 @@ class Builder extends BaseBuilder
     {
         // Execute the closure on the mongodb collection
         if ($value instanceof Closure) {
-            $results = call_user_func($value, $this->collection);
-
-            if ($results instanceof CursorInterface) {
-                $results = $results->toArray();
-            }
-
-            if (is_array($results) || is_object($results)) {
-                $results = $this->aliasIdForResult($results);
-            }
-
-            return $results;
+            return call_user_func($value, $this->collection);
         }
 
         // Create an expression for the given value
@@ -1659,13 +1649,15 @@ class Builder extends BaseBuilder
     }
 
     /**
+     * @internal
+     *
      * @psalm-param T $values
      *
      * @psalm-return T
      *
      * @template T of array|object
      */
-    private function aliasIdForResult(array|object $values): array|object
+    public function aliasIdForResult(array|object $values): array|object
     {
         if (is_array($values)) {
             if (array_key_exists('_id', $values) && ! array_key_exists('id', $values)) {

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -25,6 +25,7 @@ use MongoDB\BSON\Regex;
 use MongoDB\BSON\UTCDateTime;
 use MongoDB\Builder\Stage\FluentFactoryTrait;
 use MongoDB\Driver\Cursor;
+use MongoDB\Driver\CursorInterface;
 use Override;
 use RuntimeException;
 use stdClass;
@@ -934,7 +935,17 @@ class Builder extends BaseBuilder
     {
         // Execute the closure on the mongodb collection
         if ($value instanceof Closure) {
-            return call_user_func($value, $this->collection);
+            $results = call_user_func($value, $this->collection);
+
+            if ($results instanceof CursorInterface) {
+                $results = $results->toArray();
+            }
+
+            if (is_array($results) || is_object($results)) {
+                $results = $this->aliasIdForResult($results);
+            }
+
+            return $results;
         }
 
         // Create an expression for the given value

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -20,7 +20,6 @@ use Illuminate\Support\LazyCollection;
 use InvalidArgumentException;
 use LogicException;
 use MongoDB\BSON\Binary;
-use MongoDB\BSON\Document;
 use MongoDB\BSON\ObjectID;
 use MongoDB\BSON\Regex;
 use MongoDB\BSON\UTCDateTime;

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -28,6 +28,8 @@ use MongoDB\Laravel\Tests\Models\MemberStatus;
 use MongoDB\Laravel\Tests\Models\Soft;
 use MongoDB\Laravel\Tests\Models\SqlUser;
 use MongoDB\Laravel\Tests\Models\User;
+use MongoDB\Model\BSONArray;
+use MongoDB\Model\BSONDocument;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\TestWith;
 
@@ -907,21 +909,8 @@ class ModelTest extends TestCase
         $this->assertInstanceOf(EloquentCollection::class, $users);
         $this->assertInstanceOf(User::class, $users[0]);
 
-        $user = User::raw(function (Collection $collection) {
-            return $collection->findOne(
-                ['age' => 35],
-                ['projection' => ['_id' => 1, 'name' => 1, 'age' => 1, 'now' => '$$NOW']],
-            );
-        });
-
-        $this->assertInstanceOf(User::class, $user);
-        $this->assertArrayNotHasKey('_id', $user->getAttributes());
-        $this->assertArrayHasKey('id', $user->getAttributes());
-        $this->assertNotEmpty($user->id);
-        $this->assertInstanceOf(Carbon::class, $user->now);
-
         $count = User::raw(function (Collection $collection) {
-            return $collection->count();
+            return $collection->estimatedDocumentCount();
         });
         $this->assertEquals(3, $count);
 
@@ -929,13 +918,39 @@ class ModelTest extends TestCase
             return $collection->insertOne(['name' => 'Yvonne Yoe', 'age' => 35]);
         });
         $this->assertNotNull($result);
+    }
 
-        $result = User::raw(function (Collection $collection) {
-            return $collection->aggregate([
-                ['$set' => ['now' => '$$NOW']],
-                ['$limit' => 2],
-            ]);
-        });
+    #[DataProvider('provideTypeMap')]
+    public function testRawHyradeModel(array $typeMap): void
+    {
+        User::insert([
+            ['name' => 'John Doe', 'age' => 35, 'embed' => ['foo' => 'bar'], 'list' => [1, 2, 3]],
+            ['name' => 'Jane Doe', 'age' => 35, 'embed' => ['foo' => 'bar'], 'list' => [1, 2, 3]],
+            ['name' => 'Harry Hoe', 'age' => 15, 'embed' => ['foo' => 'bar'], 'list' => [1, 2, 3]],
+        ]);
+
+        // Single document result
+        $user = User::raw(fn (Collection $collection) => $collection->findOne(
+            ['age' => 35],
+            [
+                'projection' => ['_id' => 1, 'name' => 1, 'age' => 1, 'now' => '$$NOW', 'embed' => 1, 'list' => 1],
+                'typeMap' => $typeMap,
+            ],
+        ));
+
+        $this->assertInstanceOf(User::class, $user);
+        $this->assertArrayNotHasKey('_id', $user->getAttributes());
+        $this->assertArrayHasKey('id', $user->getAttributes());
+        $this->assertNotEmpty($user->id);
+        $this->assertInstanceOf(Carbon::class, $user->now);
+        $this->assertEquals(['foo' => 'bar'], (array) $user->embed);
+        $this->assertEquals([1, 2, 3], (array) $user->list);
+
+        // Cursor result
+        $result = User::raw(fn (Collection $collection) => $collection->aggregate([
+            ['$set' => ['now' => '$$NOW']],
+            ['$limit' => 2],
+        ], ['typeMap' => $typeMap]));
 
         $this->assertInstanceOf(EloquentCollection::class, $result);
         $this->assertCount(2, $result);
@@ -945,6 +960,17 @@ class ModelTest extends TestCase
         $this->assertArrayHasKey('id', $user->getAttributes());
         $this->assertNotEmpty($user->id);
         $this->assertInstanceOf(Carbon::class, $user->now);
+        $this->assertEquals(['foo' => 'bar'], $user->embed);
+        $this->assertEquals([1, 2, 3], $user->list);
+    }
+
+    public static function provideTypeMap(): Generator
+    {
+        yield 'default' => [[]];
+        yield 'array' => [['root' => 'array', 'document' => 'array', 'array' => 'array']];
+        yield 'object' => [['root' => 'object', 'document' => 'object', 'array' => 'array']];
+        yield 'Library BSON' => [['root' => BSONDocument::class, 'document' => BSONDocument::class, 'array' => BSONArray::class]];
+        yield 'Driver BSON' => [['root' => 'bson', 'document' => 'bson', 'array' => 'bson']];
     }
 
     public function testDotNotation(): void

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -1381,6 +1381,31 @@ class BuilderTest extends TestCase
                 ->orWhereAny(['last_name', 'email'], 'not like', '%Doe%'),
             'orWhereAny',
         ];
+
+        yield 'raw filter with _id and date' => [
+            [
+                'find' => [
+                    [
+                        '$and' => [
+                            [
+                                '$or' => [
+                                    ['foo._id' => 1],
+                                    ['created_at' => ['$gte' => new UTCDateTime(new DateTimeImmutable('2018-09-30 00:00:00.000 +00:00'))]],
+                                ],
+                            ],
+                            ['age' => 15],
+                        ],
+                    ],
+                    [], // options
+                ],
+            ],
+            fn (Builder $builder) => $builder->where([
+                '$or' => [
+                    ['foo.id' => 1],
+                    ['created_at' => ['$gte' => new DateTimeImmutable('2018-09-30 00:00:00 +00:00')]],
+                ],
+            ])->where('age', 15),
+        ];
     }
 
     #[DataProvider('provideExceptions')]

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -18,6 +18,7 @@ use MongoDB\BSON\ObjectId;
 use MongoDB\BSON\Regex;
 use MongoDB\BSON\UTCDateTime;
 use MongoDB\Collection;
+use MongoDB\Driver\Cursor;
 use MongoDB\Driver\Monitoring\CommandFailedEvent;
 use MongoDB\Driver\Monitoring\CommandStartedEvent;
 use MongoDB\Driver\Monitoring\CommandSubscriber;
@@ -313,16 +314,12 @@ class QueryBuilderTest extends TestCase
             ['name' => 'John Doe', 'age' => 25],
         ]);
 
-        $results = DB::table('users')->raw(function ($collection) {
-            return $collection->find(['age' => 20], ['typeMap' => ['root' => 'array', 'document' => 'array']]);
+        $cursor = DB::table('users')->raw(function ($collection) {
+            return $collection->find(['age' => 20]);
         });
 
-        $this->assertIsArray($results);
-        $this->assertCount(1, $results);
-        $this->assertArrayNotHasKey('_id', $results[0]);
-        $this->assertArrayHasKey('id', $results[0]);
-        $this->assertInstanceOf(ObjectId::class, $results[0]['id']);
-        $this->assertSame(20, $results[0]['age']);
+        $this->assertInstanceOf(Cursor::class, $cursor);
+        $this->assertCount(1, $cursor->toArray());
 
         $collection = DB::table('users')->raw();
         $this->assertInstanceOf(Collection::class, $collection);


### PR DESCRIPTION
Fix PHPORM-239
Fix #3151

### Checklist

- [x] Add tests and ensure they pass
- [x] Add an entry to the CHANGELOG.md file
