### PR TITLE
PHPORM-303 Require mongodb library v1.21 with aggregation builder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,11 +30,10 @@
         "illuminate/database": "^10.30|^11",
         "illuminate/events": "^10.0|^11",
         "illuminate/support": "^10.0|^11",
-        "mongodb/mongodb": "^1.18",
+        "mongodb/mongodb": "^1.21",
         "symfony/http-foundation": "^6.4|^7"
     },
     "require-dev": {
-        "mongodb/builder": "^0.2",
         "laravel/scout": "^10.3",
         "league/flysystem-gridfs": "^3.28",
         "league/flysystem-read-only": "^3.0",
@@ -54,6 +53,7 @@
         "mongodb/builder": "Provides a fluent aggregation builder for MongoDB pipelines"
     },
     "minimum-stability": "dev",
+    "prefer-stable": true,
     "replace": {
         "jenssegers/mongodb": "self.version"
     },


### PR DESCRIPTION
Fix PHPORM-303

The new search features https://github.com/mongodb/laravel-mongodb/pull/3242 and https://github.com/mongodb/laravel-mongodb/pull/3232 use the aggregation builder introduced by https://github.com/mongodb/mongo-php-library/pull/1537