### PR TITLE
PHPORM-287 Split Atlas Search CI workflow

### DIFF
--- a/.github/workflows/build-ci-atlas.yml
+++ b/.github/workflows/build-ci-atlas.yml
@@ -1,0 +1,74 @@
+name: "Atlas CI"
+
+on:
+    push:
+    pull_request:
+
+jobs:
+    build:
+        runs-on: "${{ matrix.os }}"
+
+        name: "PHP ${{ matrix.php }} Laravel ${{ matrix.laravel }} Atlas"
+
+        strategy:
+            matrix:
+                os:
+                    - "ubuntu-latest"
+                php:
+                    - "8.2"
+                    - "8.3"
+                    - "8.4"
+                laravel:
+                    - "11.*"
+
+        steps:
+            -   uses: "actions/checkout@v4"
+
+            -   name: "Create MongoDB Atlas Local"
+                run: |
+                    docker run --name mongodb -p 27017:27017 --detach mongodb/mongodb-atlas-local:latest
+                    until docker exec --tty mongodb mongosh --eval "db.runCommand({ ping: 1 })"; do
+                      sleep 1
+                    done
+                    until docker exec --tty mongodb mongosh --eval "db.createCollection('connection_test') && db.getCollection('connection_test').createSearchIndex({mappings:{dynamic: true}})"; do
+                      sleep 1
+                    done
+
+            -   name: "Show MongoDB server status"
+                run: |
+                    docker exec --tty mongodb mongosh --eval "db.runCommand({ serverStatus: 1 })"
+
+            -   name: "Installing php"
+                uses: "shivammathur/setup-php@v2"
+                with:
+                    php-version: ${{ matrix.php }}
+                    extensions: "curl,mbstring,xdebug"
+                    coverage: "xdebug"
+                    tools: "composer"
+
+            -   name: "Show Docker version"
+                if: ${{ runner.debug }}
+                run: "docker version && env"
+
+            -   name: "Restrict Laravel version"
+                run: "composer require --dev --no-update 'laravel/framework:${{ matrix.laravel }}'"
+
+            -   name: "Download Composer cache dependencies from cache"
+                id: "composer-cache"
+                run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+            -   name: "Cache Composer dependencies"
+                uses: "actions/cache@v4"
+                with:
+                    path: ${{ steps.composer-cache.outputs.dir }}
+                    key: "${{ matrix.os }}-composer-${{ hashFiles('**/composer.json') }}"
+                    restore-keys: "${{ matrix.os }}-composer-"
+
+            -   name: "Install dependencies"
+                run: |
+                  composer update --no-interaction
+
+            -   name: "Run tests"
+                run: |
+                  export MONGODB_URI="mongodb://127.0.0.1:27017/?directConnection=true"
+                  ./vendor/bin/phpunit --coverage-clover coverage.xml --group atlas-search

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -11,8 +11,6 @@ jobs:
         name: "PHP ${{ matrix.php }} Laravel ${{ matrix.laravel }} MongoDB ${{ matrix.mongodb }} ${{ matrix.mode }}"
 
         strategy:
-            # Tests with Atlas fail randomly
-            fail-fast: false
             matrix:
                 os:
                     - "ubuntu-latest"
@@ -21,11 +19,12 @@ jobs:
                     - "5.0"
                     - "6.0"
                     - "7.0"
-                    - "Atlas"
+                    - "8.0"
                 php:
                     - "8.1"
                     - "8.2"
                     - "8.3"
+                    - "8.4"
                 laravel:
                     - "10.*"
                     - "11.*"
@@ -38,7 +37,6 @@ jobs:
                     - php: "8.4"
                       laravel: "11.*"
                       mongodb: "7.0"
-                      mode: "ignore-php-req"
                       os: "ubuntu-latest"
                 exclude:
                     - php: "8.1"
@@ -48,31 +46,19 @@ jobs:
             -   uses: "actions/checkout@v4"
 
             -   name: "Create MongoDB Replica Set"
-                if: ${{ matrix.mongodb != 'Atlas' }}
                 run: |
                     docker run --name mongodb -p 27017:27017 -e MONGO_INITDB_DATABASE=unittest --detach mongo:${{ matrix.mongodb }} mongod --replSet rs --setParameter transactionLifetimeLimitSeconds=5
 
                     if [ "${{ matrix.mongodb }}" = "4.4" ]; then MONGOSH_BIN="mongo"; else MONGOSH_BIN="mongosh"; fi
