### PR TITLE
Fix `Query\Builder::pluck()` with `ObjectId` as key

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -854,7 +854,7 @@ class Builder extends BaseBuilder
         // Convert ObjectID's to strings
         if (((string) $key) === '_id') {
             $results = $results->map(function ($item) {
-                $item->_id = (string) $item->id;
+                $item->_id = $item->id;
 
                 return $item;
             });

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -854,7 +854,7 @@ class Builder extends BaseBuilder
         // Convert ObjectID's to strings
         if (((string) $key) === '_id') {
             $results = $results->map(function ($item) {
-                $item['_id'] = (string) $item['_id'];
+                $item->_id = (string) $item->id;
 
                 return $item;
             });

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -851,15 +851,6 @@ class Builder extends BaseBuilder
     {
         $results = $this->get($key === null ? [$column] : [$column, $key]);
 
-        // Convert ObjectID's to strings
-        if (((string) $key) === '_id') {
-            $results = $results->map(function ($item) {
-                $item->_id = $item->id;
-
-                return $item;
-            });
-        }
-
         $p = Arr::pluck($results, $column, $key);
 
         return new Collection($p);

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -1573,28 +1573,4 @@ class BuilderTest extends TestCase
 
         return new Builder($connection, null, $processor);
     }
-
-    public function testPluckObjectId()
-    {
-        DB::table('users')->insert([
-            ['_id' => $id = new \MongoDB\BSON\ObjectId(), 'name' => 'Jane Doe', 'age' => 20],
-        ]);
-
-        $names = DB::table('users')->pluck('name', '_id')->toArray();
-        $this->assertCount(1, $names);
-        $this->assertArrayHasKey((string) $id, $names);
-        $this->assertEquals([(string) $id => 'Jane Doe'], $names);
-    }
-
-    public function testPluckObjectIdWithIdAlias()
-    {
-        DB::table('users')->insert([
-            ['_id' => $id = new \MongoDB\BSON\ObjectId(), 'name' => 'Jane Doe', 'age' => 20],
-        ]);
-
-        $names = DB::table('users')->pluck('name', 'id')->toArray();
-        $this->assertCount(1, $names);
-        $this->assertArrayHasKey((string) $id, $names);
-        $this->assertEquals([(string) $id => 'Jane Doe'], $names);
-    }    
 }

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -1573,4 +1573,28 @@ class BuilderTest extends TestCase
 
         return new Builder($connection, null, $processor);
     }
+
+    public function testPluckObjectId()
+    {
+        DB::table('users')->insert([
+            ['_id' => $id = new \MongoDB\BSON\ObjectId(), 'name' => 'Jane Doe', 'age' => 20],
+        ]);
+
+        $names = DB::table('users')->pluck('name', '_id')->toArray();
+        $this->assertCount(1, $names);
+        $this->assertArrayHasKey((string) $id, $names);
+        $this->assertEquals([(string) $id => 'Jane Doe'], $names);
+    }
+
+    public function testPluckObjectIdWithIdAlias()
+    {
+        DB::table('users')->insert([
+            ['_id' => $id = new \MongoDB\BSON\ObjectId(), 'name' => 'Jane Doe', 'age' => 20],
+        ]);
+
+        $names = DB::table('users')->pluck('name', 'id')->toArray();
+        $this->assertCount(1, $names);
+        $this->assertArrayHasKey((string) $id, $names);
+        $this->assertEquals([(string) $id => 'Jane Doe'], $names);
+    }    
 }

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -525,6 +525,17 @@ class QueryBuilderTest extends TestCase
         $this->assertEquals([25], $age);
     }
 
+    public function testPluckObjectId()
+    {
+        $id = new ObjectId();
+        DB::table('users')->insert([
+            ['id' => $id, 'name' => 'Jane Doe'],
+        ]);
+
+        $names = DB::table('users')->pluck('name', 'id')->toArray();
+        $this->assertEquals([(string) $id => 'Jane Doe'], $names);
+    }
+
     public function testList()
     {
         DB::table('items')->insert([


### PR DESCRIPTION
-Fix bug in pluck function.
Cannot use object of type stdClass as array

-Add Tests in Query\BuilderTest
-Remove the string convert of key , thanks @GromNaN 