### PR TITLE
PHPORM-28 Add Scout engine to index into MongoDB Search

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -65,6 +65,9 @@ jobs:
                     until docker exec --tty mongodb mongosh 127.0.0.1:27017 --eval "db.runCommand({ ping: 1 })"; do
                       sleep 1
                     done
+                    until docker exec --tty mongodb mongosh 127.0.0.1:27017 --eval "db.createCollection('connection_test') && db.getCollection('connection_test').createSearchIndex({mappings:{dynamic: true}})"; do
+                      sleep 1
+                    done
 
             -   name: "Show MongoDB server status"
                 run: |

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
     },
     "require-dev": {
         "mongodb/builder": "^0.2",
+        "laravel/scout": "^11",
         "league/flysystem-gridfs": "^3.28",
         "league/flysystem-read-only": "^3.0",
         "phpunit/phpunit": "^10.3",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,8 @@ services:
         ports:
             - "27017:27017"
         healthcheck:
-            test: mongosh mongodb:27017 --quiet --eval 'db.runCommand("ping").ok'
+            test: mongosh --quiet --eval 'db.runCommand("ping").ok'
             interval: 10s
             timeout: 10s
             retries: 5
+s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,4 +22,3 @@ services:
             interval: 10s
             timeout: 10s
             retries: 5
-s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.5'
-
 services:
     app:
         tty: true
@@ -16,11 +14,11 @@ services:
 
     mongodb:
         container_name: mongodb
-        image: mongo:latest
+        image: mongodb/mongodb-atlas-local:latest
         ports:
             - "27017:27017"
         healthcheck:
-            test: echo 'db.runCommand("ping").ok' | mongosh mongodb:27017 --quiet
+            test: mongosh mongodb:27017 --quiet --eval 'db.runCommand("ping").ok'
             interval: 10s
             timeout: 10s
             retries: 5

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -24,3 +24,8 @@ parameters:
 			message: "#^Method Illuminate\\\\Database\\\\Schema\\\\Blueprint\\:\\:create\\(\\) invoked with 1 parameter, 0 required\\.$#"
 			count: 1
 			path: src/Schema/Builder.php
+
+		-
+			message: "#^Call to an undefined method Illuminate\\\\Support\\\\HigherOrderCollectionProxy\\<\\(int\\|string\\), Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\:\\:pushSoftDeleteMetadata\\(\\)\\.$#"
+			count: 1
+			path: src/Scout/ScoutEngine.php

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -17,7 +17,7 @@
         </testsuite>
     </testsuites>
     <php>
-        <env name="MONGODB_URI" value="mongodb://mongodb/"/>
+        <env name="MONGODB_URI" value="mongodb://mongodb/?directConnection=true"/>
         <env name="MONGODB_DATABASE" value="unittest"/>
         <env name="SQLITE_DATABASE" value=":memory:"/>
         <env name="QUEUE_CONNECTION" value="database"/>

--- a/src/Scout/ScoutEngine.php
+++ b/src/Scout/ScoutEngine.php
@@ -126,7 +126,8 @@ final class ScoutEngine extends Engine
                 'updateOne' => [
                     ['_id' => $model->getScoutKey()],
                     [
-                        '$setOnInsert' => ['_id' => $model->getScoutKey()],
+                        // The _id field is added automatically when the document is inserted
+                        // Update all other fields
                         '$set' => $searchableData,
                     ],
                     ['upsert' => true],

--- a/src/Scout/ScoutEngine.php
+++ b/src/Scout/ScoutEngine.php
@@ -84,6 +84,8 @@ final class ScoutEngine extends Engine
     #[Override]
     public function update($models)
     {
+        assert($models instanceof EloquentCollection, new TypeError(sprintf('Argument #1 ($models) must be of type %s, %s given', EloquentCollection::class, get_debug_type($models))));
+
         if ($models->isEmpty()) {
             return;
         }

--- a/src/Scout/ScoutEngine.php
+++ b/src/Scout/ScoutEngine.php
@@ -1,0 +1,542 @@
+<?php
+
+namespace MongoDB\Laravel\Scout;
+
+use Closure;
+use DateTimeInterface;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Collection;
+use Illuminate\Support\LazyCollection;
+use Laravel\Scout\Builder;
+use Laravel\Scout\Engines\Engine;
+use Laravel\Scout\Searchable;
+use LogicException;
+use MongoDB\BSON\Serializable;
+use MongoDB\BSON\UTCDateTime;
+use MongoDB\Collection as MongoDBCollection;
+use MongoDB\Database;
+use MongoDB\Driver\Cursor;
+use MongoDB\Driver\CursorInterface;
+use MongoDB\Exception\RuntimeException as MongoDBRuntimeException;
+use MongoDB\Laravel\Connection;
+use Override;
+use Traversable;
+use TypeError;
+
+use function array_column;
+use function array_flip;
+use function array_key_exists;
+use function array_map;
+use function array_merge;
+use function assert;
+use function call_user_func;
+use function class_uses_recursive;
+use function get_debug_type;
+use function hrtime;
+use function in_array;
+use function is_array;
+use function is_int;
+use function is_iterable;
+use function is_string;
+use function iterator_to_array;
+use function method_exists;
+use function sleep;
+use function sprintf;
+use function substr;
+use function time;
+
+/**
+ * In the context of this Laravel Scout engine, a "search index" refers to
+ * a MongoDB Collection with a Search Index.
+ */
+final class ScoutEngine extends Engine
+{
+    /** Name of the Atlas Search index. */
+    private const INDEX_NAME = 'scout';
+
+    // Atlas Search index management operations are asynchronous.
+    // They usually take less than 5 minutes to complete.
+    private const WAIT_TIMEOUT_SEC = 300;
+
+    private const DEFAULT_DEFINITION = [
+        'mappings' => [
+            'dynamic' => true,
+        ],
+    ];
+
+    public function __construct(
+        private Database $database,
+        private bool $softDelete,
+    ) {
+    }
+
+    /**
+     * Update the given model in the index.
+     *
+     * @see Engine::update()
+     *
+     * @param EloquentCollection $models
+     *
+     * @throws MongoDBRuntimeException
+     */
+    #[Override]
+    public function update($models)
+    {
+        if ($models->isEmpty()) {
+            return;
+        }
+
+        if ($this->softDelete && $this->usesSoftDelete($models)) {
+            $models->each->pushSoftDeleteMetadata();
+        }
+
+        $bulk = [];
+        foreach ($models as $model) {
+            $searchableData = $model->toSearchableArray();
+            $searchableData = self::serialize($searchableData);
+
+            if ($searchableData) {
+                unset($searchableData['_id']);
+
+                $searchableData = array_merge($searchableData, $model->scoutMetadata());
+                if (isset($searchableData['__soft_deleted'])) {
+                    $searchableData['__soft_deleted'] = (bool) $searchableData['__soft_deleted'];
+                }
+
+                $bulk[] = [
+                    'updateOne' => [
+                        ['_id' => $model->getScoutKey()],
+                        [
+                            '$setOnInsert' => ['_id' => $model->getScoutKey()],
+                            '$set' => $searchableData,
+                        ],
+                        ['upsert' => true],
+                    ],
+                ];
+            }
+        }
+
+        $this->getIndexableCollection($models)->bulkWrite($bulk);
+    }
+
+    /**
+     * Remove the given model from the index.
+     *
+     * @see Engine::delete()
+     *
+     * @param EloquentCollection $models
+     */
+    #[Override]
+    public function delete($models): void
+    {
+        assert($models instanceof Collection, new TypeError(sprintf('Argument #1 ($models) must be of type %s, %s given', Collection::class, get_debug_type($models))));
+
+        if ($models->isEmpty()) {
+            return;
+        }
+
+        $collection = $this->getIndexableCollection($models);
+        $ids = $models->map(fn (Model $model) => $model->getScoutKey())->all();
+        $collection->deleteMany(['_id' => ['$in' => $ids]]);
+    }
+
+    /**
+     * Perform the given search on the engine.
+     *
+     * @see Engine::search()
+     *
+     * @return mixed
+     */
+    #[Override]
+    public function search(Builder $builder)
+    {
+        return $this->performSearch($builder);
+    }
+
+    /**
+     * Perform the given search on the engine.
+     *
+     * @see Engine::paginate()
+     *
+     * @param int $perPage
+     * @param int $page
+     *
+     * @return mixed
+     */
+    #[Override]
+    public function paginate(Builder $builder, $perPage, $page)
+    {
+        assert(is_int($perPage), new TypeError(sprintf('Argument #2 ($perPage) must be of type int, %s given', get_debug_type($perPage))));
+        assert(is_int($page), new TypeError(sprintf('Argument #3 ($page) must be of type int, %s given', get_debug_type($page))));
+
+        $builder = clone $builder;
+        $builder->take($perPage);
+
+        return $this->performSearch($builder, $perPage * ($page - 1));
+    }
+
+    /**
+     * Perform the given search on the engine.
+     */
+    protected function performSearch(Builder $builder, ?int $offset = null): array
+    {
+        $collection = $this->getSearchableCollection($builder->model);
+
+        if ($builder->callback) {
+            $result = call_user_func(
+                $builder->callback,
+                $collection,
+                $builder->query,
+                $offset,
+            );
+            assert($result instanceof CursorInterface, new LogicException(sprintf('The search builder closure must return a MongoDB cursor, %s returned', get_debug_type($result))));
+
+            return $result->toArray();
+        }
+
+        $compound = [
+            'should' => [
+                [
+                    'text' => [
+                        'query' => $builder->query,
+                        'path' => ['wildcard' => '*'],
+                        'fuzzy' => ['maxEdits' => 2],
+                        'score' => ['boost' => ['value' => 5]],
+                    ],
+                ],
+                [
+                    'wildcard' => [
+                        'query' => $builder->query . '*',
+                        'path' => ['wildcard' => '*'],
+                        'allowAnalyzedField' => true,
+                    ],
+                ],
+            ],
+            'minimumShouldMatch' => 1,
+        ];
+
+        // "filter" specifies conditions on exact values to match
+        // "mustNot" specifies conditions on exact values that must not match
+        // They don't contribute to the relevance score
+        // https://www.mongodb.com/docs/atlas/atlas-search/compound/#options
+        foreach ($builder->wheres as $field => $value) {
+            if ($field === '__soft_deleted') {
+                $value = (bool) $value;
+            }
+
+            $compound['filter'][] = ['equals' => ['path' => $field, 'value' => $value]];
+        }
+
+        foreach ($builder->whereIns as $field => $value) {
+            $compound['filter'][] = ['in' => ['path' => $field, 'value' => $value]];
+        }
+
+        foreach ($builder->whereNotIns as $field => $value) {
+            $compound['mustNot'][] = ['in' => ['path' => $field, 'value' => $value]];
+        }
+
+        // Sort by field value only if specified
+        $sort = [];
+        foreach ($builder->orders as $order) {
+            $sort[$order['column']] = $order['direction'] === 'asc' ? 1 : -1;
+        }
+
+        $pipeline = [
+            [
+                '$search' => [
+                    'index' => self::INDEX_NAME,
+                    'compound' => $compound,
+                    'count' => ['type' => 'lowerBound'],
+                    ...($sort ? ['sort' => $sort] : []),
+                ],
+            ],
+            [
+                '$addFields' => [
+                    // Metadata field with the total count of documents
+                    '__count' => '$$SEARCH_META.count.lowerBound',
+                ],
+            ],
+        ];
+
+        if ($offset) {
+            $pipeline[] = ['$skip' => $offset];
+        }
+
+        if ($builder->limit) {
+            $pipeline[] = ['$limit' => $builder->limit];
+        }
+
+        $options = [
+            'typeMap' => ['root' => 'array', 'document' => 'array', 'array' => 'array'],
+        ];
+
+        return $collection->aggregate($pipeline, $options)->toArray();
+    }
+
+    /**
+     * Pluck and return the primary keys of the given results.
+     *
+     * @see Engine::mapIds()
+     *
+     * @param list<array|object> $results
+     */
+    #[Override]
+    public function mapIds($results): Collection
+    {
+        assert(is_array($results), new TypeError(sprintf('Argument #1 ($results) must be of type array, %s given', get_debug_type($results))));
+
+        return new Collection(array_column($results, '_id'));
+    }
+
+    /**
+     * Map the given results to instances of the given model.
+     *
+     * @see Engine::map()
+     *
+     * @param array $results
+     * @param Model $model
+     */
+    #[Override]
+    public function map(Builder $builder, $results, $model): Collection
+    {
+        assert(is_array($results), new TypeError(sprintf('Argument #2 ($results) must be of type array, %s given', get_debug_type($results))));
+        assert($model instanceof Model, new TypeError(sprintf('Argument #3 ($model) must be of type %s, %s given', Model::class, get_debug_type($model))));
+
+        if (! $results) {
+            return $model->newCollection();
+        }
+
+        $objectIds = array_column($results, '_id');
+        $objectIdPositions = array_flip($objectIds);
+
+        return $model->getScoutModelsByIds(
+            $builder,
+            $objectIds,
+        )->filter(function ($model) use ($objectIdPositions) {
+            return array_key_exists($model->getScoutKey(), $objectIdPositions);
+        })->map(function ($model) use ($results, $objectIdPositions) {
+            $result = $results[$objectIdPositions[$model->getScoutKey()]] ?? [];
+
+            foreach ($result as $key => $value) {
+                if ($key[0] === '_') {
+                    $model->withScoutMetadata($key, $value);
+                }
+            }
+
+            return $model;
+        })->sortBy(function ($model) use ($objectIdPositions) {
+            return $objectIdPositions[$model->getScoutKey()];
+        })->values();
+    }
+
+    /**
+     * Get the total count from a raw result returned by the engine.
+     * This is an estimate if the count is larger than 1000.
+     *
+     * @see Engine::getTotalCount()
+     *
+     * @param mixed $results
+     */
+    #[Override]
+    public function getTotalCount($results): int
+    {
+        if (! $results) {
+            return 0;
+        }
+
+        return $results[0]['__count'];
+    }
+
+    /**
+     * Flush all records from the engine.
+     *
+     * @see Engine::flush()
+     *
+     * @param Model $model
+     */
+    #[Override]
+    public function flush($model): void
+    {
+        assert($model instanceof Model, new TypeError(sprintf('Argument #1 ($model) must be of type %s, %s given', Model::class, get_debug_type($model))));
+
+        $collection = $this->getIndexableCollection($model);
+
+        $collection->deleteMany([]);
+    }
+
+    /**
+     * Map the given results to instances of the given model via a lazy collection.
+     *
+     * @see Engine::lazyMap()
+     *
+     * @param Builder      $builder
+     * @param array|Cursor $results
+     * @param Model        $model
+     *
+     * @return LazyCollection
+     */
+    #[Override]
+    public function lazyMap(Builder $builder, $results, $model): LazyCollection
+    {
+        assert($results instanceof Cursor || is_array($results), new TypeError(sprintf('Argument #2 ($results) must be of type %s|array, %s given', Cursor::class, get_debug_type($results))));
+        assert($model instanceof Model, new TypeError(sprintf('Argument #3 ($model) must be of type %s, %s given', Model::class, get_debug_type($model))));
+
+        if (! $results) {
+            return LazyCollection::make($model->newCollection());
+        }
+
+        $objectIds = array_column($results, '_id');
+        $objectIdPositions = array_flip($objectIds);
+
+        return $model->queryScoutModelsByIds(
+            $builder,
+            $objectIds,
+        )->cursor()->filter(function ($model) use ($objectIds) {
+            return in_array($model->getScoutKey(), $objectIds);
+        })->map(function ($model) use ($results, $objectIdPositions) {
+            $result = $results[$objectIdPositions[$model->getScoutKey()]] ?? [];
+
+            foreach ($result as $key => $value) {
+                if (substr($key, 0, 1) === '_') {
+                    $model->withScoutMetadata($key, $value);
+                }
+            }
+
+            return $model;
+        })->sortBy(function ($model) use ($objectIdPositions) {
+            return $objectIdPositions[$model->getScoutKey()];
+        })->values();
+    }
+
+    /**
+     * Create the MongoDB Atlas Search index.
+     *
+     * Accepted options:
+     *  - wait: bool, default true. Wait for the index to be created.
+     *
+     * @see Engine::createIndex()
+     *
+     * @param string            $name    Collection name
+     * @param array{wait?:bool} $options
+     */
+    #[Override]
+    public function createIndex($name, array $options = []): void
+    {
+        assert(is_string($name), new TypeError(sprintf('Argument #1 ($name) must be of type string, %s given', get_debug_type($name))));
+
+        // Ensure the collection exists before creating the search index
+        $this->database->createCollection($name);
+
+        $collection = $this->database->selectCollection($name);
+        $collection->createSearchIndex(
+            self::DEFAULT_DEFINITION,
+            ['name' => self::INDEX_NAME],
+        );
+
+        if ($options['wait'] ?? true) {
+            $this->wait(function () use ($collection) {
+                $indexes = $collection->listSearchIndexes([
+                    'name' => self::INDEX_NAME,
+                    'typeMap' => ['root' => 'bson'],
+                ]);
+
+                return $indexes->current() && $indexes->current()->status === 'READY';
+            });
+        }
+    }
+
+    /**
+     * Delete a "search index", i.e. a MongoDB collection.
+     *
+     * @see Engine::deleteIndex()
+     */
+    #[Override]
+    public function deleteIndex($name): void
+    {
+        assert(is_string($name), new TypeError(sprintf('Argument #1 ($name) must be of type string, %s given', get_debug_type($name))));
+
+        $this->database->selectCollection($name)->drop();
+    }
+
+    /** Get the MongoDB collection used to search for the provided model */
+    private function getSearchableCollection(Model|EloquentCollection $model): MongoDBCollection
+    {
+        if ($model instanceof EloquentCollection) {
+            $model = $model->first();
+        }
+
+        assert(method_exists($model, 'searchableAs'), sprintf('Model "%s" must use "%s" trait', $model::class, Searchable::class));
+
+        return $this->database->selectCollection($model->searchableAs());
+    }
+
+    /** Get the MongoDB collection used to index the provided model */
+    private function getIndexableCollection(Model|EloquentCollection $model): MongoDBCollection
+    {
+        if ($model instanceof EloquentCollection) {
+            $model = $model->first();
+        }
+
+        assert($model instanceof Model);
+        assert(method_exists($model, 'indexableAs'), sprintf('Model "%s" must use "%s" trait', $model::class, Searchable::class));
+
+        if (
+            $model->getConnection() instanceof Connection
+            && $model->getConnection()->getDatabaseName() === $this->database->getDatabaseName()
+            && $model->getTable() === $model->indexableAs()
+        ) {
+            throw new LogicException(sprintf('The MongoDB Scout collection "%s.%s" must use a different collection from the collection name of the model "%s". Set the "scout.prefix" configuration or use a distinct MongoDB database', $this->database->getDatabaseName(), $model->indexableAs(), $model::class));
+        }
+
+        return $this->database->selectCollection($model->indexableAs());
+    }
+
+    private static function serialize(mixed $value): mixed
+    {
+        if ($value instanceof DateTimeInterface) {
+            return new UTCDateTime($value);
+        }
+
+        if ($value instanceof Serializable || ! is_iterable($value)) {
+            return $value;
+        }
+
+        // Convert Laravel Collections and other Iterators to arrays
+        if ($value instanceof Traversable) {
+            $value = iterator_to_array($value);
+        }
+
+        // Recursively serialize arrays
+        return array_map(self::serialize(...), $value);
+    }
+
+    private function usesSoftDelete(Model|EloquentCollection $model): bool
+    {
+        if ($model instanceof EloquentCollection) {
+            $model = $model->first();
+        }
+
+        return in_array(SoftDeletes::class, class_uses_recursive($model));
+    }
+
+    /**
+     * Wait for the callback to return true, use it for asynchronous
+     * Atlas Search index management operations.
+     */
+    private function wait(Closure $callback): void
+    {
+        // Fallback to time() if hrtime() is not supported
+        $timeout = (hrtime()[0] ?? time()) + self::WAIT_TIMEOUT_SEC;
+        while ((hrtime()[0] ?? time()) < $timeout) {
+            if ($callback()) {
+                return;
+            }
+
+            sleep(1);
+        }
+
+        throw new MongoDBRuntimeException('Atlas search index operation time out');
+    }
+}

--- a/src/Scout/ScoutEngine.php
+++ b/src/Scout/ScoutEngine.php
@@ -17,7 +17,6 @@ use MongoDB\BSON\Serializable;
 use MongoDB\BSON\UTCDateTime;
 use MongoDB\Collection as MongoDBCollection;
 use MongoDB\Database;
-use MongoDB\Driver\Cursor;
 use MongoDB\Driver\CursorInterface;
 use MongoDB\Exception\RuntimeException as MongoDBRuntimeException;
 use MongoDB\Laravel\Connection;
@@ -311,9 +310,9 @@ final class ScoutEngine extends Engine
      *
      * @see Engine::map()
      *
-     * @param Builder      $builder
-     * @param array|Cursor $results
-     * @param Model        $model
+     * @param Builder $builder
+     * @param array   $results
+     * @param Model   $model
      *
      * @return Collection
      */
@@ -328,9 +327,9 @@ final class ScoutEngine extends Engine
      *
      * @see Engine::lazyMap()
      *
-     * @param Builder      $builder
-     * @param array|Cursor $results
-     * @param Model        $model
+     * @param Builder $builder
+     * @param array   $results
+     * @param Model   $model
      *
      * @return LazyCollection
      */

--- a/tests/AtlasSearchTest.php
+++ b/tests/AtlasSearchTest.php
@@ -14,10 +14,12 @@ use MongoDB\Laravel\Tests\Models\Book;
 
 use function array_map;
 use function assert;
+
 use function mt_getrandmax;
 use function rand;
 use function range;
 use function srand;
+use function sort;
 use function usleep;
 use function usort;
 
@@ -202,11 +204,14 @@ class AtlasSearchTest extends TestCase
 
         self::assertInstanceOf(LaravelCollection::class, $results);
         self::assertCount(3, $results);
+        // Sort results, because order is not guaranteed
+        $results = $results->all();
+        sort($results);
         self::assertSame([
             'Database System Concepts',
             'Modern Operating Systems',
             'Operating System Concepts',
-        ], $results->sort()->values()->all());
+        ], $results);
     }
 
     public function testDatabaseBuilderVectorSearch()

