### PR TITLE
PHPORM-263 Fix deprecation message for collection/table config in MongoDBQueueServiceProvider

### DIFF
--- a/src/MongoDBQueueServiceProvider.php
+++ b/src/MongoDBQueueServiceProvider.php
@@ -54,15 +54,15 @@ class MongoDBQueueServiceProvider extends QueueServiceProvider
      */
     protected function mongoFailedJobProvider(array $config): MongoFailedJobProvider
     {
-        if (! isset($config['collection']) && isset($config['table'])) {
-            trigger_error('Since mongodb/laravel-mongodb 4.4: Using "table" option for the queue is deprecated. Use "collection" instead.', E_USER_DEPRECATED);
-            $config['collection'] = $config['table'];
+        if (! isset($config['table']) && isset($config['collection'])) {
+            trigger_error('Since mongodb/laravel-mongodb 4.4: Using "collection" option for the queue is deprecated. Use "table" instead.', E_USER_DEPRECATED);
+            $config['table'] = $config['collection'];
         }
 
         return new MongoFailedJobProvider(
             $this->app['db'],
             $config['database'] ?? null,
-            $config['collection'] ?? 'failed_jobs',
+            $config['table'] ?? 'failed_jobs',
         );
     }
 }


### PR DESCRIPTION
Fix PHPORM-263

The `MongoDBQueueServiceProvider` was removed by https://github.com/mongodb/laravel-mongodb/pull/3122. We use the default Laravel configuration for failed queue.


### Checklist

- [x] Add tests and ensure they pass
