### PR TITLE
PHPORM-283 Add `Schema::dropSearchIndex()`

### DIFF
--- a/src/Schema/Blueprint.php
+++ b/src/Schema/Blueprint.php
@@ -342,7 +342,7 @@ class Blueprint extends SchemaBlueprint
     /**
      * Drop an Atlas Search or Vector Search index
      */
-    public function dropSearchIndex(string $name = 'default'): static
+    public function dropSearchIndex(string $name): static
     {
         $this->collection->dropSearchIndex($name);
 

--- a/src/Schema/Blueprint.php
+++ b/src/Schema/Blueprint.php
@@ -340,6 +340,16 @@ class Blueprint extends SchemaBlueprint
     }
 
     /**
+     * Drop an Atlas Search or Vector Search index
+     */
+    public function dropSearchIndex(string $name = 'default'): static
+    {
+        $this->collection->dropSearchIndex($name);
+
+        return $this;
+    }
+
+    /**
      * Allow fluent columns.
      *
      * @param string|array $columns

--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -540,9 +540,8 @@ class SchemaTest extends TestCase
         self::assertFalse($index['latestDefinition']['mappings']['dynamic']);
         self::assertSame('lucene.whitespace', $index['latestDefinition']['mappings']['fields']['foo']['analyzer']);
 
-        // Drop the index using default name
         Schema::table('newcollection', function (Blueprint $collection) {
-            $collection->dropSearchIndex();
+            $collection->dropSearchIndex('default');
         });
 
         $index = $this->getSearchIndex('newcollection', 'default');

--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -539,6 +539,14 @@ class SchemaTest extends TestCase
         self::assertSame('search', $index['type']);
         self::assertFalse($index['latestDefinition']['mappings']['dynamic']);
         self::assertSame('lucene.whitespace', $index['latestDefinition']['mappings']['fields']['foo']['analyzer']);
+
+        // Drop the index using default name
+        Schema::table('newcollection', function (Blueprint $collection) {
+            $collection->dropSearchIndex();
+        });
+
+        $index = $this->getSearchIndex('newcollection', 'default');
+        self::assertNull($index);
     }
 
     public function testVectorSearchIndex()
@@ -559,6 +567,14 @@ class SchemaTest extends TestCase
         self::assertSame('vector', $index['name']);
         self::assertSame('vectorSearch', $index['type']);
         self::assertSame('vector', $index['latestDefinition']['fields'][0]['type']);
+
+        // Drop the index
+        Schema::table('newcollection', function (Blueprint $collection) {
+            $collection->dropSearchIndex('vector');
+        });
+
+        $index = $this->getSearchIndex('newcollection', 'vector');
+        self::assertNull($index);
     }
 
     protected function assertIndexExists(string $collection, string $name): IndexInfo


### PR DESCRIPTION
Fix PHPORM-283

Same helper for both "search" and "vector search" indexes.

### Checklist

- [x] Add tests and ensure they pass
