### PR TITLE
PHPORM-209 Add query builder helper to set read preference

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -103,7 +103,7 @@ class Builder extends BaseBuilder
     /**
      * The maximum amount of seconds to allow the query to run.
      *
-     * @var int
+     * @var int|float
      */
     public $timeout;
 
@@ -214,7 +214,7 @@ class Builder extends BaseBuilder
     /**
      * The maximum amount of seconds to allow the query to run.
      *
-     * @param  int $seconds
+     * @param  int|float $seconds
      *
      * @return $this
      */
@@ -457,7 +457,7 @@ class Builder extends BaseBuilder
 
         // Apply order, offset, limit and projection
         if ($this->timeout) {
-            $options['maxTimeMS'] = $this->timeout * 1000;
+            $options['maxTimeMS'] = (int) ($this->timeout * 1000);
         }
 
         if ($this->orders) {
@@ -1551,13 +1551,6 @@ class Builder extends BaseBuilder
     public function readPreference(string $mode, ?array $tagSets = null, ?array $options = null): static
     {
         $this->readPreference = new ReadPreference($mode, $tagSets, $options);
-
-        return $this;
-    }
-
-    public function typeMap(array $typeMap): static
-    {
-        $this->options['typeMap'] = $typeMap;
 
         return $this;
     }

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -28,6 +28,7 @@ use MongoDB\Builder\Stage\FluentFactoryTrait;
 use MongoDB\Builder\Type\QueryInterface;
 use MongoDB\Builder\Type\SearchOperatorInterface;
 use MongoDB\Driver\Cursor;
+use MongoDB\Driver\ReadPreference;
 use Override;
 use RuntimeException;
 use stdClass;
@@ -112,6 +113,8 @@ class Builder extends BaseBuilder
      * @var int
      */
     public $hint;
+
+    private ReadPreference $readPreference;
 
     /**
      * Custom options to add to the query.
@@ -1535,6 +1538,31 @@ class Builder extends BaseBuilder
     }
 
     /**
+     * Set the read preference for the query
+     *
+     * @see https://www.php.net/manual/en/class.mongodb-driver-readpreference.php
+     *
+     * @param  string $mode
+     * @param  array  $tagSets
+     * @param  array  $options
+     *
+     * @return $this
+     */
+    public function readPreference(string $mode, ?array $tagSets = null, ?array $options = null): static
+    {
+        $this->readPreference = new ReadPreference($mode, $tagSets, $options);
+
+        return $this;
+    }
+
+    public function typeMap(array $typeMap): static
+    {
+        $this->options['typeMap'] = $typeMap;
+
+        return $this;
+    }
+
+    /**
      * Performs a full-text search of the field or fields in an Atlas collection.
      * NOTE: $search is only available for MongoDB Atlas clusters, and is not available for self-managed deployments.
      *
@@ -1640,6 +1668,10 @@ class Builder extends BaseBuilder
             if ($session) {
                 $options['session'] = $session;
             }
+        }
+
+        if (! isset($options['readPreference']) && isset($this->readPreference)) {
+            $options['readPreference'] = $this->readPreference;
         }
 
         return $options;

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -15,6 +15,7 @@ use LogicException;
 use Mockery as m;
 use MongoDB\BSON\Regex;
 use MongoDB\BSON\UTCDateTime;
+use MongoDB\Driver\ReadPreference;
 use MongoDB\Laravel\Connection;
 use MongoDB\Laravel\Query\Builder;
 use MongoDB\Laravel\Query\Grammar;
@@ -1415,6 +1416,26 @@ class BuilderTest extends TestCase
         yield 'arrow notation with id' => [
             ['find' => [['embedded._id' => 1], []]],
             fn (Builder $builder) => $builder->where('embedded->id', 1),
+        ];
+
+        yield 'options' => [
+            ['find' => [[], ['comment' => 'hello']]],
+            fn (Builder $builder) => $builder->options(['comment' => 'hello']),
+        ];
+
+        yield 'readPreference' => [
+            ['find' => [[], ['readPreference' => new ReadPreference(ReadPreference::SECONDARY_PREFERRED)]]],
+            fn (Builder $builder) => $builder->readPreference(ReadPreference::SECONDARY_PREFERRED),
+        ];
+
+        yield 'readPreference advanced' => [
+            ['find' => [[], ['readPreference' => new ReadPreference(ReadPreference::NEAREST, [['dc' => 'ny']], ['maxStalenessSeconds' => 120])]]],
+            fn (Builder $builder) => $builder->readPreference(ReadPreference::NEAREST, [['dc' => 'ny']], ['maxStalenessSeconds' => 120]),
+        ];
+
+        yield 'hint' => [
+            ['find' => [[], ['hint' => ['foo' => 1]]]],
+            fn (Builder $builder) => $builder->hint(['foo' => 1]),
         ];
     }
 

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -1437,6 +1437,11 @@ class BuilderTest extends TestCase
             ['find' => [[], ['hint' => ['foo' => 1]]]],
             fn (Builder $builder) => $builder->hint(['foo' => 1]),
         ];
+
+        yield 'timeout' => [
+            ['find' => [[], ['maxTimeMS' => 2345]]],
+            fn (Builder $builder) => $builder->timeout(2.3456),
+        ];
     }
 
     #[DataProvider('provideExceptions')]


### PR DESCRIPTION
Fix PHPORM-209

- Add a new method `Query\Builder::readPreference()` to set the read preference option for find and aggregate. 
- Add tests to the timeout option, to accept decimal number of seconds

### Checklist

- [x] Add tests and ensure they pass
