### PR TITLE
Add template types to relation classes.

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -12,12 +12,17 @@ parameters:
 
 		-
 			message: "#^Method Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:push\\(\\) invoked with 3 parameters, 0 required\\.$#"
-			count: 3
+			count: 2
 			path: src/Relations/BelongsToMany.php
 
 		-
+			message: "#^Call to an undefined method MongoDB\\\\Laravel\\\\Relations\\\\EmbedsMany\\<TRelatedModel of MongoDB\\\\Laravel\\\\Eloquent\\\\Model, TDeclaringModel of MongoDB\\\\Laravel\\\\Eloquent\\\\Model, TResult\\>\\:\\:contains\\(\\)\\.$#"
+			count: 1
+			path: src/Relations/EmbedsMany.php
+
+		-
 			message: "#^Method Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:push\\(\\) invoked with 3 parameters, 0 required\\.$#"
-			count: 6
+			count: 2
 			path: src/Relations/MorphToMany.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11,18 +11,43 @@ parameters:
 			path: src/MongoDBServiceProvider.php
 
 		-
-			message: "#^Method Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:push\\(\\) invoked with 3 parameters, 0 required\\.$#"
-			count: 2
+			message: "#^Call to an undefined method TDeclaringModel of Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:pull\\(\\)\\.$#"
+			count: 1
 			path: src/Relations/BelongsToMany.php
 
 		-
-			message: "#^Call to an undefined method MongoDB\\\\Laravel\\\\Relations\\\\EmbedsMany\\<TRelatedModel of MongoDB\\\\Laravel\\\\Eloquent\\\\Model, TDeclaringModel of MongoDB\\\\Laravel\\\\Eloquent\\\\Model, TResult\\>\\:\\:contains\\(\\)\\.$#"
+			message: "#^Method Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:push\\(\\) invoked with 3 parameters, 0 required\\.$#"
+			count: 3
+			path: src/Relations/BelongsToMany.php
+
+		-
+			message: "#^Call to an undefined method MongoDB\\\\Laravel\\\\Relations\\\\EmbedsMany\\<TRelatedModel of Illuminate\\\\Database\\\\Eloquent\\\\Model, TDeclaringModel of Illuminate\\\\Database\\\\Eloquent\\\\Model, TResult\\>\\:\\:contains\\(\\)\\.$#"
 			count: 1
 			path: src/Relations/EmbedsMany.php
 
 		-
-			message: "#^Method Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:push\\(\\) invoked with 3 parameters, 0 required\\.$#"
+			message: "#^Call to an undefined method TDeclaringModel of Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:getParentRelation\\(\\)\\.$#"
+			count: 1
+			path: src/Relations/EmbedsOneOrMany.php
+
+		-
+			message: "#^Call to an undefined method TDeclaringModel of Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:setParentRelation\\(\\)\\.$#"
+			count: 1
+			path: src/Relations/EmbedsOneOrMany.php
+
+		-
+			message: "#^Call to an undefined method TRelatedModel of Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:setParentRelation\\(\\)\\.$#"
 			count: 2
+			path: src/Relations/EmbedsOneOrMany.php
+
+		-
+			message: "#^Call to an undefined method TDeclaringModel of Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:pull\\(\\)\\.$#"
+			count: 2
+			path: src/Relations/MorphToMany.php
+
+		-
+			message: "#^Method Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:push\\(\\) invoked with 3 parameters, 0 required\\.$#"
+			count: 6
 			path: src/Relations/MorphToMany.php
 
 		-

--- a/src/Relations/BelongsTo.php
+++ b/src/Relations/BelongsTo.php
@@ -8,8 +8,8 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 
 /**
- * @template TRelatedModel of \MongoDB\Laravel\Eloquent\Model
- * @template TDeclaringModel of \MongoDB\Laravel\Eloquent\Model
+ * @template TRelatedModel of Model
+ * @template TDeclaringModel of Model
  * @extends \Illuminate\Database\Eloquent\Relations\BelongsTo<TRelatedModel, TDeclaringModel>
  */
 class BelongsTo extends \Illuminate\Database\Eloquent\Relations\BelongsTo

