### PR TITLE
PHPORM-299 Enable PHPUnit 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "laravel/scout": "^10.3",
         "league/flysystem-gridfs": "^3.28",
         "league/flysystem-read-only": "^3.0",
-        "phpunit/phpunit": "^10.3",
+        "phpunit/phpunit": "^10.3|^11.5.3",
         "orchestra/testbench": "^8.0|^9.0",
         "mockery/mockery": "^1.4.4@stable",
         "doctrine/coding-standard": "12.0.x-dev",

--- a/tests/AuthTest.php
+++ b/tests/AuthTest.php
@@ -17,10 +17,10 @@ class AuthTest extends TestCase
 {
     public function tearDown(): void
     {
-        parent::setUp();
-
         User::truncate();
         DB::table('password_reset_tokens')->truncate();
+
+        parent::tearDown();
     }
 
     public function testAuthAttempt()

--- a/tests/Eloquent/CallBuilderTest.php
+++ b/tests/Eloquent/CallBuilderTest.php
@@ -21,6 +21,8 @@ final class CallBuilderTest extends TestCase
     protected function tearDown(): void
     {
         User::truncate();
+
+        parent::tearDown();
     }
 
     #[Dataprovider('provideFunctionNames')]

--- a/tests/Eloquent/MassPrunableTest.php
+++ b/tests/Eloquent/MassPrunableTest.php
@@ -20,6 +20,8 @@ class MassPrunableTest extends TestCase
     {
         User::truncate();
         Soft::truncate();
+
+        parent::tearDown();
     }
 
     public function testPruneWithQuery(): void

--- a/tests/EmbeddedRelationsTest.php
+++ b/tests/EmbeddedRelationsTest.php
@@ -20,6 +20,8 @@ class EmbeddedRelationsTest extends TestCase
     {
         Mockery::close();
         User::truncate();
+
+        parent::tearDown();
     }
 
     public function testEmbedsManySave()

--- a/tests/GeospatialTest.php
+++ b/tests/GeospatialTest.php
@@ -53,6 +53,8 @@ class GeospatialTest extends TestCase
     public function tearDown(): void
     {
         Schema::drop('locations');
+
+        parent::tearDown();
     }
 
     public function testGeoWithin()

--- a/tests/HybridRelationsTest.php
+++ b/tests/HybridRelationsTest.php
@@ -42,6 +42,8 @@ class HybridRelationsTest extends TestCase
         Skill::truncate();
         Experience::truncate();
         Label::truncate();
+
+        parent::tearDown();
     }
 
     public function testSqlRelations()

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -56,6 +56,8 @@ class ModelTest extends TestCase
         Book::truncate();
         Item::truncate();
         Guarded::truncate();
+
+        parent::tearDown();
     }
 
     public function testNewModel(): void

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -43,6 +43,8 @@ class QueryBuilderTest extends TestCase
     {
         DB::table('users')->truncate();
         DB::table('items')->truncate();
+
+        parent::tearDown();
     }
 
     public function testDeleteWithId()

--- a/tests/RelationsTest.php
+++ b/tests/RelationsTest.php
@@ -35,6 +35,8 @@ class RelationsTest extends TestCase
         Photo::truncate();
         Label::truncate();
         Skill::truncate();
+
+        parent::tearDown();
     }
 
     public function testHasMany(): void

--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -26,6 +26,8 @@ class SchemaTest extends TestCase
         assert($database instanceof Database);
         $database->dropCollection('newcollection');
         $database->dropCollection('newcollection_two');
+
+        parent::tearDown();
     }
 
     public function testCreate(): void
@@ -37,10 +39,8 @@ class SchemaTest extends TestCase
 
     public function testCreateWithCallback(): void
     {
-        $instance = $this;
-
-        Schema::create('newcollection', function ($collection) use ($instance) {
-            $instance->assertInstanceOf(Blueprint::class, $collection);
+        Schema::create('newcollection', static function ($collection) {
+            self::assertInstanceOf(Blueprint::class, $collection);
         });
 
         $this->assertTrue(Schema::hasCollection('newcollection'));
@@ -66,14 +66,12 @@ class SchemaTest extends TestCase
 
     public function testBluePrint(): void
     {
-        $instance = $this;
-
-        Schema::table('newcollection', function ($collection) use ($instance) {
-            $instance->assertInstanceOf(Blueprint::class, $collection);
+        Schema::table('newcollection', static function ($collection) {
+            self::assertInstanceOf(Blueprint::class, $collection);
         });
 
-        Schema::table('newcollection', function ($collection) use ($instance) {
-            $instance->assertInstanceOf(Blueprint::class, $collection);
+        Schema::table('newcollection', static function ($collection) {
+            self::assertInstanceOf(Blueprint::class, $collection);
         });
     }
 

--- a/tests/SchemaVersionTest.php
+++ b/tests/SchemaVersionTest.php
@@ -15,6 +15,8 @@ class SchemaVersionTest extends TestCase
     public function tearDown(): void
     {
         SchemaVersion::truncate();
+
+        parent::tearDown();
     }
 
     public function testWithBasicDocument()

--- a/tests/Scout/ScoutEngineTest.php
+++ b/tests/Scout/ScoutEngineTest.php
@@ -141,7 +141,7 @@ class ScoutEngineTest extends TestCase
         $this->assertEquals($data, $result);
     }
 
-    public function provideSearchPipelines(): iterable
+    public static function provideSearchPipelines(): iterable
     {
         $defaultPipeline = [
             [
@@ -377,11 +377,11 @@ class ScoutEngineTest extends TestCase
 
         yield 'with callback' => [
             fn () => new Builder(new SearchableModel(), 'query', callback: function (...$args) {
-                $this->assertCount(3, $args);
-                $this->assertInstanceOf(Collection::class, $args[0]);
-                $this->assertSame('collection_searchable', $args[0]->getCollectionName());
-                $this->assertSame('query', $args[1]);
-                $this->assertNull($args[2]);
+                self::assertCount(3, $args);
+                self::assertInstanceOf(Collection::class, $args[0]);
+                self::assertSame('collection_searchable', $args[0]->getCollectionName());
+                self::assertSame('query', $args[1]);
+                self::assertNull($args[2]);
 
                 return $args[0]->aggregate(['pipeline']);
             }),

--- a/tests/SeederTest.php
+++ b/tests/SeederTest.php
@@ -14,6 +14,8 @@ class SeederTest extends TestCase
     public function tearDown(): void
     {
         User::truncate();
+
+        parent::tearDown();
     }
 
     public function testSeed(): void

--- a/tests/Ticket/GH2489Test.php
+++ b/tests/Ticket/GH2489Test.php
@@ -13,6 +13,8 @@ class GH2489Test extends TestCase
     public function tearDown(): void
     {
         Location::truncate();
+
+        parent::tearDown();
     }
 
     public function testQuerySubdocumentsUsingWhereInId()

--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -12,6 +12,8 @@ class ValidationTest extends TestCase
     public function tearDown(): void
     {
         User::truncate();
+
+        parent::tearDown();
     }
 
     public function testUnique(): void


### PR DESCRIPTION
Fix PHPORM-299

Ensures the `parent::tearDown` method is always called to remove the error/exception handlers registered by Laravel.