### PR TITLE
Owner key for morphTo relations

### DIFF
--- a/src/Relations/MorphTo.php
+++ b/src/Relations/MorphTo.php
@@ -29,7 +29,7 @@ class MorphTo extends EloquentMorphTo
     {
         $instance = $this->createModelByType($type);
 
-        $key = $instance->getKeyName();
+        $key = $this->ownerKey ?? $instance->getKeyName();
 
         $query = $instance->newQuery();
 

--- a/tests/RelationsTest.php
+++ b/tests/RelationsTest.php
@@ -675,7 +675,6 @@ class RelationsTest extends TestCase
         $relations = $check->getRelations();
         $this->assertArrayHasKey('hasImageWithCustomOwnerKey', $relations);
         $this->assertInstanceOf(Client::class, $check->hasImageWithCustomOwnerKey);
-
     }
 
     public function testMorphToMany(): void

--- a/tests/RelationsTest.php
+++ b/tests/RelationsTest.php
@@ -634,11 +634,13 @@ class RelationsTest extends TestCase
         $photo = Photo::first();
         $this->assertEquals($photo->hasImage->name, $user->name);
 
+        // eager load
         $user      = User::with('photos')->find($user->id);
         $relations = $user->getRelations();
         $this->assertArrayHasKey('photos', $relations);
         $this->assertEquals(1, $relations['photos']->count());
 
+        // inverse eager load
         $photos    = Photo::with('hasImage')->get();
         $relations = $photos[0]->getRelations();
         $this->assertArrayHasKey('hasImage', $relations);
@@ -648,7 +650,7 @@ class RelationsTest extends TestCase
         $this->assertArrayHasKey('hasImage', $relations);
         $this->assertInstanceOf(Client::class, $photos[1]->hasImage);
 
-        // inverse
+        // inverse relationship
         $photo = Photo::query()->create(['url' => 'https://graph.facebook.com/hans.thomas/picture']);
         $client = Client::create(['name' => 'Hans Thomas']);
         $photo->hasImage()->associate($client)->save();
@@ -666,6 +668,14 @@ class RelationsTest extends TestCase
         $this->assertInstanceOf(Client::class, $photo->hasImageWithCustomOwnerKey);
         $this->assertEquals($client->cclient_id, $photo->has_image_with_custom_owner_key_id);
         $this->assertEquals($client->id, $photo->hasImageWithCustomOwnerKey->id);
+
+        // inverse eager load with custom ownerKey
+        $photos    = Photo::with('hasImageWithCustomOwnerKey')->get();
+        $check = $photos->last();
+        $relations = $check->getRelations();
+        $this->assertArrayHasKey('hasImageWithCustomOwnerKey', $relations);
+        $this->assertInstanceOf(Client::class, $check->hasImageWithCustomOwnerKey);
+
     }
 
     public function testMorphToMany(): void


### PR DESCRIPTION
Hi everyone, as mentioned #3093, the `MorphTo` relationship doesn't support the custom `ownerKey` on the eager loading.
This PR would fix this issue.

### Checklist

- [x] Add tests and ensure they pass
- [ ] Add an entry to the CHANGELOG.md file