-                    until docker exec --tty mongodb $MONGOSH_BIN 127.0.0.1:27017 --eval "db.runCommand({ ping: 1 })"; do
+                    until docker exec --tty mongodb $MONGOSH_BIN --eval "db.runCommand({ ping: 1 })"; do
                       sleep 1
                     done
-                    sudo docker exec --tty mongodb $MONGOSH_BIN 127.0.0.1:27017 --eval "rs.initiate({\"_id\":\"rs\",\"members\":[{\"_id\":0,\"host\":\"127.0.0.1:27017\" }]})"
-
-            -   name: "Create MongoDB Atlas Local"
-                if: ${{ matrix.mongodb == 'Atlas' }}
-                run: |
-                    docker run --name mongodb -p 27017:27017 --detach mongodb/mongodb-atlas-local:latest
-                    until docker exec --tty mongodb mongosh 127.0.0.1:27017 --eval "db.runCommand({ ping: 1 })"; do
-                      sleep 1
-                    done
-                    until docker exec --tty mongodb mongosh 127.0.0.1:27017 --eval "db.createCollection('connection_test') && db.getCollection('connection_test').createSearchIndex({mappings:{dynamic: true}})"; do
-                      sleep 1
-                    done
+                    sudo docker exec --tty mongodb $MONGOSH_BIN --eval "rs.initiate({\"_id\":\"rs\",\"members\":[{\"_id\":0,\"host\":\"127.0.0.1:27017\" }]})"
 
             -   name: "Show MongoDB server status"
                 run: |
                     if [ "${{ matrix.mongodb }}" = "4.4" ]; then MONGOSH_BIN="mongo"; else MONGOSH_BIN="mongosh"; fi
-                    docker exec --tty mongodb $MONGOSH_BIN 127.0.0.1:27017 --eval "db.runCommand({ serverStatus: 1 })"
+                    docker exec --tty mongodb $MONGOSH_BIN --eval "db.runCommand({ serverStatus: 1 })"
 
             -   name: "Installing php"
                 uses: "shivammathur/setup-php@v2"
@@ -107,9 +93,5 @@ jobs:
                     $([[ "${{ matrix.mode }}" == ignore-php-req ]] && echo ' --ignore-platform-req=php+')
             -   name: "Run tests"
                 run: |
-                  if [ "${{ matrix.mongodb }}" = "Atlas" ]; then
-                    export MONGODB_URI="mongodb://127.0.0.1:27017/"
-                  else
-                    export MONGODB_URI="mongodb://127.0.0.1:27017/?replicaSet=rs"
-                  fi
-                  ./vendor/bin/phpunit --coverage-clover coverage.xml
+                  export MONGODB_URI="mongodb://127.0.0.1:27017/?replicaSet=rs"
+                  ./vendor/bin/phpunit --coverage-clover coverage.xml --exclude-group atlas-search

--- a/tests/AtlasSearchTest.php
+++ b/tests/AtlasSearchTest.php
@@ -11,6 +11,7 @@ use MongoDB\Collection as MongoDBCollection;
 use MongoDB\Driver\Exception\ServerException;
 use MongoDB\Laravel\Schema\Builder;
 use MongoDB\Laravel\Tests\Models\Book;
+use PHPUnit\Framework\Attributes\Group;
 
 use function array_map;
 use function assert;
@@ -21,6 +22,7 @@ use function srand;
 use function usleep;
 use function usort;
 
+#[Group('atlas-search')]
 class AtlasSearchTest extends TestCase
 {
     private array $vectors;

--- a/tests/Scout/ScoutIntegrationTest.php
+++ b/tests/Scout/ScoutIntegrationTest.php
@@ -12,6 +12,7 @@ use MongoDB\Laravel\Tests\Scout\Models\SearchableInSameNamespace;
 use MongoDB\Laravel\Tests\TestCase;
 use Override;
 use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\Group;
 
 use function array_merge;
 use function count;
@@ -21,6 +22,7 @@ use function range;
 use function sprintf;
 use function usleep;
 
+#[Group('atlas-search')]
 class ScoutIntegrationTest extends TestCase
 {
     #[Override]


### PR DESCRIPTION
Fix PHPORM-287

- Split Atlas-search tests into a distinct workflow
- Create PHPUnit group for tests using Atlas Search
- Remove host:port when connecting to localhost witch mongosh
