### PR TITLE
PHPORM-278 Introduce `Connection::getDatabase()` and `getClient()`

### DIFF
--- a/src/Concerns/ManagesTransactions.php
+++ b/src/Concerns/ManagesTransactions.php
@@ -12,15 +12,18 @@ use Throwable;
 
 use function MongoDB\with_transaction;
 
-/** @see https://docs.mongodb.com/manual/core/transactions/ */
+/**
+ * @internal
+ *
+ * @see https://docs.mongodb.com/manual/core/transactions/
+ */
 trait ManagesTransactions
 {
     protected ?Session $session = null;
 
     protected $transactions = 0;
 
-    /** @return Client */
-    abstract public function getMongoClient();
+    abstract public function getClient(): ?Client;
 
     public function getSession(): ?Session
     {
@@ -30,7 +33,7 @@ trait ManagesTransactions
     private function getSessionOrCreate(): Session
     {
         if ($this->session === null) {
-            $this->session = $this->getMongoClient()->startSession();
+            $this->session = $this->getClient()->startSession();
         }
 
         return $this->session;

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -71,7 +71,7 @@ class Connection extends BaseConnection
         $this->database = $this->getDefaultDatabaseName($dsn, $config);
 
         // Select database
-        $this->db = $this->connection->selectDatabase($this->database);
+        $this->db = $this->connection->getDatabase($this->database);
 
         $this->tablePrefix = $config['prefix'] ?? '';
 
@@ -139,7 +139,7 @@ class Connection extends BaseConnection
     public function getDatabase(?string $name = null): Database
     {
         if ($name && $name !== $this->database) {
-            return $this->connection->{$name};
+            return $this->connection->getDatabase($name);
         }
 
         return $this->db;

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -22,8 +22,11 @@ use function filter_var;
 use function implode;
 use function is_array;
 use function preg_match;
+use function sprintf;
 use function str_contains;
+use function trigger_error;
 
+use const E_USER_DEPRECATED;
 use const FILTER_FLAG_IPV6;
 use const FILTER_VALIDATE_IP;
 
@@ -65,9 +68,10 @@ class Connection extends BaseConnection
 
         // Create the connection
         $this->connection = $this->createConnection($dsn, $config, $options);
+        $this->database = $this->getDefaultDatabaseName($dsn, $config);
 
         // Select database
-        $this->db = $this->connection->selectDatabase($this->getDefaultDatabaseName($dsn, $config));
+        $this->db = $this->connection->selectDatabase($this->database);
 
         $this->tablePrefix = $config['prefix'] ?? '';
 
@@ -114,29 +118,53 @@ class Connection extends BaseConnection
     /**
      * Get the MongoDB database object.
      *
+     * @deprecated since mongodb/laravel-mongodb:5.2, use getDatabase() instead
+     *
      * @return Database
      */
     public function getMongoDB()
     {
+        trigger_error(sprintf('Since mongodb/laravel-mongodb:5.2, Method "%s()" is deprecated, use "getDatabase()" instead.', __FUNCTION__), E_USER_DEPRECATED);
+
         return $this->db;
     }
 
     /**
-     * return MongoDB object.
+     * Get the MongoDB database object.
+     *
+     * @param string|null $name Name of the database, if not provided the default database will be returned.
+     *
+     * @return Database
+     */
+    public function getDatabase(?string $name = null): Database
+    {
+        if ($name && $name !== $this->database) {
+            return $this->connection->{$name};
+        }
+
+        return $this->db;
+    }
+
+    /**
+     * Return MongoDB object.
+     *
+     * @deprecated since mongodb/laravel-mongodb:5.2, use getClient() instead
      *
      * @return Client
      */
     public function getMongoClient()
     {
-        return $this->connection;
+        trigger_error(sprintf('Since mongodb/laravel-mongodb:5.2, method "%s()" is deprecated, use "getClient()" instead.', __FUNCTION__), E_USER_DEPRECATED);
+
+        return $this->getClient();
     }
 
     /**
-     * {@inheritDoc}
+     * Get the MongoDB client.
      */
-    public function getDatabaseName()
+    public function getClient(): ?Client
     {
-        return $this->getMongoDB()->getDatabaseName();
+        return $this->connection;
     }
 
     public function enableQueryLog()
@@ -233,7 +261,7 @@ class Connection extends BaseConnection
      */
     public function ping(): void
     {
-        $this->getMongoClient()->getManager()->selectServer(new ReadPreference(ReadPreference::PRIMARY_PREFERRED));
+        $this->getClient()->getManager()->selectServer(new ReadPreference(ReadPreference::PRIMARY_PREFERRED));
     }
 
     /** @inheritdoc */

--- a/src/MongoDBServiceProvider.php
+++ b/src/MongoDBServiceProvider.php
@@ -133,7 +133,7 @@ class MongoDBServiceProvider extends ServiceProvider
                     }
 
                     $bucket = $connection->getClient()
-                        ->selectDatabase($config['database'] ?? $connection->getDatabaseName())
+                        ->getDatabase($config['database'] ?? $connection->getDatabaseName())
                         ->selectGridFSBucket(['bucketName' => $config['bucket'] ?? 'fs', 'disableMD5' => true]);
                 }
 

--- a/src/MongoDBServiceProvider.php
+++ b/src/MongoDBServiceProvider.php
@@ -67,7 +67,7 @@ class MongoDBServiceProvider extends ServiceProvider
                 assert($connection instanceof Connection, new InvalidArgumentException(sprintf('The database connection "%s" used for the session does not use the "mongodb" driver.', $connectionName)));
 
                 return new MongoDbSessionHandler(
-                    $connection->getMongoClient(),
+                    $connection->getClient(),
                     $app->config->get('session.options', []) + [
                         'database' => $connection->getDatabaseName(),
                         'collection' => $app->config->get('session.table') ?: 'sessions',
@@ -132,7 +132,7 @@ class MongoDBServiceProvider extends ServiceProvider
                         throw new InvalidArgumentException(sprintf('The database connection "%s" does not use the "mongodb" driver.', $config['connection'] ?? $app['config']['database.default']));
                     }
 
-                    $bucket = $connection->getMongoClient()
+                    $bucket = $connection->getClient()
                         ->selectDatabase($config['database'] ?? $connection->getDatabaseName())
                         ->selectGridFSBucket(['bucketName' => $config['bucket'] ?? 'fs', 'disableMD5' => true]);
                 }
@@ -171,7 +171,7 @@ class MongoDBServiceProvider extends ServiceProvider
 
                 assert($connection instanceof Connection, new InvalidArgumentException(sprintf('The connection "%s" is not a MongoDB connection.', $connectionName)));
 
-                return new ScoutEngine($connection->getMongoDB(), $softDelete, $indexDefinitions);
+                return new ScoutEngine($connection->getDatabase(), $softDelete, $indexDefinitions);
             });
 
             return $engineManager;

