### PR TITLE
PHPORM-259 Register MongoDB Session Handler with `SESSION_DRIVER=mongodb`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
         "illuminate/database": "^10.30|^11",
         "illuminate/events": "^10.0|^11",
         "illuminate/support": "^10.0|^11",
-        "mongodb/mongodb": "^1.18"
+        "mongodb/mongodb": "^1.18",
+        "symfony/http-foundation": "^6.4|^7"
     },
     "require-dev": {
         "mongodb/builder": "^0.2",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,26 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Call to an undefined method Illuminate\\\\Database\\\\Eloquent\\\\Builder\\<static\\(MongoDB\\\\Laravel\\\\Auth\\\\User\\)\\>\\:\\:pull\\(\\)\\.$#"
-			count: 1
-			path: src/Auth/User.php
-
-		-
-			message: "#^Call to an undefined method Illuminate\\\\Database\\\\Eloquent\\\\Builder\\<static\\(MongoDB\\\\Laravel\\\\Auth\\\\User\\)\\>\\:\\:push\\(\\)\\.$#"
-			count: 1
-			path: src/Auth/User.php
-
-		-
-			message: "#^Call to an undefined method Illuminate\\\\Database\\\\Eloquent\\\\Builder\\<static\\(MongoDB\\\\Laravel\\\\Eloquent\\\\Model\\)\\>\\:\\:pull\\(\\)\\.$#"
-			count: 1
-			path: src/Eloquent/Model.php
-
-		-
-			message: "#^Call to an undefined method Illuminate\\\\Database\\\\Eloquent\\\\Builder\\<static\\(MongoDB\\\\Laravel\\\\Eloquent\\\\Model\\)\\>\\:\\:push\\(\\)\\.$#"
-			count: 1
-			path: src/Eloquent/Model.php
-
-		-
 			message: "#^Access to an undefined property Illuminate\\\\Container\\\\Container\\:\\:\\$config\\.$#"
 			count: 3
 			path: src/MongoDBBusServiceProvider.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,9 +1,34 @@
 parameters:
 	ignoreErrors:
 		-
+			message: "#^Call to an undefined method Illuminate\\\\Database\\\\Eloquent\\\\Builder\\<static\\(MongoDB\\\\Laravel\\\\Auth\\\\User\\)\\>\\:\\:pull\\(\\)\\.$#"
+			count: 1
+			path: src/Auth/User.php
+
+		-
+			message: "#^Call to an undefined method Illuminate\\\\Database\\\\Eloquent\\\\Builder\\<static\\(MongoDB\\\\Laravel\\\\Auth\\\\User\\)\\>\\:\\:push\\(\\)\\.$#"
+			count: 1
+			path: src/Auth/User.php
+
+		-
+			message: "#^Call to an undefined method Illuminate\\\\Database\\\\Eloquent\\\\Builder\\<static\\(MongoDB\\\\Laravel\\\\Eloquent\\\\Model\\)\\>\\:\\:pull\\(\\)\\.$#"
+			count: 1
+			path: src/Eloquent/Model.php
+
+		-
+			message: "#^Call to an undefined method Illuminate\\\\Database\\\\Eloquent\\\\Builder\\<static\\(MongoDB\\\\Laravel\\\\Eloquent\\\\Model\\)\\>\\:\\:push\\(\\)\\.$#"
+			count: 1
+			path: src/Eloquent/Model.php
+
+		-
 			message: "#^Access to an undefined property Illuminate\\\\Container\\\\Container\\:\\:\\$config\\.$#"
 			count: 3
 			path: src/MongoDBBusServiceProvider.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Foundation\\\\Application\\:\\:\\$config\\.$#"
+			count: 4
+			path: src/MongoDBServiceProvider.php
 
 		-
 			message: "#^Method Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:push\\(\\) invoked with 3 parameters, 0 required\\.$#"


### PR DESCRIPTION
Fix [PHPORM-259](https://jira.mongodb.org/browse/PHPORM-259)

Adding the "mongodb" session driver that uses [Symfony MongoDbSessionHandler](https://github.com/symfony/symfony/blob/6.4/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MongoDbSessionHandler.php) to store the sessions. This handler is optimized and maintained in the Symfony repository.

Registration:

1. Configure a [`mongodb` connection](https://www.mongodb.com/docs/drivers/php/laravel-mongodb/v5.x/quick-start/configure-mongodb/#set-the-connection-string-in-the-database-configuration) in `config/database.php`.

2. Select the session driver and connection with `.env` file
```ini
SESSION_DRIVER=mongodb
SESSION_CONNECTION=mongodb # optional, this is the default value
```

Or in `config/session.php`
```php
<?php return [
    'driver' => 'mongodb',     // required
    'connection' => 'mongodb', // the database connection name, default is "mongodb"
    'table' => 'sessions',     // the collection name, default is "sessions"
    'lifetime' => null,        // the ttl of session in minutes, default is 120 minutes
    'options' => []            // Additional driver options
];
```

List of additional options and some documentation in the class: https://github.com/symfony/symfony/blob/6.4/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MongoDbSessionHandler.php#L39-L46