--- a/src/Relations/BelongsTo.php
+++ b/src/Relations/BelongsTo.php
@@ -7,6 +7,11 @@ namespace MongoDB\Laravel\Relations;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 
+/**
+ * @template TRelatedModel of \MongoDB\Laravel\Eloquent\Model
+ * @template TDeclaringModel of \MongoDB\Laravel\Eloquent\Model
+ * @extends \Illuminate\Database\Eloquent\Relations\BelongsTo<TRelatedModel, TDeclaringModel>
+ */
 class BelongsTo extends \Illuminate\Database\Eloquent\Relations\BelongsTo
 {
     /**

--- a/src/Relations/BelongsTo.php
+++ b/src/Relations/BelongsTo.php
@@ -6,13 +6,14 @@ namespace MongoDB\Laravel\Relations;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo as EloquentBelongsTo;
 
 /**
  * @template TRelatedModel of Model
  * @template TDeclaringModel of Model
- * @extends \Illuminate\Database\Eloquent\Relations\BelongsTo<TRelatedModel, TDeclaringModel>
+ * @extends EloquentBelongsTo<TRelatedModel, TDeclaringModel>
  */
-class BelongsTo extends \Illuminate\Database\Eloquent\Relations\BelongsTo
+class BelongsTo extends EloquentBelongsTo
 {
     /**
      * Get the key for comparing against the parent key in "has" query.

--- a/src/Relations/BelongsToMany.php
+++ b/src/Relations/BelongsToMany.php
@@ -22,8 +22,8 @@ use function in_array;
 use function is_numeric;
 
 /**
- * @template TRelatedModel of \MongoDB\Laravel\Eloquent\Model
- * @template TDeclaringModel of \MongoDB\Laravel\Eloquent\Model
+ * @template TRelatedModel of Model
+ * @template TDeclaringModel of Model
  * @extends EloquentBelongsToMany<TRelatedModel, TDeclaringModel>
  */
 class BelongsToMany extends EloquentBelongsToMany

--- a/src/Relations/BelongsToMany.php
+++ b/src/Relations/BelongsToMany.php
@@ -21,6 +21,11 @@ use function count;
 use function in_array;
 use function is_numeric;
 
+/**
+ * @template TRelatedModel of \MongoDB\Laravel\Eloquent\Model
+ * @template TDeclaringModel of \MongoDB\Laravel\Eloquent\Model
+ * @extends EloquentBelongsToMany<TRelatedModel, TDeclaringModel>
+ */
 class BelongsToMany extends EloquentBelongsToMany
 {
     /**

--- a/src/Relations/EmbedsMany.php
+++ b/src/Relations/EmbedsMany.php
@@ -21,6 +21,12 @@ use function method_exists;
 use function throw_if;
 use function value;
 
+/**
+ * @template TRelatedModel of \MongoDB\Laravel\Eloquent\Model
+ * @template TDeclaringModel of \MongoDB\Laravel\Eloquent\Model
+ * @template TResult
+ * @extends EmbedsOneOrMany<TRelatedModel, TDeclaringModel, TResult>
+ */
 class EmbedsMany extends EmbedsOneOrMany
 {
     /** @inheritdoc */

--- a/src/Relations/EmbedsMany.php
+++ b/src/Relations/EmbedsMany.php
@@ -22,8 +22,8 @@ use function throw_if;
 use function value;
 
 /**
- * @template TRelatedModel of \MongoDB\Laravel\Eloquent\Model
- * @template TDeclaringModel of \MongoDB\Laravel\Eloquent\Model
+ * @template TRelatedModel of Model
+ * @template TDeclaringModel of Model
  * @template TResult
  * @extends EmbedsOneOrMany<TRelatedModel, TDeclaringModel, TResult>
  */

--- a/src/Relations/EmbedsOne.php
+++ b/src/Relations/EmbedsOne.php
@@ -12,8 +12,8 @@ use Throwable;
 use function throw_if;
 
 /**
- * @template TRelatedModel of \MongoDB\Laravel\Eloquent\Model
- * @template TDeclaringModel of \MongoDB\Laravel\Eloquent\Model
+ * @template TRelatedModel of Model
+ * @template TDeclaringModel of Model
  * @template TResult
  * @extends EmbedsOneOrMany<TRelatedModel, TDeclaringModel, TResult>
  */

--- a/src/Relations/EmbedsOne.php
+++ b/src/Relations/EmbedsOne.php
@@ -11,6 +11,12 @@ use Throwable;
 
 use function throw_if;
 
+/**
+ * @template TRelatedModel of \MongoDB\Laravel\Eloquent\Model
+ * @template TDeclaringModel of \MongoDB\Laravel\Eloquent\Model
+ * @template TResult
+ * @extends EmbedsOneOrMany<TRelatedModel, TDeclaringModel, TResult>
+ */
 class EmbedsOne extends EmbedsOneOrMany
 {
     public function initRelation(array $models, $relation)

--- a/src/Relations/EmbedsOneOrMany.php
+++ b/src/Relations/EmbedsOneOrMany.php
@@ -25,7 +25,7 @@ use function throw_if;
  * @template TRelatedModel of Model
  * @template TDeclaringModel of Model
  * @template TResult
- * @extends \Illuminate\Database\Eloquent\Relations\Relation<TRelatedModel, TDeclaringModel, TResult>
+ * @extends Relation<TRelatedModel, TDeclaringModel, TResult>
  */
 abstract class EmbedsOneOrMany extends Relation
 {

--- a/src/Relations/EmbedsOneOrMany.php
+++ b/src/Relations/EmbedsOneOrMany.php
@@ -21,6 +21,12 @@ use function is_array;
 use function str_starts_with;
 use function throw_if;
 
+/**
+ * @template TRelatedModel of \MongoDB\Laravel\Eloquent\Model
+ * @template TDeclaringModel of \MongoDB\Laravel\Eloquent\Model
+ * @template TResult
+ * @extends \Illuminate\Database\Eloquent\Relations\Relation<TRelatedModel, TDeclaringModel, TResult>
+ */
 abstract class EmbedsOneOrMany extends Relation
 {
     /**

--- a/src/Relations/EmbedsOneOrMany.php
+++ b/src/Relations/EmbedsOneOrMany.php
@@ -22,8 +22,8 @@ use function str_starts_with;
 use function throw_if;
 
 /**
- * @template TRelatedModel of \MongoDB\Laravel\Eloquent\Model
- * @template TDeclaringModel of \MongoDB\Laravel\Eloquent\Model
+ * @template TRelatedModel of Model
+ * @template TDeclaringModel of Model
  * @template TResult
  * @extends \Illuminate\Database\Eloquent\Relations\Relation<TRelatedModel, TDeclaringModel, TResult>
  */

--- a/src/Relations/HasMany.php
+++ b/src/Relations/HasMany.php
@@ -9,8 +9,8 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany as EloquentHasMany;
 
 /**
- * @template TRelatedModel of \MongoDB\Laravel\Eloquent\Model
- * @template TDeclaringModel of \MongoDB\Laravel\Eloquent\Model
+ * @template TRelatedModel of Model
+ * @template TDeclaringModel of Model
  * @extends EloquentHasMany<TRelatedModel, TDeclaringModel>
  */
 class HasMany extends EloquentHasMany

--- a/src/Relations/HasMany.php
+++ b/src/Relations/HasMany.php
@@ -8,6 +8,11 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany as EloquentHasMany;
 
+/**
+ * @template TRelatedModel of \MongoDB\Laravel\Eloquent\Model
+ * @template TDeclaringModel of \MongoDB\Laravel\Eloquent\Model
+ * @extends EloquentHasMany<TRelatedModel, TDeclaringModel>
+ */
 class HasMany extends EloquentHasMany
 {
     /**

--- a/src/Relations/HasOne.php
+++ b/src/Relations/HasOne.php
@@ -9,8 +9,8 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasOne as EloquentHasOne;
 
 /**
- * @template TRelatedModel of \MongoDB\Laravel\Eloquent\Model
- * @template TDeclaringModel of \MongoDB\Laravel\Eloquent\Model
+ * @template TRelatedModel of Model
+ * @template TDeclaringModel of Model
  * @extends EloquentHasOne<TRelatedModel, TDeclaringModel>
  */
 class HasOne extends EloquentHasOne

--- a/src/Relations/HasOne.php
+++ b/src/Relations/HasOne.php
@@ -8,6 +8,11 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasOne as EloquentHasOne;
 
+/**
+ * @template TRelatedModel of \MongoDB\Laravel\Eloquent\Model
+ * @template TDeclaringModel of \MongoDB\Laravel\Eloquent\Model
+ * @extends EloquentHasOne<TRelatedModel, TDeclaringModel>
+ */
 class HasOne extends EloquentHasOne
 {
     /**

--- a/src/Relations/MorphMany.php
+++ b/src/Relations/MorphMany.php
@@ -8,8 +8,8 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphMany as EloquentMorphMany;
 
 /**
- * @template TRelatedModel of \MongoDB\Laravel\Eloquent\Model
- * @template TDeclaringModel of \MongoDB\Laravel\Eloquent\Model
+ * @template TRelatedModel of Model
+ * @template TDeclaringModel of Model
  * @extends EloquentMorphMany<TRelatedModel, TDeclaringModel>
  */
 class MorphMany extends EloquentMorphMany

--- a/src/Relations/MorphMany.php
+++ b/src/Relations/MorphMany.php
@@ -7,6 +7,11 @@ namespace MongoDB\Laravel\Relations;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphMany as EloquentMorphMany;
 
+/**
+ * @template TRelatedModel of \MongoDB\Laravel\Eloquent\Model
+ * @template TDeclaringModel of \MongoDB\Laravel\Eloquent\Model
+ * @extends EloquentMorphMany<TRelatedModel, TDeclaringModel>
+ */
 class MorphMany extends EloquentMorphMany
 {
     /**

--- a/src/Relations/MorphTo.php
+++ b/src/Relations/MorphTo.php
@@ -7,6 +7,11 @@ namespace MongoDB\Laravel\Relations;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo as EloquentMorphTo;
 
+/**
+ * @template TRelatedModel of \MongoDB\Laravel\Eloquent\Model
+ * @template TDeclaringModel of \MongoDB\Laravel\Eloquent\Model
+ * @extends EloquentMorphTo<TRelatedModel, TDeclaringModel>
+ */
 class MorphTo extends EloquentMorphTo
 {
     /** @inheritdoc */

--- a/src/Relations/MorphTo.php
+++ b/src/Relations/MorphTo.php
@@ -8,8 +8,8 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo as EloquentMorphTo;
 
 /**
- * @template TRelatedModel of \MongoDB\Laravel\Eloquent\Model
- * @template TDeclaringModel of \MongoDB\Laravel\Eloquent\Model
+ * @template TRelatedModel of Model
+ * @template TDeclaringModel of Model
  * @extends EloquentMorphTo<TRelatedModel, TDeclaringModel>
  */
 class MorphTo extends EloquentMorphTo

--- a/src/Relations/MorphToMany.php
+++ b/src/Relations/MorphToMany.php
@@ -25,8 +25,8 @@ use function is_array;
 use function is_numeric;
 
 /**
- * @template TRelatedModel of \MongoDB\Laravel\Eloquent\Model
- * @template TDeclaringModel of \MongoDB\Laravel\Eloquent\Model
+ * @template TRelatedModel of Model
+ * @template TDeclaringModel of Model
  * @extends EloquentMorphToMany<TRelatedModel, TDeclaringModel>
  */
 class MorphToMany extends EloquentMorphToMany

--- a/src/Relations/MorphToMany.php
+++ b/src/Relations/MorphToMany.php
@@ -24,6 +24,11 @@ use function in_array;
 use function is_array;
 use function is_numeric;
 
+/**
+ * @template TRelatedModel of \MongoDB\Laravel\Eloquent\Model
+ * @template TDeclaringModel of \MongoDB\Laravel\Eloquent\Model
+ * @extends EloquentMorphToMany<TRelatedModel, TDeclaringModel>
+ */
 class MorphToMany extends EloquentMorphToMany
 {
     /** @inheritdoc */


### PR DESCRIPTION
This allows users of the package to properly define template types for their relations without receiving false positive warnings from phpstan about the relations not being generic, as well as allowing larastan to infer the model types returned from relation property accesses.

```php
/**
 * @return EmbedsMany<Items, ItemCollection>
 */
public function items(): EmbedsMany
{
  return $this->embedsMany(Item::class);
}
```

As a result this also cleans up the packages phpstan baseline a bit too :tada: 

### Checklist

- [ ] Add tests and ensure they pass