--- a/src/Schema/Blueprint.php
+++ b/src/Schema/Blueprint.php
@@ -251,7 +251,7 @@ class Blueprint extends SchemaBlueprint
     {
         $collection = $this->collection->getCollectionName();
 
-        $db = $this->connection->getMongoDB();
+        $db = $this->connection->getDatabase();
 
         // Ensure the collection is created.
         $db->createCollection($collection, $options);

--- a/src/Schema/Builder.php
+++ b/src/Schema/Builder.php
@@ -76,7 +76,7 @@ class Builder extends \Illuminate\Database\Schema\Builder
      */
     public function hasCollection($name)
     {
-        $db = $this->connection->getMongoDB();
+        $db = $this->connection->getDatabase();
 
         $collections = iterator_to_array($db->listCollections([
             'filter' => ['name' => $name],
@@ -139,7 +139,7 @@ class Builder extends \Illuminate\Database\Schema\Builder
 
     public function getTables()
     {
-        $db = $this->connection->getMongoDB();
+        $db = $this->connection->getDatabase();
         $collections = [];
 
         foreach ($db->listCollectionNames() as $collectionName) {
@@ -167,7 +167,7 @@ class Builder extends \Illuminate\Database\Schema\Builder
 
     public function getTableListing()
     {
-        $collections = iterator_to_array($this->connection->getMongoDB()->listCollectionNames());
+        $collections = iterator_to_array($this->connection->getDatabase()->listCollectionNames());
 
         sort($collections);
 
@@ -176,7 +176,7 @@ class Builder extends \Illuminate\Database\Schema\Builder
 
     public function getColumns($table)
     {
-        $stats = $this->connection->getMongoDB()->selectCollection($table)->aggregate([
+        $stats = $this->connection->getDatabase()->selectCollection($table)->aggregate([
             // Sample 1,000 documents to get a representative sample of the collection
             ['$sample' => ['size' => 1_000]],
             // Convert each document to an array of fields
@@ -229,7 +229,7 @@ class Builder extends \Illuminate\Database\Schema\Builder
 
     public function getIndexes($table)
     {
-        $collection = $this->connection->getMongoDB()->selectCollection($table);
+        $collection = $this->connection->getDatabase()->selectCollection($table);
         assert($collection instanceof Collection);
         $indexList = [];
 
@@ -301,7 +301,7 @@ class Builder extends \Illuminate\Database\Schema\Builder
      */
     public function getCollection($name)
     {
-        $db = $this->connection->getMongoDB();
+        $db = $this->connection->getDatabase();
 
         $collections = iterator_to_array($db->listCollections([
             'filter' => ['name' => $name],
@@ -318,7 +318,7 @@ class Builder extends \Illuminate\Database\Schema\Builder
     protected function getAllCollections()
     {
         $collections = [];
-        foreach ($this->connection->getMongoDB()->listCollections() as $collection) {
+        foreach ($this->connection->getDatabase()->listCollections() as $collection) {
             $collections[] = $collection->getName();
         }
 


### PR DESCRIPTION
And deprecate getMongoDB and get MongoClient

Fix PHPORM-278

### Checklist

- [x] Add tests and ensure they pass
