### PR TITLE
PHPORM-241 Add return type to CommandSubscriber

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [5.0.2] - 2024-09-17
+
+* Fix missing return types in CommandSubscriber by @GromNaN in [#3158](https://github.com/mongodb/laravel-mongodb/pull/3158)
+
 ## [5.0.1] - 2024-09-13
 
 * Restore support for Laravel 10 by @GromNaN in [#3148](https://github.com/mongodb/laravel-mongodb/pull/3148)

--- a/src/CommandSubscriber.php
+++ b/src/CommandSubscriber.php
@@ -21,17 +21,17 @@ final class CommandSubscriber implements CommandSubscriberInterface
     {
     }
 
-    public function commandStarted(CommandStartedEvent $event)
+    public function commandStarted(CommandStartedEvent $event): void
     {
         $this->commands[$event->getOperationId()] = $event;
     }
 
-    public function commandFailed(CommandFailedEvent $event)
+    public function commandFailed(CommandFailedEvent $event): void
     {
         $this->logQuery($event);
     }
 
-    public function commandSucceeded(CommandSucceededEvent $event)
+    public function commandSucceeded(CommandSucceededEvent $event): void
     {
         $this->logQuery($event);
     }


### PR DESCRIPTION
https://github.com/mongodb/laravel-mongodb/pull/3157 was merged into the wrong branch.


### Checklist

- [x] Add tests and ensure they pass
- [x] Add an entry to the CHANGELOG.md file
