### PR TITLE
PHPORM-302 Compatibility with spatie/laravel-query-builder v6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "orchestra/testbench": "^8.0|^9.0",
         "mockery/mockery": "^1.4.4@stable",
         "doctrine/coding-standard": "12.0.x-dev",
-        "spatie/laravel-query-builder": "^5.6",
+        "spatie/laravel-query-builder": "^5.6|^6",
         "phpstan/phpstan": "^1.10",
         "rector/rector": "^1.2"
     },


### PR DESCRIPTION
Fix PHPORM-302

For compatibility with Laravel 12.x
https://github.com/spatie/laravel-query-builder/releases/tag/6.3.1 