### PR TITLE
PHPORM-256: Disable mongoc_client reuse between connections

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -217,6 +217,10 @@ class Connection extends BaseConnection
             $options['password'] = $config['password'];
         }
 
+        if (isset($config['name'])) {
+            $driverOptions += ['connectionName' => $config['name']];
+        }
+
         return new Client($dsn, $options, $driverOptions);
     }
 

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -277,6 +277,34 @@ class ConnectionTest extends TestCase
         }
     }
 
+    public function testQueryLogWithMultipleClients()
+    {
+        $connection = DB::connection('mongodb');
+        $this->assertInstanceOf(Connection::class, $connection);
+
+        // Create a second connection with the same config as the first
+        // Make sure to change the name as it's used as a connection identifier
+        $config = $connection->getConfig();
+        $config['name'] = 'mongodb2';
+        $secondConnection = new Connection($config);
+
+        $connection->enableQueryLog();
+        $secondConnection->enableQueryLog();
+
+        $this->assertCount(0, $connection->getQueryLog());
+        $this->assertCount(0, $secondConnection->getQueryLog());
+
+        $connection->table('items')->get();
+
+        $this->assertCount(1, $connection->getQueryLog());
+        $this->assertCount(0, $secondConnection->getQueryLog());
+
+        $secondConnection->table('items')->get();
+
+        $this->assertCount(1, $connection->getQueryLog());
+        $this->assertCount(1, $secondConnection->getQueryLog());
+    }
+
     public function testDisableQueryLog()
     {
         // Disabled by default


### PR DESCRIPTION
PHPORM-256, fixes #3183 

The issue described in the query can happen when multiple connections use the same client config. In that case, `MongoDB\Driver\Manager` reuses the underlying `mongoc_client` instance for performance reasons. However, as the query logger relies on APM callbacks which are tied to the `mongoc_client`, there is no way for us to keep this separate.

Disabling client persistence would solve this problem, but it would potentially introduce performance issues, as the connection would no longer be reused across multiple requests, introducing a delay for connection establishment in every request. However, by using the name of the connection from the config, we can introduce a unique identifier in the driver options, leading to the driver opening separate `mongoc_client` connections for each Laravel database connection, while at the same time leveraging connection persistence. Since the driver does not yield warnings or errors when encountering unknown driver options, we can safely inject this option that ends up being unused. @jmikola let me know if you can think of a better way to fix this.

The test in this PR fails without the patch, seeing a logged query in `$secondConnection` before actually running a query through the collection.