### PR TITLE
PHPORM-295 VectorSearch path cannot be an array

### DIFF
--- a/src/Eloquent/Builder.php
+++ b/src/Eloquent/Builder.php
@@ -112,7 +112,7 @@ class Builder extends EloquentBuilder
      */
     public function vectorSearch(
         string $index,
-        array|string $path,
+        string $path,
         array $queryVector,
         int $limit,
         bool $exact = false,

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -1604,7 +1604,7 @@ class Builder extends BaseBuilder
      */
     public function vectorSearch(
         string $index,
-        array|string $path,
+        string $path,
         array $queryVector,
         int $limit,
         bool $exact = false,


### PR DESCRIPTION
Fix PHPORM-295

Related to https://github.com/mongodb/mongo-php-library/pull/1579