--- a/tests/AtlasSearchTest.php
+++ b/tests/AtlasSearchTest.php
@@ -14,12 +14,11 @@ use MongoDB\Laravel\Tests\Models\Book;
 
 use function array_map;
 use function assert;
-
 use function mt_getrandmax;
 use function rand;
 use function range;
-use function srand;
 use function sort;
+use function srand;
 use function usleep;
 use function usort;
 

--- a/tests/AtlasSearchTest.php
+++ b/tests/AtlasSearchTest.php
@@ -17,7 +17,6 @@ use function assert;
 use function mt_getrandmax;
 use function rand;
 use function range;
-use function sort;
 use function srand;
 use function usleep;
 use function usort;
@@ -203,14 +202,11 @@ class AtlasSearchTest extends TestCase
 
         self::assertInstanceOf(LaravelCollection::class, $results);
         self::assertCount(3, $results);
-        // Sort results, because order is not guaranteed
-        $results = $results->all();
-        sort($results);
         self::assertSame([
             'Database System Concepts',
             'Modern Operating Systems',
             'Operating System Concepts',
-        ], $results);
+        ], $results->sort()->values()->all());
     }
 
     public function testDatabaseBuilderVectorSearch()

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -406,8 +406,9 @@ class ModelTest extends TestCase
         $this->assertEquals(2, Soft::count());
     }
 
