### PR TITLE
Increase connection timeouts to allow using Atlas shared clusters

### DIFF
--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -351,7 +351,7 @@ class ConnectionTest extends TestCase
             'database' => 'unittest',
             'options'  => [
                 'connectTimeoutMS'         => 1000,
-                'serverSelectionTimeoutMS' => 1000,
+                'serverSelectionTimeoutMS' => 6000,
             ],
         ];
 

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -350,8 +350,8 @@ class ConnectionTest extends TestCase
             'dsn'      => env('MONGODB_URI', 'mongodb://127.0.0.1/'),
             'database' => 'unittest',
             'options'  => [
-                'connectTimeoutMS'         => 100,
-                'serverSelectionTimeoutMS' => 250,
+                'connectTimeoutMS'         => 1000,
+                'serverSelectionTimeoutMS' => 1000,
             ],
         ];
 

--- a/tests/config/database.php
+++ b/tests/config/database.php
@@ -10,8 +10,8 @@ return [
             'dsn' => env('MONGODB_URI', 'mongodb://127.0.0.1/'),
             'database' => env('MONGODB_DATABASE', 'unittest'),
             'options' => [
-                'connectTimeoutMS'         => 100,
-                'serverSelectionTimeoutMS' => 250,
+                'connectTimeoutMS'         => 1000,
+                'serverSelectionTimeoutMS' => 1000,
             ],
         ],
 

--- a/tests/config/database.php
+++ b/tests/config/database.php
@@ -11,7 +11,7 @@ return [
             'database' => env('MONGODB_DATABASE', 'unittest'),
             'options' => [
                 'connectTimeoutMS'         => 1000,
-                'serverSelectionTimeoutMS' => 1000,
+                'serverSelectionTimeoutMS' => 6000,
             ],
         ],
 


### PR DESCRIPTION
I wasted far too much time trying to run the tests using an Atlas M0 cluster. It turned out that the error was due to a delay too short to allow the connection.