### PR TITLE
PHPORM-275 PHPORM-276 Add `Query\Builder::search()` and `autocomplete()`

### DIFF
--- a/src/Eloquent/Builder.php
+++ b/src/Eloquent/Builder.php
@@ -5,7 +5,10 @@ declare(strict_types=1);
 namespace MongoDB\Laravel\Eloquent;
 
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
 use MongoDB\BSON\Document;
+use MongoDB\Builder\Type\SearchOperatorInterface;
 use MongoDB\Driver\CursorInterface;
 use MongoDB\Driver\Exception\WriteException;
 use MongoDB\Laravel\Connection;
@@ -21,7 +24,10 @@ use function is_object;
 use function iterator_to_array;
 use function property_exists;
 
-/** @method \MongoDB\Laravel\Query\Builder toBase() */
+/**
+ * @method \MongoDB\Laravel\Query\Builder toBase()
+ * @template TModel of Model
+ */
 class Builder extends EloquentBuilder
 {
     private const DUPLICATE_KEY_ERROR = 11000;
@@ -70,9 +76,27 @@ class Builder extends EloquentBuilder
         return $result ?: $this;
     }
 
-    public function search(...$args)
-    {
-        $results = $this->toBase()->search(...$args);
+    /**
+     * Performs a full-text search of the field or fields in an Atlas collection.
+     *
+     * @see https://www.mongodb.com/docs/atlas/atlas-search/aggregation-stages/search/
+     *
+     * @return Collection<int, TModel>
+     */
+    public function search(
+        SearchOperatorInterface|array $operator,
+        ?string $index = null,
+        ?array $highlight = null,
+        ?bool $concurrent = null,
+        ?string $count = null,
+        ?string $searchAfter = null,
+        ?string $searchBefore = null,
+        ?bool $scoreDetails = null,
+        ?array $sort = null,
+        ?bool $returnStoredSource = null,
+        ?array $tracking = null,
+    ): Collection {
+        $results = $this->toBase()->search($operator, $index, $highlight, $concurrent, $count, $searchAfter, $searchBefore, $scoreDetails, $sort, $returnStoredSource, $tracking);
 
         return $this->model->hydrate($results->all());
     }

--- a/src/Eloquent/Builder.php
+++ b/src/Eloquent/Builder.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MongoDB\Laravel\Eloquent;
 
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Illuminate\Support\Collection;
 use MongoDB\BSON\Document;
 use MongoDB\Driver\CursorInterface;
 use MongoDB\Driver\Exception\WriteException;
@@ -16,6 +17,7 @@ use MongoDB\Model\BSONDocument;
 use function array_key_exists;
 use function array_merge;
 use function collect;
+use function compact;
 use function is_array;
 use function is_object;
 use function iterator_to_array;
@@ -67,6 +69,18 @@ class Builder extends EloquentBuilder
         $result = $this->toBase()->aggregate($function, $columns);
 
         return $result ?: $this;
+    }
+
+    public function search(...$args)
+    {
+        $results = $this->toBase()->search(...$args);
+
+        return $this->model->hydrate($results->all());
+    }
+
+    public function autocomplete(string $path, string $query, bool|array $fuzzy = false, string $tokenOrder = 'any'): Collection
+    {
+        return $this->toBase()->autocomplete(...compact('path', 'query', 'fuzzy', 'tokenOrder'));
     }
 
     /** @inheritdoc */

--- a/src/Eloquent/Builder.php
+++ b/src/Eloquent/Builder.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace MongoDB\Laravel\Eloquent;
 
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
-use Illuminate\Support\Collection;
 use MongoDB\BSON\Document;
 use MongoDB\Driver\CursorInterface;
 use MongoDB\Driver\Exception\WriteException;
@@ -17,7 +16,6 @@ use MongoDB\Model\BSONDocument;
 use function array_key_exists;
 use function array_merge;
 use function collect;
-use function compact;
 use function is_array;
 use function is_object;
 use function iterator_to_array;
@@ -51,6 +49,7 @@ class Builder extends EloquentBuilder
         'insertusing',
         'max',
         'min',
+        'autocomplete',
         'pluck',
         'pull',
         'push',
@@ -76,11 +75,6 @@ class Builder extends EloquentBuilder
         $results = $this->toBase()->search(...$args);
 
         return $this->model->hydrate($results->all());