+    /** @param class-string<Model> $model */
     #[DataProvider('provideId')]
-    public function testPrimaryKey(string $model, $id, $expected, bool $expectedFound): void
+    public function testPrimaryKey(string $model, mixed $id, mixed $expected, bool $expectedFound): void
     {
         $model::truncate();
         $expectedType = get_debug_type($expected);

--- a/tests/Models/SchemaVersion.php
+++ b/tests/Models/SchemaVersion.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace MongoDB\Laravel\Tests\Models;
 
 use MongoDB\Laravel\Eloquent\HasSchemaVersion;
-use MongoDB\Laravel\Eloquent\Model as Eloquent;
+use MongoDB\Laravel\Eloquent\Model;
 
-class SchemaVersion extends Eloquent
+class SchemaVersion extends Model
 {
     use HasSchemaVersion;
 

--- a/tests/Scout/Models/ScoutUser.php
+++ b/tests/Scout/Models/ScoutUser.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Laravel\Tests\Scout\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\SQLiteBuilder;
+use Illuminate\Support\Facades\Schema;
+use Laravel\Scout\Searchable;
+use MongoDB\Laravel\Eloquent\SoftDeletes;
+
+use function assert;
+
+class ScoutUser extends Model
+{
+    use Searchable;
+    use SoftDeletes;
+
+    protected $connection       = 'sqlite';
+    protected $table            = 'scout_users';
+    protected static $unguarded = true;
+
+    /**
+     * Create the SQL table for the model.
+     */
+    public static function executeSchema(): void
+    {
+        $schema = Schema::connection('sqlite');
+        assert($schema instanceof SQLiteBuilder);
+
+        $schema->dropIfExists('scout_users');
+        $schema->create('scout_users', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->string('email')->nullable();
+            $table->date('email_verified_at')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+}

--- a/tests/Scout/Models/SearchableInSameNamespace.php
+++ b/tests/Scout/Models/SearchableInSameNamespace.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Laravel\Tests\Scout\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Laravel\Scout\Searchable;
+use MongoDB\Laravel\Eloquent\DocumentModel;
+
+class SearchableInSameNamespace extends Model
+{
+    use DocumentModel;
+    use Searchable;
+
+    protected $keyType = 'string';
+    protected $connection = 'mongodb';
+    protected $fillable = ['name'];
+
+    /**
+     * Using the same collection as the model collection as Scout index
+     * is prohibited to prevent erasing the data.
+     *
+     * @see Searchable::searchableAs()
+     */
+    public function indexableAs(): string
+    {
+        return $this->getTable();
+    }
+}

--- a/tests/Scout/Models/SearchableModel.php
+++ b/tests/Scout/Models/SearchableModel.php
@@ -39,7 +39,7 @@ class SearchableModel extends Model
 
     /**
      * This method must be overridden when the `getScoutKey` method is also overridden,
-     * to support model serialization for async indexation jobs.
+     * to support model serialization for async indexing jobs.
      *
      * @see Searchable::getScoutKeyName()
      */

--- a/tests/Scout/Models/SearchableModel.php
+++ b/tests/Scout/Models/SearchableModel.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace MongoDB\Laravel\Tests\Scout\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Laravel\Scout\Searchable;
+
+class SearchableModel extends Model
+{
+    use Searchable;
+    use SoftDeletes;
+
+    protected $connection = 'sqlite';
+    protected $fillable = ['id', 'name', 'date'];
+
+    /** @see Searchable::searchableAs() */
+    public function searchableAs(): string
+    {
+        return 'collection_searchable';
+    }
+
+    /** @see Searchable::indexableAs() */
+    public function indexableAs(): string
+    {
+        return 'collection_indexable';
+    }
+
+    /**
+     * Overriding the `getScoutKey` method to ensure the custom key is used for indexing
+     * and searching the model.
+     *
+     * @see Searchable::getScoutKey()
+     */
+    public function getScoutKey(): string
+    {
+        return $this->getAttribute($this->getScoutKeyName()) ?: 'key_' . $this->getKey();
+    }
+
+    /**
+     * This method must be overridden when the `getScoutKey` method is also overridden,
+     * to support model serialization for async indexation jobs.
+     *
+     * @see Searchable::getScoutKeyName()
+     */
+    public function getScoutKeyName(): string
+    {
+        return 'scout_key';
+    }
+}

--- a/tests/Scout/ScoutEngineTest.php
+++ b/tests/Scout/ScoutEngineTest.php
@@ -403,11 +403,11 @@ class ScoutEngineTest extends TestCase
     }
 
     #[DataProvider('provideResultsForMapIds')]
-    public function testMapIds(array $results): void
+    public function testLazyMapIds(array $results): void
     {
         $engine = new ScoutEngine(m::mock(Database::class), softDelete: false);
 
-        $ids = $engine->mapIds($results);
+        $ids = $engine->lazyMap($results);
 
         $this->assertInstanceOf(IlluminateCollection::class, $ids);
         $this->assertEquals(['key_1', 'key_2'], $ids->all());

--- a/tests/Scout/ScoutEngineTest.php
+++ b/tests/Scout/ScoutEngineTest.php
@@ -1,0 +1,548 @@
+<?php
+
+namespace MongoDB\Laravel\Tests\Scout;
+
+use Closure;
+use DateTimeImmutable;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Support\Collection as IlluminateCollection;
+use Laravel\Scout\Builder;
+use Laravel\Scout\Jobs\RemoveFromSearch;
+use Mockery as m;
+use MongoDB\BSON\Document;
+use MongoDB\BSON\UTCDateTime;
+use MongoDB\Collection;
+use MongoDB\Database;
+use MongoDB\Driver\CursorInterface;
+use MongoDB\Laravel\Scout\ScoutEngine;
+use MongoDB\Laravel\Tests\Scout\Models\SearchableModel;
+use MongoDB\Laravel\Tests\TestCase;
+use MongoDB\Model\BSONDocument;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+use function array_replace_recursive;
+use function serialize;
+use function unserialize;
+
+/** Unit tests that do not require an Atlas Search cluster */
+class ScoutEngineTest extends TestCase
+{
+    private const EXPECTED_SEARCH_OPTIONS = ['typeMap' => ['root' => 'array', 'document' => 'array', 'array' => 'array']];
+
+    /** @param callable(): Builder $builder  */
+    #[DataProvider('provideSearchPipelines')]
+    public function testSearch(Closure $builder, array $expectedPipeline): void
+    {
+        $data = [['_id' => 'key_1', '__count' => 15], ['_id' => 'key_2', '__count' => 15]];
+        $database = m::mock(Database::class);
+        $collection = m::mock(Collection::class);
+        $database->shouldReceive('selectCollection')
+            ->with('collection_searchable')
+            ->andReturn($collection);
+        $cursor = m::mock(CursorInterface::class);
+        $cursor->shouldReceive('toArray')->once()->with()->andReturn($data);
+
+        $collection->shouldReceive('aggregate')
+            ->once()
+            ->withArgs(function ($pipeline, $options) use ($expectedPipeline) {
+                self::assertEquals($expectedPipeline, $pipeline);
+                self::assertEquals(self::EXPECTED_SEARCH_OPTIONS, $options);
+
+                return true;
+            })
+            ->andReturn($cursor);
+
+        $engine = new ScoutEngine($database, softDelete: false);
+        $result = $engine->search($builder());
+        $this->assertEquals($data, $result);
+    }
+
+    public function provideSearchPipelines(): iterable
+    {
+        $defaultPipeline = [
+            [
+                '$search' => [
+                    'index' => 'scout',
+                    'compound' => [
+                        'should' => [
+                            [
+                                'text' => [
+                                    'path' => ['wildcard' => '*'],
+                                    'query' => 'lar',
+                                    'fuzzy' => ['maxEdits' => 2],
+                                    'score' => ['boost' => ['value' => 5]],
+                                ],
+                            ],
+                            [
+                                'wildcard' => [
+                                    'query' => 'lar*',
+                                    'path' => ['wildcard' => '*'],
+                                    'allowAnalyzedField' => true,
+                                ],
+                            ],
+                        ],
+                        'minimumShouldMatch' => 1,
+                    ],
+                    'count' => [
+                        'type' => 'lowerBound',
+                    ],
+                ],
+            ],
+            [
+                '$addFields' => [
+                    '__count' => '$$SEARCH_META.count.lowerBound',
+                ],
+            ],
+        ];
+
+        yield 'simple string' => [
+            function () {
+                return new Builder(new SearchableModel(), 'lar');
+            },
+            $defaultPipeline,
+        ];
+
+        yield 'where conditions' => [
+            function () {
+                $builder = new Builder(new SearchableModel(), 'lar');
+                $builder->where('foo', 'bar');
+                $builder->where('key', 'value');
+
+                return $builder;
+            },
+            array_replace_recursive($defaultPipeline, [
+                [
+                    '$search' => [
+                        'compound' => [
+                            'filter' => [
+                                ['equals' => ['path' => 'foo', 'value' => 'bar']],
+                                ['equals' => ['path' => 'key', 'value' => 'value']],
+                            ],
+                        ],
+                    ],
+                ],
+            ]),
+        ];
+
+        yield 'where in conditions' => [
+            function () {
+                $builder = new Builder(new SearchableModel(), 'lar');
+                $builder->where('foo', 'bar');
+                $builder->where('bar', 'baz');
+                $builder->whereIn('qux', [1, 2]);
+                $builder->whereIn('quux', [1, 2]);
+
+                return $builder;
+            },
+            array_replace_recursive($defaultPipeline, [
+                [
+                    '$search' => [
+                        'compound' => [
+                            'filter' => [
+                                ['equals' => ['path' => 'foo', 'value' => 'bar']],
+                                ['equals' => ['path' => 'bar', 'value' => 'baz']],
+                                ['in' => ['path' => 'qux', 'value' => [1, 2]]],
+                                ['in' => ['path' => 'quux', 'value' => [1, 2]]],
+                            ],
+                        ],
+                    ],
+                ],
+            ]),
+        ];
+
+        yield 'where not in conditions' => [
+            function () {
+                $builder = new Builder(new SearchableModel(), 'lar');
+                $builder->where('foo', 'bar');
+                $builder->where('bar', 'baz');
+                $builder->whereIn('qux', [1, 2]);
+                $builder->whereIn('quux', [1, 2]);
+                $builder->whereNotIn('eaea', [3]);
+
+                return $builder;
+            },
+            array_replace_recursive($defaultPipeline, [
+                [
+                    '$search' => [
+                        'compound' => [
+                            'filter' => [
+                                ['equals' => ['path' => 'foo', 'value' => 'bar']],
+                                ['equals' => ['path' => 'bar', 'value' => 'baz']],
+                                ['in' => ['path' => 'qux', 'value' => [1, 2]]],
+                                ['in' => ['path' => 'quux', 'value' => [1, 2]]],
+                            ],
+                            'mustNot' => [
+                                ['in' => ['path' => 'eaea', 'value' => [3]]],
+                            ],
+                        ],
+                    ],
+                ],
+            ]),
+        ];
+
+        yield 'where in conditions without other conditions' => [
+            function () {
+                $builder = new Builder(new SearchableModel(), 'lar');
+                $builder->whereIn('qux', [1, 2]);
+                $builder->whereIn('quux', [1, 2]);
+
+                return $builder;
+            },
+            array_replace_recursive($defaultPipeline, [
+                [
+                    '$search' => [
+                        'compound' => [
+                            'filter' => [
+                                ['in' => ['path' => 'qux', 'value' => [1, 2]]],
+                                ['in' => ['path' => 'quux', 'value' => [1, 2]]],
+                            ],
+                        ],
+                    ],
+                ],
+            ]),
+        ];
+
+        yield 'where not in conditions without other conditions' => [
+            function () {
+                $builder = new Builder(new SearchableModel(), 'lar');
+                $builder->whereIn('qux', [1, 2]);
+                $builder->whereIn('quux', [1, 2]);
+                $builder->whereNotIn('eaea', [3]);
+
+                return $builder;
+            },
+            array_replace_recursive($defaultPipeline, [
+                [
+                    '$search' => [
+                        'compound' => [
+                            'filter' => [
+                                ['in' => ['path' => 'qux', 'value' => [1, 2]]],
+                                ['in' => ['path' => 'quux', 'value' => [1, 2]]],
+                            ],
+                            'mustNot' => [
+                                ['in' => ['path' => 'eaea', 'value' => [3]]],
+                            ],
+                        ],
+                    ],
+                ],
+            ]),
+        ];
+
+        yield 'empty where in conditions' => [
+            function () {
+                $builder = new Builder(new SearchableModel(), 'lar');
+                $builder->whereIn('qux', [1, 2]);
+                $builder->whereIn('quux', [1, 2]);
+                $builder->whereNotIn('eaea', [3]);
+
+                return $builder;
+            },
+            array_replace_recursive($defaultPipeline, [
+                [
+                    '$search' => [
+                        'compound' => [
+                            'filter' => [
+                                ['in' => ['path' => 'qux', 'value' => [1, 2]]],
+                                ['in' => ['path' => 'quux', 'value' => [1, 2]]],
+                            ],
+                            'mustNot' => [
+                                ['in' => ['path' => 'eaea', 'value' => [3]]],
+                            ],
+                        ],
+                    ],
+                ],
+            ]),
+        ];
+
+        yield 'exclude soft-deleted' => [
+            function () {
+                return new Builder(new SearchableModel(), 'lar', softDelete: true);
+            },
+            array_replace_recursive($defaultPipeline, [
+                [
+                    '$search' => [
+                        'compound' => [
+                            'filter' => [
+                                ['equals' => ['path' => '__soft_deleted', 'value' => 0]],
+                            ],
+                        ],
+                    ],
+                ],
+            ]),
+        ];
+
+        yield 'only trashed' => [
+            function () {
+                $builder = new Builder(new SearchableModel(), 'lar', softDelete: true);
+                $builder->onlyTrashed();
+
+                return $builder;
+            },
+            array_replace_recursive($defaultPipeline, [
+                [
+                    '$search' => [
+                        'compound' => [
+                            'filter' => [
+                                ['equals' => ['path' => '__soft_deleted', 'value' => 1]],
+                            ],
+                        ],
+                    ],
+                ],
+            ]),
+        ];
+
+        yield 'with callback' => [
+            fn () => new Builder(new SearchableModel(), 'query', callback: function (...$args) {
+                $this->assertCount(3, $args);
+                $this->assertInstanceOf(Collection::class, $args[0]);
+                $this->assertSame('query', $args[1]);
+                $this->assertNull($args[2]);
+
+                return $args[0]->aggregate(['pipeline'], self::EXPECTED_SEARCH_OPTIONS);
+            }),
+            ['pipeline'],
+        ];
+
+        yield 'ordered' => [
+            function () {
+                $builder = new Builder(new SearchableModel(), 'lar');
+                $builder->orderBy('name', 'desc');
+                $builder->orderBy('age', 'asc');
+
+                return $builder;
+            },
+            array_replace_recursive($defaultPipeline, [
+                [
+                    '$search' => [
+                        'sort' => [
+                            'name' => -1,
+                            'age' => 1,
+                        ],
+                    ],
+                ],
+            ]),
+        ];
+    }
+
+    public function testPaginate()
+    {
+        $perPage = 5;
+        $page = 3;
+
+        $database = m::mock(Database::class);
+        $collection = m::mock(Collection::class);
+        $cursor = m::mock(CursorInterface::class);
+        $database->shouldReceive('selectCollection')
+            ->with('collection_searchable')
+            ->andReturn($collection);
+        $collection->shouldReceive('aggregate')
+            ->once()
+            ->withArgs(function (...$args) {
+                self::assertSame([
+                    [
+                        '$search' => [
+                            'index' => 'scout',
+                            'compound' => [
+                                'should' => [
+                                    [
+                                        'text' => [
+                                            'query' => 'mustang',
+                                            'path' => ['wildcard' => '*'],
+                                            'fuzzy' => ['maxEdits' => 2],
+                                            'score' => ['boost' => ['value' => 5]],
+                                        ],
+                                    ],
+                                    [
+                                        'wildcard' => [
+                                            'query' => 'mustang*',
+                                            'path' => ['wildcard' => '*'],
+                                            'allowAnalyzedField' => true,
+                                        ],
+                                    ],
+                                ],
+                                'minimumShouldMatch' => 1,
+                            ],
+                            'count' => [
+                                'type' => 'lowerBound',
+                            ],
+                            'sort' => [
+                                'name' => -1,
+                            ],
+                        ],
+                    ],
+                    [
+                        '$addFields' => [
+                            '__count' => '$$SEARCH_META.count.lowerBound',
+                        ],
+                    ],
+                    [
+                        '$skip' => 10,
+                    ],
+                    [
+                        '$limit' => 5,
+                    ],
+                ], $args[0]);
+
+                $this->assertSame(self::EXPECTED_SEARCH_OPTIONS, $args[1]);
+
+                return true;
+            })
+            ->andReturn($cursor);
+        $cursor->shouldReceive('toArray')
+            ->once()
+            ->with()
+            ->andReturn([['_id' => 'key_1', '__count' => 17], ['_id' => 'key_2', '__count' => 17]]);
+
+        $engine = new ScoutEngine($database, softDelete: false);
+        $builder = new Builder(new SearchableModel(), 'mustang');
+        $builder->orderBy('name', 'desc');
+        $engine->paginate($builder, $perPage, $page);
+    }
+
+    #[DataProvider('provideResultsForMapIds')]
+    public function testMapIds(array $results): void
+    {
+        $engine = new ScoutEngine(m::mock(Database::class), softDelete: false);
+
+        $ids = $engine->mapIds($results);
+
+        $this->assertInstanceOf(IlluminateCollection::class, $ids);
+        $this->assertEquals(['key_1', 'key_2'], $ids->all());
+    }
+
+    public static function provideResultsForMapIds(): iterable
+    {
+        yield 'array' => [
+            [
+                ['_id' => 'key_1', 'foo' => 'bar'],
+                ['_id' => 'key_2', 'foo' => 'bar'],
+            ],
+        ];
+
+        yield 'object' => [
+            [
+                (object) ['_id' => 'key_1', 'foo' => 'bar'],
+                (object) ['_id' => 'key_2', 'foo' => 'bar'],
+            ],
+        ];
+
+        yield Document::class => [
+            [
+                Document::fromPHP(['_id' => 'key_1', 'foo' => 'bar']),
+                Document::fromPHP(['_id' => 'key_2', 'foo' => 'bar']),
+            ],
+        ];
+
+        yield BSONDocument::class => [
+            [
+                new BSONDocument(['_id' => 'key_1', 'foo' => 'bar']),
+                new BSONDocument(['_id' => 'key_2', 'foo' => 'bar']),
+            ],
+        ];
+    }
+
+    public function testUpdate(): void
+    {
+        $date = new DateTimeImmutable('2000-01-02 03:04:05');
+        $database = m::mock(Database::class);
+        $collection = m::mock(Collection::class);
+        $database->shouldReceive('selectCollection')
+            ->with('collection_indexable')
+            ->andReturn($collection);
+        $collection->shouldReceive('bulkWrite')
+            ->once()
+            ->with([
+                [
+                    'updateOne' => [
+                        ['_id' => 'key_1'],
+                        ['$setOnInsert' => ['_id' => 'key_1'], '$set' => ['id' => 1, 'date' => new UTCDateTime($date)]],
+                        ['upsert' => true],
+                    ],
+                ],
+                [
+                    'updateOne' => [
+                        ['_id' => 'key_2'],
+                        ['$setOnInsert' => ['_id' => 'key_2'], '$set' => ['id' => 2]],
+                        ['upsert' => true],
+                    ],
+                ],
+            ]);
+
+        $engine = new ScoutEngine($database, softDelete: false);
+        $engine->update(EloquentCollection::make([
+            new SearchableModel([
+                'id' => 1,
+                'date' => $date,
+            ]),
+            new SearchableModel([
+                'id' => 2,
+            ]),
+        ]));
+    }
+
+    public function testUpdateWithSoftDelete(): void
+    {
+        $date = new DateTimeImmutable('2000-01-02 03:04:05');
+        $database = m::mock(Database::class);
+        $collection = m::mock(Collection::class);
+        $database->shouldReceive('selectCollection')
+            ->with('collection_indexable')
+            ->andReturn($collection);
+        $collection->shouldReceive('bulkWrite')
+            ->once()
+            ->with([
+                [
+                    'updateOne' => [
+                        ['_id' => 'key_1'],
+                        ['$setOnInsert' => ['_id' => 'key_1'], '$set' => ['id' => 1]],
+                        ['upsert' => true],
+                    ],
+                ],
+            ]);
+
+        $model = new SearchableModel(['id' => 1]);
+        $model->delete();
+
+        $engine = new ScoutEngine($database, softDelete: false);
+        $engine->update(EloquentCollection::make([$model]));
+    }
+
+    public function testDelete(): void
+    {
+        $database = m::mock(Database::class);
+        $collection = m::mock(Collection::class);
+        $database->shouldReceive('selectCollection')
+            ->with('collection_indexable')
+            ->andReturn($collection);
+        $collection->shouldReceive('deleteMany')
+            ->once()
+            ->with(['_id' => ['$in' => ['key_1', 'key_2']]]);
+
+        $engine = new ScoutEngine($database, softDelete: false);
+        $engine->delete(EloquentCollection::make([
+            new SearchableModel(['id' => 1]),
+            new SearchableModel(['id' => 2]),
+        ]));
+    }
+
+    public function testDeleteWithRemoveableScoutCollection(): void
+    {
+        $job = new RemoveFromSearch(EloquentCollection::make([
+            new SearchableModel(['id' => 5, 'scout_key' => 'key_5']),
+        ]));
+
+        $job = unserialize(serialize($job));
+
+        $database = m::mock(Database::class);
+        $collection = m::mock(Collection::class);
+        $database->shouldReceive('selectCollection')
+            ->with('collection_indexable')
+            ->andReturn($collection);
+        $collection->shouldReceive('deleteMany')
+            ->once()
+            ->with(['_id' => ['$in' => ['key_5']]]);
+
+        $engine = new ScoutEngine($database, softDelete: false);
+        $engine->delete($job->models);
+    }
+}

--- a/tests/Scout/ScoutEngineTest.php
+++ b/tests/Scout/ScoutEngineTest.php
@@ -485,14 +485,14 @@ class ScoutEngineTest extends TestCase
                 [
                     'updateOne' => [
                         ['_id' => 'key_1'],
-                        ['$setOnInsert' => ['_id' => 'key_1'], '$set' => ['id' => 1, 'date' => new UTCDateTime($date)]],
+                        ['$set' => ['id' => 1, 'date' => new UTCDateTime($date)]],
                         ['upsert' => true],
                     ],
                 ],
                 [
                     'updateOne' => [
                         ['_id' => 'key_2'],
-                        ['$setOnInsert' => ['_id' => 'key_2'], '$set' => ['id' => 2]],
+                        ['$set' => ['id' => 2]],
                         ['upsert' => true],
                     ],
                 ],
@@ -525,7 +525,7 @@ class ScoutEngineTest extends TestCase
                     [
                         'updateOne' => [
                             ['_id' => 'key_1'],
-                            ['$setOnInsert' => ['_id' => 'key_1'], '$set' => ['id' => 1, '__soft_deleted' => false]],
+                            ['$set' => ['id' => 1, '__soft_deleted' => false]],
                             ['upsert' => true],
                         ],
                     ],

--- a/tests/Scout/ScoutIntegrationTest.php
+++ b/tests/Scout/ScoutIntegrationTest.php
@@ -146,6 +146,26 @@ class ScoutIntegrationTest extends TestCase
     }
 
     #[Depends('testItCanCreateTheCollection')]
+    public function testItCanUseBasicSearchCursor()
+    {
+        // All the search queries use "sort" option to ensure the results are deterministic
+        $results = ScoutUser::search('lar')->take(10)->orderBy('id')->cursor();
+
+        self::assertSame([
+            1 => 'Laravel Framework',
+            11 => 'Larry Casper',
+            12 => 'Reta Larkin',
+            20 => 'Prof. Larry Prosacco DVM',
+            39 => 'Linkwood Larkin',
+            40 => 'Otis Larson MD',
+            41 => 'Gudrun Larkin',
+            42 => 'Dax Larkin',
+            43 => 'Dana Larson Sr.',
+            44 => 'Amos Larson Sr.',
+        ], $results->pluck('name', 'id')->all());
+    }
+
+    #[Depends('testItCanCreateTheCollection')]
     public function testItCanUseBasicSearchWithQueryCallback()
     {
         $results = ScoutUser::search('lar')->take(10)->orderBy('id')->query(function ($query) {

--- a/tests/Scout/ScoutIntegrationTest.php
+++ b/tests/Scout/ScoutIntegrationTest.php
@@ -42,6 +42,8 @@ class ScoutIntegrationTest extends TestCase
     {
         parent::setUp();
 
+        $this->skipIfSearchIndexManagementIsNotSupported();
+
         // Init the SQL database with some objects that will be indexed
         // Test data copied from Laravel Scout tests
         // https://github.com/laravel/scout/blob/10.x/tests/Integration/SearchableTests.php
@@ -88,8 +90,6 @@ class ScoutIntegrationTest extends TestCase
     /** This test create the search index for tests performing search */
     public function testItCanCreateTheCollection()
     {
-        $this->skipIfSearchIndexManagementIsNotSupported();
-
         $collection = DB::connection('mongodb')->getCollection('prefix_scout_users');
         $collection->drop();
 
@@ -111,7 +111,7 @@ class ScoutIntegrationTest extends TestCase
                 ['$search' => ['index' => 'scout', 'exists' => ['path' => 'name']]],
             ])->toArray();
 
-            if (count($indexedDocuments) > 0) {
+            if (count($indexedDocuments) >= 44) {
                 break;
             }
 

--- a/tests/Scout/ScoutIntegrationTest.php
+++ b/tests/Scout/ScoutIntegrationTest.php
@@ -1,0 +1,242 @@
+<?php
+
+namespace MongoDB\Laravel\Tests\Scout;
+
+use DateTimeImmutable;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\LazyCollection;
+use Laravel\Scout\ScoutServiceProvider;
+use LogicException;
+use MongoDB\Laravel\Tests\Scout\Models\ScoutUser;
+use MongoDB\Laravel\Tests\Scout\Models\SearchableInSameNamespace;
+use MongoDB\Laravel\Tests\TestCase;
+use Override;
+use PHPUnit\Framework\Attributes\Depends;
+
+use function array_merge;
+use function count;
+use function env;
+use function Orchestra\Testbench\artisan;
+use function range;
+use function sprintf;
+use function usleep;
+
+class ScoutIntegrationTest extends TestCase
+{
+    #[Override]
+    protected function getPackageProviders($app): array
+    {
+        return array_merge(parent::getPackageProviders($app), [ScoutServiceProvider::class]);
+    }
+
+    #[Override]
+    protected function getEnvironmentSetUp($app): void
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('scout.driver', 'mongodb');
+        $app['config']->set('scout.prefix', 'prefix_');
+    }
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        // Init the SQL database with some objects that will be indexed
+        // Test data copied from Laravel Scout tests
+        // https://github.com/laravel/scout/blob/10.x/tests/Integration/SearchableTests.php
+        ScoutUser::executeSchema();
+
+        $collect = LazyCollection::make(function () {
+            yield ['name' => 'Laravel Framework'];
+
+            foreach (range(2, 10) as $key) {
+                yield ['name' => 'Example ' . $key];
+            }
+
+            yield ['name' => 'Larry Casper', 'email_verified_at' => null];
+            yield ['name' => 'Reta Larkin'];
+
+            foreach (range(13, 19) as $key) {
+                yield ['name' => 'Example ' . $key];
+            }
+
+            yield ['name' => 'Prof. Larry Prosacco DVM', 'email_verified_at' => null];
+
+            foreach (range(21, 38) as $key) {
+                yield ['name' => 'Example ' . $key, 'email_verified_at' => null];
+            }
+
+            yield ['name' => 'Linkwood Larkin', 'email_verified_at' => null];
+            yield ['name' => 'Otis Larson MD'];
+            yield ['name' => 'Gudrun Larkin'];
+            yield ['name' => 'Dax Larkin'];
+            yield ['name' => 'Dana Larson Sr.'];
+            yield ['name' => 'Amos Larson Sr.'];
+        });
+
+        $id = 0;
+        $date = new DateTimeImmutable('2021-01-01 00:00:00');
+        foreach ($collect as $data) {
+            $data = array_merge(['id' => ++$id, 'email_verified_at' => $date], $data);
+            ScoutUser::create($data)->save();
+        }
+
+        self::assertSame(44, ScoutUser::count());
+    }
+
+    /** This test create the search index for tests performing search */
+    public function testItCanCreateTheCollection()
+    {
+        $this->skipIfSearchIndexManagementIsNotSupported();
+
+        $collection = DB::connection('mongodb')->getCollection('prefix_scout_users');
+        $collection->drop();
+
+        // Recreate the indexes using the artisan commands
+        // Ensure they return a success exit code (0)
+        self::assertSame(0, artisan($this, 'scout:delete-index', ['name' => ScoutUser::class]));
+        self::assertSame(0, artisan($this, 'scout:index', ['name' => ScoutUser::class]));
+        self::assertSame(0, artisan($this, 'scout:import', ['model' => ScoutUser::class]));
+
+        self::assertSame(44, $collection->countDocuments());
+
+        $searchIndexes = $collection->listSearchIndexes(['name' => 'scout']);
+        self::assertCount(1, $searchIndexes);
+
+        // Wait for all documents to be indexed asynchronously
+        $i = 100;
+        while (true) {
+            $indexedDocuments = $collection->aggregate([
+                ['$search' => ['index' => 'scout', 'exists' => ['path' => 'name']]],
+            ])->toArray();
+
+            if (count($indexedDocuments) > 0) {
+                break;
+            }
+
+            if ($i-- === 0) {
+                self::fail('Documents not indexed');
+            }
+
+            usleep(100_000);
+        }
+
+        self::assertCount(44, $indexedDocuments);
+    }
+
+    #[Depends('testItCanCreateTheCollection')]
+    public function testItCanUseBasicSearch()
+    {
+        // All the search queries use "sort" option to ensure the results are deterministic
+        $results = ScoutUser::search('lar')->take(10)->orderBy('id')->get();
+
+        self::assertSame([
+            1 => 'Laravel Framework',
+            11 => 'Larry Casper',
+            12 => 'Reta Larkin',
+            20 => 'Prof. Larry Prosacco DVM',
+            39 => 'Linkwood Larkin',
+            40 => 'Otis Larson MD',
+            41 => 'Gudrun Larkin',
+            42 => 'Dax Larkin',
+            43 => 'Dana Larson Sr.',
+            44 => 'Amos Larson Sr.',
+        ], $results->pluck('name', 'id')->all());
+    }
+
+    #[Depends('testItCanCreateTheCollection')]
+    public function testItCanUseBasicSearchWithQueryCallback()
+    {
+        $results = ScoutUser::search('lar')->take(10)->orderBy('id')->query(function ($query) {
+            return $query->whereNotNull('email_verified_at');
+        })->get();
+
+        self::assertSame([
+            1 => 'Laravel Framework',
+            12 => 'Reta Larkin',
+            40 => 'Otis Larson MD',
+            41 => 'Gudrun Larkin',
+            42 => 'Dax Larkin',
+            43 => 'Dana Larson Sr.',
+            44 => 'Amos Larson Sr.',
+        ], $results->pluck('name', 'id')->all());
+    }
+
+    #[Depends('testItCanCreateTheCollection')]
+    public function testItCanUseBasicSearchToFetchKeys()
+    {
+        $results = ScoutUser::search('lar')->orderBy('id')->take(10)->keys();
+
+        self::assertSame([1, 11, 12, 20, 39, 40, 41, 42, 43, 44], $results->all());
+    }
+
+    #[Depends('testItCanCreateTheCollection')]
+    public function testItCanUseBasicSearchWithQueryCallbackToFetchKeys()
+    {
+        $results = ScoutUser::search('lar')->take(10)->orderBy('id', 'desc')->query(function ($query) {
+            return $query->whereNotNull('email_verified_at');
+        })->keys();
+
+        self::assertSame([44, 43, 42, 41, 40, 39, 20, 12, 11, 1], $results->all());
+    }
+
+    #[Depends('testItCanCreateTheCollection')]
+    public function testItCanUsePaginatedSearch()
+    {
+        $page1 = ScoutUser::search('lar')->take(10)->orderBy('id')->paginate(5, 'page', 1);
+        $page2 = ScoutUser::search('lar')->take(10)->orderBy('id')->paginate(5, 'page', 2);
+
+        self::assertSame([
+            1 => 'Laravel Framework',
+            11 => 'Larry Casper',
+            12 => 'Reta Larkin',
+            20 => 'Prof. Larry Prosacco DVM',
+            39 => 'Linkwood Larkin',
+        ], $page1->pluck('name', 'id')->all());
+
+        self::assertSame([
+            40 => 'Otis Larson MD',
+            41 => 'Gudrun Larkin',
+            42 => 'Dax Larkin',
+            43 => 'Dana Larson Sr.',
+            44 => 'Amos Larson Sr.',
+        ], $page2->pluck('name', 'id')->all());
+    }
+
+    #[Depends('testItCanCreateTheCollection')]
+    public function testItCanUsePaginatedSearchWithQueryCallback()
+    {
+        $queryCallback = function ($query) {
+            return $query->whereNotNull('email_verified_at');
+        };
+
+        $page1 = ScoutUser::search('lar')->take(10)->orderBy('id')->query($queryCallback)->paginate(5, 'page', 1);
+        $page2 = ScoutUser::search('lar')->take(10)->orderBy('id')->query($queryCallback)->paginate(5, 'page', 2);
+
+        self::assertSame([
+            1 => 'Laravel Framework',
+            12 => 'Reta Larkin',
+        ], $page1->pluck('name', 'id')->all());
+
+        self::assertSame([
+            40 => 'Otis Larson MD',
+            41 => 'Gudrun Larkin',
+            42 => 'Dax Larkin',
+            43 => 'Dana Larson Sr.',
+            44 => 'Amos Larson Sr.',
+        ], $page2->pluck('name', 'id')->all());
+    }
+
+    public function testItCannotIndexInTheSameNamespace()
+    {
+        self::expectException(LogicException::class);
+        self::expectExceptionMessage(sprintf(
+            'The MongoDB Scout collection "%s.searchable_in_same_namespaces" must use a different collection from the collection name of the model "%s". Set the "scout.prefix" configuration or use a distinct MongoDB database',
+            env('MONGODB_DATABASE', 'unittest'),
+            SearchableInSameNamespace::class,
+        ),);
+
+        SearchableInSameNamespace::create(['name' => 'test']);
+    }
+}


### PR DESCRIPTION
Fix PHPORM-28

- And "index" stands for a MongoDB collection with an Atlas Search index named "scout".
- The collection name MUST be prefixed to prevent error of indexing in the same MongoDB Collection as the source documents.

### Checklist

- [x] Add tests and ensure they pass
