### PR TITLE
PHPORM-268 Add configuration for scout search indexes

### DIFF
--- a/src/MongoDBServiceProvider.php
+++ b/src/MongoDBServiceProvider.php
@@ -167,10 +167,11 @@ class MongoDBServiceProvider extends ServiceProvider
                 $connectionName = $app->get('config')->get('scout.mongodb.connection', 'mongodb');
                 $connection = $app->get('db')->connection($connectionName);
                 $softDelete = (bool) $app->get('config')->get('scout.soft_delete', false);
+                $indexDefinitions = $app->get('config')->get('scout.mongodb.index-definitions', []);
 
                 assert($connection instanceof Connection, new InvalidArgumentException(sprintf('The connection "%s" is not a MongoDB connection.', $connectionName)));
 
-                return new ScoutEngine($connection->getMongoDB(), $softDelete);
+                return new ScoutEngine($connection->getMongoDB(), $softDelete, $indexDefinitions);
             });
 
             return $engineManager;

--- a/src/Scout/ScoutEngine.php
+++ b/src/Scout/ScoutEngine.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Collection;
 use Illuminate\Support\LazyCollection;
+use InvalidArgumentException;
 use Laravel\Scout\Builder;
 use Laravel\Scout\Engines\Engine;
 use Laravel\Scout\Searchable;
@@ -439,7 +440,7 @@ final class ScoutEngine extends Engine
 
         $definition = $this->indexDefinitions[$name] ?? self::DEFAULT_DEFINITION;
         if (! isset($definition['mappings'])) {
-            throw new LogicException(sprintf('The search index definition for collection "scout.mongodb.index-definition.%s" must contain a "mappings" key. Find documentation at https://www.mongodb.com/docs/atlas/atlas-search/create-index/', $name));
+            throw new InvalidArgumentException(sprintf('Invalid search index definition for collection "%s", the "mappings" key is required. Find documentation at https://www.mongodb.com/docs/manual/reference/command/createSearchIndexes/#search-index-definition-syntax', $name));
         }
 
         // Ensure the collection exists before creating the search index

--- a/tests/Scout/ScoutEngineTest.php
+++ b/tests/Scout/ScoutEngineTest.php
@@ -2,6 +2,7 @@
 
 namespace MongoDB\Laravel\Tests\Scout;
 
+use ArrayIterator;
 use Closure;
 use DateTimeImmutable;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
@@ -9,7 +10,9 @@ use Illuminate\Support\Collection as LaravelCollection;
 use Illuminate\Support\LazyCollection;
 use Laravel\Scout\Builder;
 use Laravel\Scout\Jobs\RemoveFromSearch;
+use LogicException;
 use Mockery as m;
+use MongoDB\BSON\Document;
 use MongoDB\BSON\UTCDateTime;
 use MongoDB\Collection;
 use MongoDB\Database;
@@ -30,6 +33,82 @@ use function unserialize;
 class ScoutEngineTest extends TestCase
 {
     private const EXPECTED_TYPEMAP = ['root' => 'object', 'document' => 'bson', 'array' => 'bson'];
+
+    public function testCreateIndexInvalidDefinition(): void
+    {
+        $database = m::mock(Database::class);
+        $engine = new ScoutEngine($database, false, ['collection_invalid' => ['foo' => 'bar']]);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('The search index definition for collection "scout.mongodb.index-definition.collection_invalid" must contain a "mappings" key');
+        $engine->createIndex('collection_invalid');
+    }
+
+    public function testCreateIndex(): void
+    {
+        $collectionName = 'collection_custom';
+        $expectedDefinition = [
+            'mappings' => [
+                'dynamic' => true,
+            ],
+        ];
+
+        $database = m::mock(Database::class);
+        $collection = m::mock(Collection::class);
+        $database->shouldReceive('createCollection')
+            ->once()
+            ->with($collectionName);
+        $database->shouldReceive('selectCollection')
+            ->with($collectionName)
+            ->andReturn($collection);
+        $collection->shouldReceive('createSearchIndex')
+            ->once()
+            ->with($expectedDefinition, ['name' => 'scout']);
+        $collection->shouldReceive('listSearchIndexes')
+            ->once()
+            ->with(['name' => 'scout', 'typeMap' => ['root' => 'bson']])
+            ->andReturn(new ArrayIterator([Document::fromPHP(['name' => 'scout', 'status' => 'READY'])]));
+
+        $engine = new ScoutEngine($database, false, []);
+        $engine->createIndex($collectionName);
+    }
+
+    public function testCreateIndexCustomDefinition(): void
+    {
+        $collectionName = 'collection_custom';
+        $expectedDefinition = [
+            'mappings' => [
+                [
+                    'analyzer' => 'lucene.standard',
+                    'fields' => [
+                        [
+                            'name' => 'wildcard',
+                            'type' => 'string',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $database = m::mock(Database::class);
+        $collection = m::mock(Collection::class);
+        $database->shouldReceive('createCollection')
+            ->once()
+            ->with($collectionName);
+        $database->shouldReceive('selectCollection')
+            ->with($collectionName)
+            ->andReturn($collection);
+        $collection->shouldReceive('createSearchIndex')
+            ->once()
+            ->with($expectedDefinition, ['name' => 'scout']);
+        $collection->shouldReceive('listSearchIndexes')
+            ->once()
+            ->with(['name' => 'scout', 'typeMap' => ['root' => 'bson']])
+            ->andReturn(new ArrayIterator([Document::fromPHP(['name' => 'scout', 'status' => 'READY'])]));
+
+        $engine = new ScoutEngine($database, false, [$collectionName => $expectedDefinition]);
+        $engine->createIndex($collectionName);
+    }
 
     /** @param callable(): Builder $builder  */
     #[DataProvider('provideSearchPipelines')]

--- a/tests/Scout/ScoutEngineTest.php
+++ b/tests/Scout/ScoutEngineTest.php
@@ -40,7 +40,7 @@ class ScoutEngineTest extends TestCase
         $engine = new ScoutEngine($database, false, ['collection_invalid' => ['foo' => 'bar']]);
 
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('The search index definition for collection "scout.mongodb.index-definition.collection_invalid" must contain a "mappings" key');
+        $this->expectExceptionMessage('Invalid search index definition for collection "collection_invalid", the "mappings" key is required.');
         $engine->createIndex('collection_invalid');
     }
 


### PR DESCRIPTION
Fix PHPORM-268

The configuration looks like this:

```php
<?php # scout.php

return [
    'driver' => env('SCOUT_DRIVER', 'mongodb'),
    'prefix' => env('SCOUT_PREFIX', 'scout_'),

    'mongodb' => [
        'connection' => env('SCOUT_MONGODB_CONNECTION', 'mongodb'),
        'index-definitions' => [
            'scout_books' => [
                // The definition here
                'mappings' => ['dynamic' => true],
            ],
        ]
    ],
],
```