### PR TITLE
PHPORM-243 Alias `_id` to `id` in `Schema::getColumns()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [5.1.0] - next
 
 * Convert `_id` and `UTCDateTime` in results of `Model::raw()` before hydratation by @GromNaN in [#3152](https://github.com/mongodb/laravel-mongodb/pull/3152)
+* Alias `_id` to `id` in `Schema::getColumns()` by @GromNaN in [#3160](https://github.com/mongodb/laravel-mongodb/pull/3160)
 
 ## [5.0.2] - 2024-09-17
 

--- a/src/Schema/Builder.php
+++ b/src/Schema/Builder.php
@@ -11,6 +11,7 @@ use MongoDB\Model\IndexInfo;
 use function array_fill_keys;
 use function array_filter;
 use function array_keys;
+use function array_map;
 use function assert;
 use function count;
 use function current;
@@ -19,6 +20,8 @@ use function in_array;
 use function iterator_to_array;
 use function sort;
 use function sprintf;
+use function str_ends_with;
+use function substr;
 use function usort;
 
 class Builder extends \Illuminate\Database\Schema\Builder
@@ -42,8 +45,11 @@ class Builder extends \Illuminate\Database\Schema\Builder
      */
     public function hasColumns($table, array $columns): bool
     {
-        // The field "id" (alias of "_id") is required for all MongoDB documents
+        // The field "id" (alias of "_id") always exist on MongoDB collections
         $columns = array_filter($columns, fn (string $column): bool => ! in_array($column, ['_id', 'id'], true));
+
+        // Any subfield named "*.id" is an alias of "*._id"
+        $columns = array_map(fn (string $column): string => str_ends_with($column, '.id') ? substr($column, 0, -3) . '._id' : $column, $columns);
 
         if ($columns === []) {
             return true;

--- a/src/Schema/Builder.php
+++ b/src/Schema/Builder.php
@@ -45,7 +45,7 @@ class Builder extends \Illuminate\Database\Schema\Builder
      */
     public function hasColumns($table, array $columns): bool
     {
-        // The field "id" (alias of "_id") always exist on MongoDB collections
+        // The field "id" (alias of "_id") always exists in MongoDB documents
         $columns = array_filter($columns, fn (string $column): bool => ! in_array($column, ['_id', 'id'], true));
 
         // Any subfield named "*.id" is an alias of "*._id"

--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -377,10 +377,12 @@ class SchemaTest extends TestCase
         $this->assertTrue(Schema::hasColumn('newcollection', '_id'));
         $this->assertTrue(Schema::hasColumn('newcollection', 'id'));
 
-        DB::connection()->table('newcollection')->insert(['column1' => 'value']);
+        DB::connection()->table('newcollection')->insert(['column1' => 'value', 'embed' => ['_id' => 1]]);
 
         $this->assertTrue(Schema::hasColumn('newcollection', 'column1'));
         $this->assertFalse(Schema::hasColumn('newcollection', 'column2'));
+        $this->assertTrue(Schema::hasColumn('newcollection', 'embed._id'));
+        $this->assertTrue(Schema::hasColumn('newcollection', 'embed.id'));
     }
 
     public function testHasColumns(): void

--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -374,6 +374,9 @@ class SchemaTest extends TestCase
 
     public function testHasColumn(): void
     {
+        $this->assertTrue(Schema::hasColumn('newcollection', '_id'));
+        $this->assertTrue(Schema::hasColumn('newcollection', 'id'));
+
         DB::connection()->table('newcollection')->insert(['column1' => 'value']);
 
         $this->assertTrue(Schema::hasColumn('newcollection', 'column1'));
@@ -382,6 +385,9 @@ class SchemaTest extends TestCase
 
     public function testHasColumns(): void
     {
+        $this->assertTrue(Schema::hasColumns('newcollection', ['_id']));
+        $this->assertTrue(Schema::hasColumns('newcollection', ['id']));
+
         // Insert documents with both column1 and column2
         DB::connection()->table('newcollection')->insert([
             ['column1' => 'value1', 'column2' => 'value2'],
@@ -451,8 +457,9 @@ class SchemaTest extends TestCase
             $this->assertIsString($column['comment']);
         });
 
-        $this->assertEquals('objectId', $columns->get('_id')['type']);
-        $this->assertEquals('objectId', $columns->get('_id')['generation']['type']);
+        $this->assertNull($columns->get('_id'), '_id is renamed to id');
+        $this->assertEquals('objectId', $columns->get('id')['type']);
+        $this->assertEquals('objectId', $columns->get('id')['generation']['type']);
         $this->assertNull($columns->get('text')['generation']);
         $this->assertEquals('string', $columns->get('text')['type']);
         $this->assertEquals('date', $columns->get('date')['type']);


### PR DESCRIPTION
Fix PHPORM-243

```diff
❯ php artisan model:show book

  App\Models\Book .............................................................  
  Database ............................................................ mongodb  
  Table ................................................................. books  

  Attributes ...................................................... type / cast  
- _id ..................................................... objectId / accessor  
+ id ...................................................... objectId / accessor   
  author nullable ...................................................... string  
  created_at nullable ......................................... date / datetime  
  description nullable ................................................. string  
  isbn nullable ........................................................ string  
  publication_date nullable ............................................ string  
  title nullable ....................................................... string  
  updated_at nullable ......................................... date / datetime  
-  id ................................................................. accessor  
```

Required for API Platform integration with Laravel: https://github.com/api-platform/laravel/blob/e821ad27072228e4638f3de92d51fc3d15e02c7b/Eloquent/Metadata/ModelMetadata.php#L68

### Checklist

- [x] Add tests and ensure they pass
- [x] Add an entry to the CHANGELOG.md file