-    }
-
-    public function autocomplete(string $path, string $query, bool|array $fuzzy = false, string $tokenOrder = 'any'): Collection
-    {
-        return $this->toBase()->autocomplete(...compact('path', 'query', 'fuzzy', 'tokenOrder'));
     }
 
     /** @inheritdoc */

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -1497,19 +1497,9 @@ class Builder extends BaseBuilder
      * Performs a full-text search of the field or fields in an Atlas collection.
      * NOTE: $search is only available for MongoDB Atlas clusters, and is not available for self-managed deployments.
      *
-     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/search/
+     * @see https://www.mongodb.com/docs/atlas/atlas-search/aggregation-stages/search/
      *
-     * @param SearchOperatorInterface|array $operator           Operator to search with.  You can provide a specific operator or use the compound operator to run a compound query with multiple operators.
-     * @param ?string                       $index              Name of the Atlas Search index to use. If omitted, defaults to "default".
-     * @param ?array                        $highlight          Specifies the highlighting options for displaying search terms in their original context.
-     * @param ?bool                         $concurrent         Parallelize search across segments on dedicated search nodes.
-     * @param ?string                       $count              Document that specifies the count options for retrieving a count of the results.
-     * @param ?string                       $searchAfter        Reference point for retrieving results. searchAfter returns documents starting immediately following the specified reference point.
-     * @param ?string                       $searchBefore       Reference point for retrieving results. searchBefore returns documents starting immediately before the specified reference point.
-     * @param ?bool                         $scoreDetails       Flag that specifies whether to retrieve a detailed breakdown of the score for the documents in the results. If omitted, defaults to false.
-     * @param ?array                        $sort               Document that specifies the fields to sort the Atlas Search results by in ascending or descending order.
-     * @param ?bool                         $returnStoredSource Flag that specifies whether to perform a full document lookup on the backend database or return only stored source fields directly from Atlas Search.
-     * @param ?array                        $tracking           Document that specifies the tracking option to retrieve analytics information on the search terms.
+     * @return Collection<object|array>
      */
     public function search(
         SearchOperatorInterface|array $operator,
@@ -1524,12 +1514,33 @@ class Builder extends BaseBuilder
         ?bool $returnStoredSource = null,
         ?array $tracking = null,
     ): Collection {
-        $args = array_filter(compact(['operator', 'index', 'highlight', 'concurrent', 'count', 'searchAfter', 'searchBefore', 'scoreDetails', 'sort', 'returnStoredSource', 'tracking']), fn ($arg) => $arg !== null);
+        // Forward named arguments to the search stage, skip null values
+        $args = array_filter([
+            'operator' => $operator,
+            'index' => $index,
+            'highlight' => $highlight,
+            'concurrent' => $concurrent,
+            'count' => $count,
+            'searchAfter' => $searchAfter,
+            'searchBefore' => $searchBefore,
+            'scoreDetails' => $scoreDetails,
+            'sort' => $sort,
+            'returnStoredSource' => $returnStoredSource,
+            'tracking' => $tracking,
+        ], fn ($arg) => $arg !== null);
 
         return $this->aggregate()->search(...$args)->get();
     }
 
-    /** @return Collection<string> */
+    /**
+     * Performs an autocomplete search of the field using an Atlas Search index.
+     * NOTE: $search is only available for MongoDB Atlas clusters, and is not available for self-managed deployments.
+     * You must create an Atlas Search index with an autocomplete configuration before you can use this stage.
+     *
+     * @see https://www.mongodb.com/docs/atlas/atlas-search/autocomplete/
+     *
+     * @return Collection<string>
+     */
     public function autocomplete(string $path, string $query, bool|array $fuzzy = false, string $tokenOrder = 'any'): Collection
     {
         $args = ['path' => $path, 'query' => $query, 'tokenOrder' => $tokenOrder];

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -1524,7 +1524,9 @@ class Builder extends BaseBuilder
         ?bool $returnStoredSource = null,
         ?array $tracking = null,
     ): Collection {
-        return $this->aggregate()->search(...array_filter(func_get_args(), fn ($arg) => $arg !== null))->get();
+        $args = array_filter(compact(['operator', 'index', 'highlight', 'concurrent', 'count', 'searchAfter', 'searchBefore', 'scoreDetails', 'sort', 'returnStoredSource', 'tracking']), fn ($arg) => $arg !== null);
+
+        return $this->aggregate()->search(...$args)->get();
     }
 
     /** @return Collection<string> */

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -24,12 +24,14 @@ use MongoDB\BSON\ObjectID;
 use MongoDB\BSON\Regex;
 use MongoDB\BSON\UTCDateTime;
 use MongoDB\Builder\Stage\FluentFactoryTrait;
+use MongoDB\Builder\Type\SearchOperatorInterface;
 use MongoDB\Driver\Cursor;
 use Override;
 use RuntimeException;
 use stdClass;
 
 use function array_fill_keys;
