### PR TITLE
Supports disabling _id to id automatic conversion and disablling returning results as arrays in aggregate instead of bson object based on database configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,18 @@
 Laravel MongoDB
 ===============
-
+This is fork supports disabling _id to id automatic conversion and disablling returning results as arrays in aggregate instead of bson object based on database configuration.
+ 'mongodb' => [
+                  'driver' => 'mongodb',
+                  'dsn' => env('DB_URI'),
+                  'database' => env('DB_NAME'),
+                  'options'  => [
+                   
+                    'ssl' => true,
+                    'AggregateCollectionArray'=>true, //add this to disable aggregate array
+                    'DisableAliasIdForResult'=>true, //add this to disable automatic _id conversion
+                    'tlsAllowInvalidCertificates' => true, 
+                ],
+          ],
 [![Latest Stable Version](http://img.shields.io/github/release/mongodb/laravel-mongodb.svg)](https://packagist.org/packages/mongodb/laravel-mongodb)
 [![Total Downloads](http://img.shields.io/packagist/dm/mongodb/laravel-mongodb.svg)](https://packagist.org/packages/mongodb/laravel-mongodb)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/mongodb/laravel-mongodb/build-ci.yml)](https://github.com/mongodb/laravel-mongodb/actions/workflows/build-ci.yml)

--- a/src/Eloquent/Builder.php
+++ b/src/Eloquent/Builder.php
@@ -181,7 +181,10 @@ class Builder extends EloquentBuilder
 
         // Convert MongoCursor results to a collection of models.
         if ($results instanceof CursorInterface) {
-            $results->setTypeMap(['root' => 'array', 'document' => 'array', 'array' => 'array']);
+            if(!config('database.connections.mongodb.options.AggregateCollectionArray')){
+                $results->setTypeMap(['root' => 'array', 'document' => 'array', 'array' => 'array']);
+            }
+            
             $results = $this->query->aliasIdForResult(iterator_to_array($results));
 
             return $this->model->hydrate($results);

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -1667,6 +1667,9 @@ class Builder extends BaseBuilder
      */
     public function aliasIdForResult(array|object $values): array|object
     {
+        if(config('database.connections.mongodb.options.DisableAliasIdForResult')){
+            return $values;
+        }
         if (is_array($values)) {
             if (array_key_exists('_id', $values) && ! array_key_exists('id', $values)) {
                 $values['id'] = $values['_id'];


### PR DESCRIPTION
This is fork supports disabling _id to id automatic conversion and disablling returning results as arrays in aggregate instead of bson object based on database configuration.
 'mongodb' => [
                  'driver' => 'mongodb',
                  'dsn' => env('DB_URI'),
                  'database' => env('DB_NAME'),
                  'options'  => [
                   
                    'ssl' => true,
                    'AggregateCollectionArray'=>true, //add this to disable aggregate array
                    'DisableAliasIdForResult'=>true, //add this to disable automatic _id conversion
                    'tlsAllowInvalidCertificates' => true, 
                ],
          ],
### Checklist
This is indeed required for me cause we have developed full fledged ERP Project with 20+ modules using v4 in completely Laravel. Changing all the 
code is not practical
- [ ] Add tests and ensure they pass
