### PR TITLE
PHPORM-273 Add schema helpers to create search and vector indexes

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -53,4 +53,8 @@
     <rule ref="PSR1.Classes.ClassDeclaration.MultipleClasses">
         <exclude-pattern>tests/Ticket/*.php</exclude-pattern>
     </rule>
+
+    <rule ref="SlevomatCodingStandard.Commenting.DocCommentSpacing.IncorrectAnnotationsGroup">
+        <exclude-pattern>src/Schema/Blueprint.php</exclude-pattern>
+    </rule>
 </ruleset>

--- a/src/Schema/Blueprint.php
+++ b/src/Schema/Blueprint.php
@@ -17,12 +17,81 @@ use function is_string;
 use function key;
 
 /**
- * @phpstan-type SearchIndexField array{type: 'boolean'|'date'|'dateFacet'|'objectId'|'stringFacet'|'uuid'} | array{type: 'autocomplete', analyzer?: string, maxGrams?: int, minGrams?: int, tokenization?: 'edgeGram'|'rightEdgeGram'|'nGram', foldDiacritics?: bool} | array{type: 'document'|'embeddedDocuments', dynamic?:bool, fields: array<string, array>} | array{type: 'geo', indexShapes?: bool} | array{type: 'number'|'numberFacet', representation?: 'int64'|'double', indexIntegers?: bool, indexDoubles?: bool} | array{type: 'token', normalizer?: 'lowercase'|'none'} | array{type: 'string', analyzer?: string, searchAnalyzer?: string, indexOptions?: 'docs'|'freqs'|'positions'|'offsets', store?: bool, ignoreAbove?: int, multi?: array<string, array>, norms?: 'include'|'omit'}
- * @phpstan-type SearchIndexAnalyser array{name: string, charFilters?: list<array<string, mixed>>, tokenizer: array{type: string}, tokenFilters?: list<array<string, mixed>>}
- * @phpstan-type SearchIndexStoredSource bool | array{includes: array<string>} | array{excludes: array<string>}
- * @phpstan-type SearchIndexDefinition array{analyser?: string, analyzers?: SearchIndexAnalyser[], searchAnalyzer?: string, mappings: array{dynamic: true} | array{dynamic?: bool, fields: array<string, SearchIndexField>}, storedSource?: SearchIndexStoredSource}
- * @phpstan-type VectorSearchIndexField array{type: 'vector', path: string, numDimensions: int, similarity: 'euclidean'|'cosine'|'dotProduct', quantization?: 'none'|'scalar'|'binary'}
- * @phpstan-type VectorSearchIndexDefinition array{fields: array<string, VectorSearchIndexField>}
+ * @phpstan-type TypeSearchIndexField array{
+ *     type: 'boolean'|'date'|'dateFacet'|'objectId'|'stringFacet'|'uuid',
+ * } | array{
+ *     type: 'autocomplete',
+ *     analyzer?: string,
+ *     maxGrams?: int,
+ *     minGrams?: int,
+ *     tokenization?: 'edgeGram'|'rightEdgeGram'|'nGram',
+ *     foldDiacritics?: bool,
+ * } | array{
+ *     type: 'document'|'embeddedDocuments',
+ *     dynamic?:bool,
+ *     fields: array<string, array<mixed>>,
+ * } | array{
+ *     type: 'geo',
+ *     indexShapes?: bool,
+ * } | array{
+ *     type: 'number'|'numberFacet',
+ *     representation?: 'int64'|'double',
+ *     indexIntegers?: bool,
+ *     indexDoubles?: bool,
+ * } | array{
+ *     type: 'token',
+ *     normalizer?: 'lowercase'|'none',
+ * } | array{
+ *     type: 'string',
+ *     analyzer?: string,
+ *     searchAnalyzer?: string,
+ *     indexOptions?: 'docs'|'freqs'|'positions'|'offsets',
+ *     store?: bool,
+ *     ignoreAbove?: int,
+ *     multi?: array<string, array<mixed>>,
+ *     norms?: 'include'|'omit',
+ * }
+ * @phpstan-type TypeSearchIndexCharFilter array{
+ *      type: 'icuNormalize'|'persian',
+ *  } | array{
+ *     type: 'htmlStrip',
+ *     ignoredTags?: string[],
+ * } | array{
+ *     type: 'mapping',
+ *     mappings?: array<string, string>,
+ * }
+ * @phpstan-type TypeSearchIndexTokenFilter array{type: string, ...}
+ * @phpstan-type TypeSearchIndexAnalyzer array{
+ *     name: string,
+ *     charFilters?: TypeSearchIndexCharFilter,
+ *     tokenizer: array{type: string},
+ *     tokenFilters?: TypeSearchIndexTokenFilter,
+ * }
+ * @phpstan-type TypeSearchIndexStoredSource bool | array{
+ *     includes: array<string>,
+ * } | array{
+ *     excludes: array<string>,
+ * }
+ * @phpstan-type TypeSearchIndexDefinition array{
+ *     analyser?: string,
+ *     analyzers?: TypeSearchIndexAnalyzer[],
+ *     searchAnalyzer?: string,
+ *     mappings: array{dynamic: true} | array{dynamic?: bool, fields: array<string, TypeSearchIndexField>},
+ *     storedSource?: TypeSearchIndexStoredSource,
+ * }
+ * @phpstan-type TypeVectorSearchIndexField array{
+ *     type: 'vector',
+ *     path: string,
+ *     numDimensions: int,
+ *     similarity: 'euclidean'|'cosine'|'dotProduct',
+ *     quantization?: 'none'|'scalar'|'binary',
+ * } | array{
+ *     type: 'filter',
+ *      path: string,
+ * }
+ * @phpstan-type TypeVectorSearchIndexDefinition array{
+ *     fields: array<string, TypeVectorSearchIndexField>,
+ * }
  */
 class Blueprint extends SchemaBlueprint
 {
@@ -314,9 +383,9 @@ class Blueprint extends SchemaBlueprint
     /**
      * Create an Atlas Search Index.
      *
-     * @see https://www.mongodb.com/docs/atlas/atlas-search/
+     * @see https://www.mongodb.com/docs/manual/reference/command/createSearchIndexes/
      *
-     * @phpstan-param SearchIndexDefinition $definition
+     * @phpstan-param TypeSearchIndexDefinition $definition
      */
     public function searchIndex(array $definition, string $name = 'default'): static
     {
@@ -330,7 +399,7 @@ class Blueprint extends SchemaBlueprint
      *
      * @see https://www.mongodb.com/docs/atlas/atlas-vector-search/
      *
-     * @phpstan-param VectorSearchIndexDefinition $definition
+     * @phpstan-param TypeVectorSearchIndexDefinition $definition
      */
     public function vectorSearchIndex(array $definition, string $name = 'default'): static
     {

--- a/src/Schema/Blueprint.php
+++ b/src/Schema/Blueprint.php
@@ -16,6 +16,14 @@ use function is_int;
 use function is_string;
 use function key;
 
+/**
+ * @phpstan-type SearchIndexField array{type: 'boolean'|'date'|'dateFacet'|'objectId'|'stringFacet'|'uuid'} | array{type: 'autocomplete', analyzer?: string, maxGrams?: int, minGrams?: int, tokenization?: 'edgeGram'|'rightEdgeGram'|'nGram', foldDiacritics?: bool} | array{type: 'document'|'embeddedDocuments', dynamic?:bool, fields: array<string, array>} | array{type: 'geo', indexShapes?: bool} | array{type: 'number'|'numberFacet', representation?: 'int64'|'double', indexIntegers?: bool, indexDoubles?: bool} | array{type: 'token', normalizer?: 'lowercase'|'none'} | array{type: 'string', analyzer?: string, searchAnalyzer?: string, indexOptions?: 'docs'|'freqs'|'positions'|'offsets', store?: bool, ignoreAbove?: int, multi?: array<string, array>, norms?: 'include'|'omit'}
+ * @phpstan-type SearchIndexAnalyser array{name: string, charFilters?: list<array<string, mixed>>, tokenizer: array{type: string}, tokenFilters?: list<array<string, mixed>>}
+ * @phpstan-type SearchIndexStoredSource bool | array{includes: array<string>} | array{excludes: array<string>}
+ * @phpstan-type SearchIndexDefinition array{analyser?: string, analyzers?: SearchIndexAnalyser[], searchAnalyzer?: string, mappings: array{dynamic: true} | array{dynamic?: bool, fields: array<string, SearchIndexField>}, storedSource?: SearchIndexStoredSource}
+ * @phpstan-type VectorSearchIndexField array{type: 'vector', path: string, numDimensions: int, similarity: 'euclidean'|'cosine'|'dotProduct', quantization?: 'none'|'scalar'|'binary'}
+ * @phpstan-type VectorSearchIndexDefinition array{fields: array<string, VectorSearchIndexField>}
+ */
 class Blueprint extends SchemaBlueprint
 {
     /**
@@ -299,6 +307,34 @@ class Blueprint extends SchemaBlueprint
         $options['unique'] = true;
 
         $this->index($columns, null, null, $options);
+
+        return $this;
+    }
+
+    /**
+     * Create an Atlas Search Index.
+     *
+     * @see https://www.mongodb.com/docs/atlas/atlas-search/
+     *
+     * @phpstan-param SearchIndexDefinition $definition
+     */
+    public function searchIndex(array $definition, string $name = 'default'): static
+    {
+        $this->collection->createSearchIndex($definition, ['name' => $name, 'type' => 'search']);
+
+        return $this;
+    }
+
+    /**
+     * Create an Atlas Vector Search Index.
+     *
+     * @see https://www.mongodb.com/docs/atlas/atlas-vector-search/
+     *
+     * @phpstan-param VectorSearchIndexDefinition $definition
+     */
+    public function vectorSearchIndex(array $definition, string $name = 'default'): static
+    {
+        $this->collection->createSearchIndex($definition, ['name' => $name, 'type' => 'vectorSearch']);
 
         return $this;
     }

--- a/src/Schema/Blueprint.php
+++ b/src/Schema/Blueprint.php
@@ -16,98 +16,6 @@ use function is_int;
 use function is_string;
 use function key;
 
-/**
- * @link https://www.mongodb.com/docs/atlas/atlas-search/define-field-mappings/#std-label-fts-field-mappings
- * @phpstan-type TypeSearchIndexField array{
- *     type: 'boolean'|'date'|'dateFacet'|'objectId'|'stringFacet'|'uuid',
- * } | array{
- *     type: 'autocomplete',
- *     analyzer?: string,
- *     maxGrams?: int,
- *     minGrams?: int,
- *     tokenization?: 'edgeGram'|'rightEdgeGram'|'nGram',
- *     foldDiacritics?: bool,
- * } | array{
- *     type: 'document'|'embeddedDocuments',
- *     dynamic?:bool,
- *     fields: array<string, array<mixed>>,
- * } | array{
- *     type: 'geo',
- *     indexShapes?: bool,
- * } | array{
- *     type: 'number'|'numberFacet',
- *     representation?: 'int64'|'double',
- *     indexIntegers?: bool,
- *     indexDoubles?: bool,
- * } | array{
- *     type: 'token',
- *     normalizer?: 'lowercase'|'none',
- * } | array{
- *     type: 'string',
- *     analyzer?: string,
- *     searchAnalyzer?: string,
- *     indexOptions?: 'docs'|'freqs'|'positions'|'offsets',
- *     store?: bool,
- *     ignoreAbove?: int,
- *     multi?: array<string, array<string, mixed>>,
- *     norms?: 'include'|'omit',
- * }
- * @link https://www.mongodb.com/docs/atlas/atlas-search/analyzers/character-filters/
- * @phpstan-type TypeSearchIndexCharFilter array{
- *      type: 'icuNormalize'|'persian',
- *  } | array{
- *     type: 'htmlStrip',
- *     ignoredTags?: string[],
- * } | array{
- *     type: 'mapping',
- *     mappings?: array<string, string>,
- * }
- * @link https://www.mongodb.com/docs/atlas/atlas-search/analyzers/token-filters/
- * @phpstan-type TypeSearchIndexTokenFilter array{type: string, ...}
- * @link https://www.mongodb.com/docs/atlas/atlas-search/analyzers/custom/
- * @phpstan-type TypeSearchIndexAnalyzer array{
- *     name: string,
- *     charFilters?: TypeSearchIndexCharFilter,
- *     tokenizer: array{type: string},
- *     tokenFilters?: TypeSearchIndexTokenFilter,
- * }
- * @link https://www.mongodb.com/docs/atlas/atlas-search/stored-source-definition/#std-label-fts-stored-source-definition
- * @phpstan-type TypeSearchIndexStoredSource bool | array{
- *     includes: array<string>,
- * } | array{
- *     excludes: array<string>,
- * }
- * @link https://www.mongodb.com/docs/atlas/atlas-search/synonyms/#std-label-synonyms-ref
- * @phpstan-type TypeSearchIndexSynonyms array{
- *     analyzer: string,
- *     name: string,
- *     source?: array{collection: string},
- * }
- * @link https://www.mongodb.com/docs/manual/reference/command/createSearchIndexes/#std-label-search-index-definition-create
- * @phpstan-type TypeSearchIndexDefinition array{
- *     analyzer?: string,
- *     analyzers?: TypeSearchIndexAnalyzer[],
- *     searchAnalyzer?: string,
- *     mappings: array{dynamic: true} | array{dynamic?: bool, fields: array<string, TypeSearchIndexField|TypeSearchIndexField[]>},
- *     storedSource?: TypeSearchIndexStoredSource,
- *     synonyms?: TypeSearchIndexSynonyms[],
- * }
- * @link https://www.mongodb.com/docs/atlas/atlas-vector-search/vector-search-type/#atlas-vector-search-index-fields
- * @phpstan-type TypeVectorSearchIndexField array{
- *     type: 'vector',
- *     path: string,
- *     numDimensions: int,
- *     similarity: 'euclidean'|'cosine'|'dotProduct',
- *     quantization?: 'none'|'scalar'|'binary',
- * } | array{
- *     type: 'filter',
- *     path: string,
- * }
- * @link https://www.mongodb.com/docs/atlas/atlas-vector-search/vector-search-type/#atlas-vector-search-index-fields
- * @phpstan-type TypeVectorSearchIndexDefinition array{
- *     fields: array<string, TypeVectorSearchIndexField>,
- * }
- */
 class Blueprint extends SchemaBlueprint
 {
     /**
@@ -400,7 +308,15 @@ class Blueprint extends SchemaBlueprint
      *
      * @see https://www.mongodb.com/docs/manual/reference/command/createSearchIndexes/#std-label-search-index-definition-create
      *
-     * @phpstan-param TypeSearchIndexDefinition $definition
+     * @phpstan-param array{
+     *      analyzer?: string,
+     *      analyzers?: list<array>,
+     *      searchAnalyzer?: string,
+     *      mappings: array{dynamic: true} | array{dynamic?: bool, fields: array<string, array>},
+     *      storedSource?: bool|array,
+     *      synonyms?: list<array>,
+     *      ...
+     *  } $definition
      */
     public function searchIndex(array $definition, string $name = 'default'): static
     {
@@ -414,7 +330,7 @@ class Blueprint extends SchemaBlueprint
      *
      * @see https://www.mongodb.com/docs/manual/reference/command/createSearchIndexes/#std-label-vector-search-index-definition-create
      *
-     * @phpstan-param TypeVectorSearchIndexDefinition $definition
+     * @phpstan-param array{fields: array<string, array{type: string, ...}>} $definition
      */
     public function vectorSearchIndex(array $definition, string $name = 'default'): static
     {

--- a/src/Schema/Blueprint.php
+++ b/src/Schema/Blueprint.php
@@ -88,7 +88,7 @@ use function key;
  *     analyzer?: string,
  *     analyzers?: TypeSearchIndexAnalyzer[],
  *     searchAnalyzer?: string,
- *     mappings: array{dynamic: true} | array{dynamic?: bool, fields: array<string, TypeSearchIndexField>},
+ *     mappings: array{dynamic: true} | array{dynamic?: bool, fields: array<string, TypeSearchIndexField|TypeSearchIndexField[]>},
  *     storedSource?: TypeSearchIndexStoredSource,
  *     synonyms?: TypeSearchIndexSynonyms[],
  * }

--- a/src/Schema/Blueprint.php
+++ b/src/Schema/Blueprint.php
@@ -87,7 +87,7 @@ use function key;
  *     quantization?: 'none'|'scalar'|'binary',
  * } | array{
  *     type: 'filter',
- *      path: string,
+ *     path: string,
  * }
  * @phpstan-type TypeVectorSearchIndexDefinition array{
  *     fields: array<string, TypeVectorSearchIndexField>,

--- a/src/Schema/Blueprint.php
+++ b/src/Schema/Blueprint.php
@@ -49,7 +49,7 @@ use function key;
  *     indexOptions?: 'docs'|'freqs'|'positions'|'offsets',
  *     store?: bool,
  *     ignoreAbove?: int,
- *     multi?: array<string, array<mixed>>,
+ *     multi?: array<string, array<string, mixed>>,
  *     norms?: 'include'|'omit',
  * }
  * @link https://www.mongodb.com/docs/atlas/atlas-search/analyzers/character-filters/
@@ -77,13 +77,20 @@ use function key;
  * } | array{
  *     excludes: array<string>,
  * }
+ * @link https://www.mongodb.com/docs/atlas/atlas-search/synonyms/#std-label-synonyms-ref
+ * @phpstan-type TypeSearchIndexSynonyms array{
+ *     analyzer: string,
+ *     name: string,
+ *     source?: array{collection: string},
+ * }
  * @link https://www.mongodb.com/docs/manual/reference/command/createSearchIndexes/#std-label-search-index-definition-create
  * @phpstan-type TypeSearchIndexDefinition array{
- *     analyser?: string,
+ *     analyzer?: string,
  *     analyzers?: TypeSearchIndexAnalyzer[],
  *     searchAnalyzer?: string,
  *     mappings: array{dynamic: true} | array{dynamic?: bool, fields: array<string, TypeSearchIndexField>},
  *     storedSource?: TypeSearchIndexStoredSource,
+ *     synonyms?: TypeSearchIndexSynonyms[],
  * }
  * @link https://www.mongodb.com/docs/atlas/atlas-vector-search/vector-search-type/#atlas-vector-search-index-fields
  * @phpstan-type TypeVectorSearchIndexField array{

--- a/src/Schema/Blueprint.php
+++ b/src/Schema/Blueprint.php
@@ -17,6 +17,7 @@ use function is_string;
 use function key;
 
 /**
+ * @link https://www.mongodb.com/docs/atlas/atlas-search/define-field-mappings/#std-label-fts-field-mappings
  * @phpstan-type TypeSearchIndexField array{
  *     type: 'boolean'|'date'|'dateFacet'|'objectId'|'stringFacet'|'uuid',
  * } | array{
@@ -51,6 +52,7 @@ use function key;
  *     multi?: array<string, array<mixed>>,
  *     norms?: 'include'|'omit',
  * }
+ * @link https://www.mongodb.com/docs/atlas/atlas-search/analyzers/character-filters/
  * @phpstan-type TypeSearchIndexCharFilter array{
  *      type: 'icuNormalize'|'persian',
  *  } | array{
@@ -60,18 +62,22 @@ use function key;
  *     type: 'mapping',
  *     mappings?: array<string, string>,
  * }
+ * @link https://www.mongodb.com/docs/atlas/atlas-search/analyzers/token-filters/
  * @phpstan-type TypeSearchIndexTokenFilter array{type: string, ...}
+ * @link https://www.mongodb.com/docs/atlas/atlas-search/analyzers/custom/
  * @phpstan-type TypeSearchIndexAnalyzer array{
  *     name: string,
  *     charFilters?: TypeSearchIndexCharFilter,
  *     tokenizer: array{type: string},
  *     tokenFilters?: TypeSearchIndexTokenFilter,
  * }
+ * @link https://www.mongodb.com/docs/atlas/atlas-search/stored-source-definition/#std-label-fts-stored-source-definition
  * @phpstan-type TypeSearchIndexStoredSource bool | array{
  *     includes: array<string>,
  * } | array{
  *     excludes: array<string>,
  * }
+ * @link https://www.mongodb.com/docs/manual/reference/command/createSearchIndexes/#std-label-search-index-definition-create
  * @phpstan-type TypeSearchIndexDefinition array{
  *     analyser?: string,
  *     analyzers?: TypeSearchIndexAnalyzer[],
@@ -79,6 +85,7 @@ use function key;
  *     mappings: array{dynamic: true} | array{dynamic?: bool, fields: array<string, TypeSearchIndexField>},
  *     storedSource?: TypeSearchIndexStoredSource,
  * }
+ * @link https://www.mongodb.com/docs/atlas/atlas-vector-search/vector-search-type/#atlas-vector-search-index-fields
  * @phpstan-type TypeVectorSearchIndexField array{
  *     type: 'vector',
  *     path: string,
@@ -89,6 +96,7 @@ use function key;
  *     type: 'filter',
  *     path: string,
  * }
+ * @link https://www.mongodb.com/docs/atlas/atlas-vector-search/vector-search-type/#atlas-vector-search-index-fields
  * @phpstan-type TypeVectorSearchIndexDefinition array{
  *     fields: array<string, TypeVectorSearchIndexField>,
  * }
@@ -383,7 +391,7 @@ class Blueprint extends SchemaBlueprint
     /**
      * Create an Atlas Search Index.
      *
-     * @see https://www.mongodb.com/docs/manual/reference/command/createSearchIndexes/
+     * @see https://www.mongodb.com/docs/manual/reference/command/createSearchIndexes/#std-label-search-index-definition-create
      *
      * @phpstan-param TypeSearchIndexDefinition $definition
      */
@@ -397,7 +405,7 @@ class Blueprint extends SchemaBlueprint
     /**
      * Create an Atlas Vector Search Index.
      *
-     * @see https://www.mongodb.com/docs/atlas/atlas-vector-search/
+     * @see https://www.mongodb.com/docs/manual/reference/command/createSearchIndexes/#std-label-vector-search-index-definition-create
      *
      * @phpstan-param TypeVectorSearchIndexDefinition $definition
      */

--- a/src/Schema/Builder.php
+++ b/src/Schema/Builder.php
@@ -253,6 +253,11 @@ class Builder extends \Illuminate\Database\Schema\Builder
         try {
             $indexes = $collection->listSearchIndexes(['typeMap' => ['root' => 'array', 'array' => 'array', 'document' => 'array']]);
             foreach ($indexes as $index) {
+                // Status 'DOES_NOT_EXIST' means the index has been dropped but is still in the process of being removed
+                if ($index['status'] === 'DOES_NOT_EXIST') {
+                    continue;
+                }
+
                 $indexList[] = [
                     'name' => $index['name'],
                     'columns' => match ($index['type']) {

--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -7,6 +7,7 @@ namespace MongoDB\Laravel\Tests;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use MongoDB\BSON\Binary;
+use MongoDB\BSON\Document;
 use MongoDB\BSON\UTCDateTime;
 use MongoDB\Collection;
 use MongoDB\Laravel\Schema\Blueprint;
@@ -541,7 +542,7 @@ class SchemaTest extends TestCase
         });
 
         $index = $this->getSearchIndex('newcollection', 'default');
-        self::assertNotFalse($index);
+        self::assertNotNull($index);
 
         self::assertSame('default', $index['name']);
         self::assertSame('search', $index['type']);
@@ -562,7 +563,7 @@ class SchemaTest extends TestCase
         });
 
         $index = $this->getSearchIndex('newcollection', 'vector');
-        self::assertNotFalse($index);
+        self::assertNotNull($index);
 
         self::assertSame('vector', $index['name']);
         self::assertSame('vectorSearch', $index['type']);
@@ -583,15 +584,15 @@ class SchemaTest extends TestCase
         return false;
     }
 
-    protected function getSearchIndex(string $collection, string $name)
+    protected function getSearchIndex(string $collection, string $name): ?Document
     {
         $collection = DB::getCollection($collection);
         assert($collection instanceof Collection);
 
-        foreach ($collection->listSearchIndexes(['name' => $name]) as $index) {
+        foreach ($collection->listSearchIndexes(['name' => $name, 'typeMap' => ['root' => 'bson']]) as $index) {
             return $index;
         }
 
-        return false;
+        return null;
     }
 }

--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -525,9 +525,10 @@ class SchemaTest extends TestCase
         $this->assertSame([], $indexes);
     }
 
-    /** @todo requires SearchIndex support */
     public function testSearchIndex(): void
     {
+        $this->skipIfSearchIndexManagementIsNotSupported();
+
         Schema::create('newcollection', function (Blueprint $collection) {
             $collection->searchIndex([
                 'mappings' => [
@@ -550,6 +551,8 @@ class SchemaTest extends TestCase
 
     public function testVectorSearchIndex()
     {
+        $this->skipIfSearchIndexManagementIsNotSupported();
+
         Schema::create('newcollection', function (Blueprint $collection) {
             $collection->vectorSearchIndex([
                 'fields' => [

--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -7,9 +7,9 @@ namespace MongoDB\Laravel\Tests;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use MongoDB\BSON\Binary;
-use MongoDB\BSON\Document;
 use MongoDB\BSON\UTCDateTime;
 use MongoDB\Collection;
+use MongoDB\Database;
 use MongoDB\Laravel\Schema\Blueprint;
 
 use function assert;
@@ -20,8 +20,10 @@ class SchemaTest extends TestCase
 {
     public function tearDown(): void
     {
-        Schema::drop('newcollection');
-        Schema::drop('newcollection_two');
+        $database = $this->getConnection('mongodb')->getMongoDB();
+        assert($database instanceof Database);
+        $database->dropCollection('newcollection');
+        $database->dropCollection('newcollection_two');
     }
 
     public function testCreate(): void
@@ -477,6 +479,7 @@ class SchemaTest extends TestCase
         $this->assertSame([], $columns);
     }
 
+    /** @see AtlasSearchTest::testGetIndexes() */
     public function testGetIndexes()
     {
         Schema::create('newcollection', function (Blueprint $collection) {
@@ -584,12 +587,12 @@ class SchemaTest extends TestCase
         return false;
     }
 
-    protected function getSearchIndex(string $collection, string $name): ?Document
+    protected function getSearchIndex(string $collection, string $name): ?array
     {
         $collection = DB::getCollection($collection);
         assert($collection instanceof Collection);
 
-        foreach ($collection->listSearchIndexes(['name' => $name, 'typeMap' => ['root' => 'bson']]) as $index) {
+        foreach ($collection->listSearchIndexes(['name' => $name, 'typeMap' => ['root' => 'array', 'array' => 'array', 'document' => 'array']]) as $index) {
             return $index;
         }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -76,6 +76,8 @@ class TestCase extends OrchestraTestCase
                 case 40324:
                 // MongoDB 7: PlanExecutor error during aggregation :: caused by :: Search index commands are only supported with Atlas.
                 case 115:
+                // MongoDB 7: $listSearchIndexes stage is only allowed on MongoDB Atlas
+                case 6047401:
                 // MongoDB 8: Using Atlas Search Database Commands and the $listSearchIndexes aggregation stage requires additional configuration.
                 case 31082:
                     self::markTestSkipped('Search index management is not supported on this server');


### PR DESCRIPTION
Fix PHPORM-273

The new helpers have advanced array-shape types for the index definition. The support for autocompletion of the array-shaped arguments in PHPStorm is not good for use-case 😞 (even if [it was improved in 2022](https://blog.jetbrains.com/phpstorm/2022/02/phpstorm-2022-1-eap-3/))

### Checklist

- [x] Add tests and ensure they pass