+use function array_filter;
 use function array_is_list;
 use function array_key_exists;
 use function array_map;
@@ -1488,6 +1490,42 @@ class Builder extends BaseBuilder
         $this->options = $options;
 
         return $this;
+    }
+
+    /**
+     * Performs a full-text search of the field or fields in an Atlas collection.
+     * NOTE: $search is only available for MongoDB Atlas clusters, and is not available for self-managed deployments.
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/search/
+     *
+     * @param SearchOperatorInterface|array $operator           Operator to search with.  You can provide a specific operator or use the compound operator to run a compound query with multiple operators.
+     * @param ?string                       $index              Name of the Atlas Search index to use. If omitted, defaults to "default".
+     * @param ?array                        $highlight          Specifies the highlighting options for displaying search terms in their original context.
+     * @param ?bool                         $concurrent         Parallelize search across segments on dedicated search nodes.
+     * @param ?string                       $count              Document that specifies the count options for retrieving a count of the results.
+     * @param ?string                       $searchAfter        Reference point for retrieving results. searchAfter returns documents starting immediately following the specified reference point.
+     * @param ?string                       $searchBefore       Reference point for retrieving results. searchBefore returns documents starting immediately before the specified reference point.
+     * @param ?bool                         $scoreDetails       Flag that specifies whether to retrieve a detailed breakdown of the score for the documents in the results. If omitted, defaults to false.
+     * @param ?array                        $sort               Document that specifies the fields to sort the Atlas Search results by in ascending or descending order.
+     * @param ?bool                         $returnStoredSource Flag that specifies whether to perform a full document lookup on the backend database or return only stored source fields directly from Atlas Search.
+     * @param ?array                        $tracking           Document that specifies the tracking option to retrieve analytics information on the search terms.
+     */
+    public function search(
+        SearchOperatorInterface|array $operator,
+        ?string $index = null,
+        ?array $highlight = null,
+        ?bool $concurrent = null,
+        ?string $count = null,
+        ?string $searchAfter = null,
+        ?string $searchBefore = null,
+        ?bool $scoreDetails = null,
+        ?array $sort = null,
+        ?bool $returnStoredSource = null,
+        ?array $tracking = null,
+    ): Collection|LazyCollection {
+        return $this->aggregate()
+            ->search(...array_filter(func_get_args(), fn ($arg) => $arg !== null))
+            ->get();
     }
 
     /**

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -42,7 +42,6 @@ use function assert;
 use function blank;
 use function call_user_func;
 use function call_user_func_array;
-use function compact;
 use function count;
 use function ctype_xdigit;
 use function date_default_timezone_get;
@@ -1531,11 +1530,11 @@ class Builder extends BaseBuilder
     /** @return Collection<string> */
     public function autocomplete(string $path, string $query, bool|array $fuzzy = false, string $tokenOrder = 'any'): Collection
     {
-        $args = compact('path', 'query', 'fuzzy', 'tokenOrder');
-        if ($args['fuzzy'] === true) {
+        $args = ['path' => $path, 'query' => $query, 'tokenOrder' => $tokenOrder];
+        if ($fuzzy === true) {
             $args['fuzzy'] = ['maxEdits' => 2];
-        } elseif ($args['fuzzy'] === false) {
-            unset($args['fuzzy']);
+        } elseif ($fuzzy !== false) {
+            $args['fuzzy'] = $fuzzy;
         }
 
         return $this->aggregate()->search(

--- a/tests/AtlasSearchTest.php
+++ b/tests/AtlasSearchTest.php
@@ -154,6 +154,24 @@ class AtlasSearchTest extends TestCase
         ], $results->pluck('title')->all());
     }
 
+    public function testEloquentBuilderWithAdvancedParameters()
+    {
+        $results = Book::search(
+            concurrent: true,
+            operator: Search::text('title', 'systems'),
+            sort: ['title' => -1],
+        );
+
+        self::assertInstanceOf(EloquentCollection::class, $results);
+        self::assertCount(3, $results);
+        self::assertInstanceOf(Book::class, $results->first());
+        self::assertSame([
+            'Operating System Concepts',
+            'Database System Concepts',
+            'Modern Operating Systems',
+        ], $results->pluck('title')->all());
+    }
+
     public function testDatabaseBuilderSearch()
     {
         $results = $this->getConnection('mongodb')->table('books')

--- a/tests/AtlasSearchTest.php
+++ b/tests/AtlasSearchTest.php
@@ -2,7 +2,8 @@
 
 namespace MongoDB\Laravel\Tests;
 
-use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Support\Collection as LaravelCollection;
 use Illuminate\Support\Facades\Schema;
 use MongoDB\Builder\Search;
 use MongoDB\Collection as MongoDBCollection;
@@ -44,8 +45,8 @@ class AtlasSearchTest extends TestCase
         ]);
 
         $collection = $this->getConnection('mongodb')->getCollection('books');
