### PR TITLE
PHPORM-274 List search indexes in `Schema::getIndexes()` introspection method

### DIFF
--- a/src/Schema/Builder.php
+++ b/src/Schema/Builder.php
@@ -15,6 +15,7 @@ use function array_fill_keys;
 use function array_filter;
 use function array_keys;
 use function array_map;
+use function array_merge;
 use function assert;
 use function count;
 use function current;
@@ -243,7 +244,7 @@ class Builder extends \Illuminate\Database\Schema\Builder
                     $index->isText() => 'text',
                     $index->is2dSphere() => '2dsphere',
                     $index->isTtl() => 'ttl',
-                    default => 'default',
+                    default => null,
                 },
                 'unique' => $index->isUnique(),
             ];
@@ -255,7 +256,10 @@ class Builder extends \Illuminate\Database\Schema\Builder
                 $indexList[] = [
                     'name' => $index['name'],
                     'columns' => match ($index['type']) {
-                        'search' => array_keys($index['latestDefinition']['mappings']['fields'] ?? []),
+                        'search' => array_merge(
+                            $index['latestDefinition']['mappings']['dynamic'] ? ['dynamic'] : [],
+                            array_keys($index['latestDefinition']['mappings']['fields'] ?? []),
+                        ),
                         'vectorSearch' => array_column($index['latestDefinition']['fields'], 'path'),
                     },
                     'type' => $index['type'],

--- a/src/Schema/Builder.php
+++ b/src/Schema/Builder.php
@@ -319,6 +319,12 @@ class Builder extends \Illuminate\Database\Schema\Builder
     /** @internal */
     public static function isAtlasSearchNotSupportedException(ServerException $e): bool
     {
-        return in_array($e->getCode(), [59, 40324, 115, 6047401, 31082], true);
+        return in_array($e->getCode(), [
+            59,      // MongoDB 4 to 6, 7-community: no such command: 'createSearchIndexes'
+            40324,   // MongoDB 4 to 6: Unrecognized pipeline stage name: '$listSearchIndexes'
+            115,     // MongoDB 7-ent: Search index commands are only supported with Atlas.
+            6047401, // MongoDB 7: $listSearchIndexes stage is only allowed on MongoDB Atlas
+            31082,   // MongoDB 8: Using Atlas Search Database Commands and the $listSearchIndexes aggregation stage requires additional configuration.
+        ], true);
     }
 }

