### PR TITLE
fixbug in pluck function

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -854,7 +854,7 @@ class Builder extends BaseBuilder
         // Convert ObjectID's to strings
         if (((string) $key) === '_id') {
             $results = $results->map(function ($item) {
-                $item['_id'] = (string) $item['_id'];
+                $item->_id = (string) $item->id;
 
                 return $item;
             });


### PR DESCRIPTION
Fix bug in pluck function.
Cannot use object of type stdClass as array

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.
-->

### Checklist

- [ ] Add tests and ensure they pass
