### PR TITLE
Fix generation of SARIF reports

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -13,7 +13,7 @@ parameters:
 
     ignoreErrors:
         - '#Unsafe usage of new static#'
-        - '#Call to an undefined method [a-zA-Z0-9\\_\<\>]+::[a-zA-Z]+\(\)#'
+        - '#Call to an undefined method [a-zA-Z0-9\\_\<\>\(\)]+::[a-zA-Z]+\(\)#'
 
 services:
     errorFormatter.sarif:

--- a/tests/PHPStan/SarifErrorFormatter.php
+++ b/tests/PHPStan/SarifErrorFormatter.php
@@ -63,9 +63,6 @@ class SarifErrorFormatter implements ErrorFormatter
                                 'uri' => $this->relativePathHelper->getRelativePath($fileSpecificError->getFile()),
                                 'uriBaseId' => self::URI_BASE_ID,
                             ],
-                            'region' => [
-                                'startLine' => $fileSpecificError->getLine(),
-                            ],
                         ],
                     ],
                 ],
@@ -76,6 +73,10 @@ class SarifErrorFormatter implements ErrorFormatter
 
             if ($fileSpecificError->getTip() !== null) {
                 $result['properties']['tip'] = $fileSpecificError->getTip();
+            }
+
+            if ($fileSpecificError->getLine() !== null) {
+                $result['locations'][0]['physicalLocation']['region']['startLine'] = $fileSpecificError->getLine();
             }
 
             $results[] = $result;


### PR DESCRIPTION
This showed up in #3192. When PHPStan adds an error about unmatched exclusion patterns, `getLine()` returns `null`, which violates the schema. To work around this, we only add a region to an error if a line is present.