--- a/tests/AtlasSearchTest.php
+++ b/tests/AtlasSearchTest.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace MongoDB\Laravel\Tests;
+
+use Illuminate\Support\Facades\Schema;
+use MongoDB\Collection as MongoDBCollection;
+use MongoDB\Driver\Exception\ServerException;
+use MongoDB\Laravel\Schema\Builder;
+use MongoDB\Laravel\Tests\Models\Book;
+
+use function assert;
+use function usleep;
+
+class AtlasSearchTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Book::insert([
+            ['title' => 'Introduction to Algorithms'],
+            ['title' => 'Clean Code: A Handbook of Agile Software Craftsmanship'],
+            ['title' => 'Design Patterns: Elements of Reusable Object-Oriented Software'],
+            ['title' => 'The Pragmatic Programmer: Your Journey to Mastery'],
+            ['title' => 'Artificial Intelligence: A Modern Approach'],
+            ['title' => 'Structure and Interpretation of Computer Programs'],
+            ['title' => 'Code Complete: A Practical Handbook of Software Construction'],
+            ['title' => 'The Art of Computer Programming'],
+            ['title' => 'Computer Networks'],
+            ['title' => 'Operating System Concepts'],
+            ['title' => 'Database System Concepts'],
+            ['title' => 'Compilers: Principles, Techniques, and Tools'],
+            ['title' => 'Introduction to the Theory of Computation'],
+            ['title' => 'Modern Operating Systems'],
+            ['title' => 'Computer Organization and Design'],
+            ['title' => 'The Mythical Man-Month: Essays on Software Engineering'],
+            ['title' => 'Algorithms'],
+            ['title' => 'Understanding Machine Learning: From Theory to Algorithms'],
+            ['title' => 'Deep Learning'],
+            ['title' => 'Pattern Recognition and Machine Learning'],
+        ]);
+
+        $collection = $this->getConnection('mongodb')->getCollection('books');
+        assert($collection instanceof MongoDBCollection);
+        try {
+            $collection->createSearchIndex([
+                'mappings' => [
+                    'fields' => [
+                        'title' => [
+                            ['type' => 'string', 'analyzer' => 'lucene.english'],
+                            ['type' => 'autocomplete', 'analyzer' => 'lucene.english'],
+                        ],
+                    ],
+                ],
+            ]);
+
+            $collection->createSearchIndex([
+                'fields' => [
+                    ['type' => 'vector', 'numDimensions' => 16, 'path' => 'vector16', 'similarity' => 'cosine'],
+                    ['type' => 'vector', 'numDimensions' => 32, 'path' => 'vector32', 'similarity' => 'euclidean'],
+                ],
+            ], ['name' => 'vector', 'type' => 'vectorSearch']);
+        } catch (ServerException $e) {
+            if (Builder::isAtlasSearchNotSupportedException($e)) {
+                self::markTestSkipped('Atlas Search not supported. ' . $e->getMessage());
+            }
+
+            throw $e;
+        }
+
+        // Wait for the index to be ready
+        do {
+            $ready = true;
+            usleep(10_000);
+            foreach ($collection->listSearchIndexes() as $index) {
+                if ($index['status'] !== 'READY') {
+                    $ready = false;
+                }
+            }
+        } while (! $ready);
+    }
+
+    public function tearDown(): void
+    {
+        $this->getConnection('mongodb')->getCollection('books')->drop();
+
+        parent::tearDown();
+    }
+
+    public function testGetIndexes()
+    {
+        $indexes = Schema::getIndexes('books');
+
+        self::assertCount(3, $indexes);
+
+        $expected = [
+            [
+                'name' => '_id_',
+                'columns' => ['_id'],
+                'primary' => true,
+                'type' => 'default',
+                'unique' => false,
+            ],
+            [
+                'name' => 'default',
+                'columns' => ['title'],
+                'type' => 'search',
+                'primary' => false,
+                'unique' => false,
+            ],
+            [
+                'name' => 'vector',
+                'columns' => ['vector16', 'vector32'],
+                'type' => 'vectorSearch',
+                'primary' => false,
+                'unique' => false,
+            ],
+        ];
+
+        self::assertSame($expected, $indexes);
+    }
+}

--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -482,20 +482,41 @@ class SchemaTest extends TestCase
             $collection->string('mykey3')->index();
         });
         $indexes = Schema::getIndexes('newcollection');
-        $this->assertIsArray($indexes);
-        $this->assertCount(4, $indexes);
+        self::assertIsArray($indexes);
+        self::assertCount(4, $indexes);
 
-        $indexes = collect($indexes)->keyBy('name');
+        $expected = [
+            [
+                'name' => '_id_',
+                'columns' => ['_id'],
+                'primary' => true,
+                'type' => null,
+                'unique' => false,
+            ],
+            [
+                'name' => 'mykey1_1',
+                'columns' => ['mykey1'],
+                'primary' => false,
+                'type' => null,
+                'unique' => false,
+            ],
+            [
+                'name' => 'unique_index_1',
+                'columns' => ['unique_index'],
+                'primary' => false,
+                'type' => null,
+                'unique' => true,
+            ],
+            [
+                'name' => 'mykey3_1',
+                'columns' => ['mykey3'],
+                'primary' => false,
+                'type' => null,
+                'unique' => false,
+            ],
+        ];
 
-        $indexes->each(function ($index) {
-            $this->assertIsString($index['name']);
-            $this->assertIsString($index['type']);
-            $this->assertIsArray($index['columns']);
-            $this->assertIsBool($index['unique']);
-            $this->assertIsBool($index['primary']);
-        });
-        $this->assertTrue($indexes->get('_id_')['primary']);
-        $this->assertTrue($indexes->get('unique_index_1')['unique']);
+        self::assertSame($expected, $indexes);
 
         // Non-existent collection
         $indexes = Schema::getIndexes('missing');


### PR DESCRIPTION
Fix PHPORM-274

Search indexes are a distinct type of index that are exposed using a specific method. Listing the search indexes in `Schema::getIndexes()` so they are listed by the command `php artisan db:table`.