-
         assert($collection instanceof MongoDBCollection);
+
         try {
             $collection->createSearchIndex([
                 'mappings' => [
@@ -143,7 +144,7 @@ class AtlasSearchTest extends TestCase
     {
         $results = Book::search(Search::text('title', 'systems'));
 
-        self::assertInstanceOf(Collection::class, $results);
+        self::assertInstanceOf(EloquentCollection::class, $results);
         self::assertCount(3, $results);
         self::assertInstanceOf(Book::class, $results->first());
         self::assertSame([
@@ -158,7 +159,7 @@ class AtlasSearchTest extends TestCase
         $results = $this->getConnection('mongodb')->table('books')
             ->search(Search::text('title', 'systems'));
 
-        self::assertInstanceOf(\Illuminate\Support\Collection::class, $results);
+        self::assertInstanceOf(LaravelCollection::class, $results);
         self::assertCount(3, $results);
         self::assertIsArray($results->first());
         self::assertSame([
@@ -172,7 +173,7 @@ class AtlasSearchTest extends TestCase
     {
         $results = Book::autocomplete('title', 'system');
 
-        self::assertInstanceOf(\Illuminate\Support\Collection::class, $results);
+        self::assertInstanceOf(LaravelCollection::class, $results);
         self::assertCount(3, $results);
         self::assertSame([
             'Operating System Concepts',
@@ -186,7 +187,7 @@ class AtlasSearchTest extends TestCase
         $results = $this->getConnection('mongodb')->table('books')
             ->autocomplete('title', 'system');
 
-        self::assertInstanceOf(\Illuminate\Support\Collection::class, $results);
+        self::assertInstanceOf(LaravelCollection::class, $results);
         self::assertCount(3, $results);
         self::assertSame([
             'Operating System Concepts',

--- a/tests/AtlasSearchTest.php
+++ b/tests/AtlasSearchTest.php
@@ -54,6 +54,7 @@ class AtlasSearchTest extends TestCase
                         'title' => [
                             ['type' => 'string', 'analyzer' => 'lucene.english'],
                             ['type' => 'autocomplete', 'analyzer' => 'lucene.english'],
+                            ['type' => 'token'],
                         ],
                     ],
                 ],
@@ -142,48 +143,33 @@ class AtlasSearchTest extends TestCase
 
     public function testEloquentBuilderSearch()
     {
-        $results = Book::search(Search::text('title', 'systems'));
-
-        self::assertInstanceOf(EloquentCollection::class, $results);
-        self::assertCount(3, $results);
-        self::assertInstanceOf(Book::class, $results->first());
-        self::assertSame([
-            'Operating System Concepts',
-            'Database System Concepts',
-            'Modern Operating Systems',
-        ], $results->pluck('title')->all());
-    }
-
-    public function testEloquentBuilderWithAdvancedParameters()
-    {
         $results = Book::search(
-            concurrent: true,
+            sort: ['title' => 1],
             operator: Search::text('title', 'systems'),
-            sort: ['title' => -1],
         );
 
         self::assertInstanceOf(EloquentCollection::class, $results);
         self::assertCount(3, $results);
         self::assertInstanceOf(Book::class, $results->first());
         self::assertSame([
-            'Operating System Concepts',
             'Database System Concepts',
             'Modern Operating Systems',
+            'Operating System Concepts',
         ], $results->pluck('title')->all());
     }
 
     public function testDatabaseBuilderSearch()
     {
         $results = $this->getConnection('mongodb')->table('books')
-            ->search(Search::text('title', 'systems'));
+            ->search(Search::text('title', 'systems'), sort: ['title' => 1]);
 
         self::assertInstanceOf(LaravelCollection::class, $results);
         self::assertCount(3, $results);
         self::assertIsArray($results->first());
         self::assertSame([
-            'Operating System Concepts',
             'Database System Concepts',
             'Modern Operating Systems',
+            'Operating System Concepts',
         ], $results->pluck('title')->all());
     }
 


### PR DESCRIPTION
Fix PHPORM-275 and PHPORM-276


### Checklist

- [x] Add tests and ensure they pass
- [x] `Model::search()` returns a collection of model instances
- [x] Rebase on https://github.com/mongodb/laravel-mongodb/pull/3233
