### PR TITLE
DOCSP-46918: Rename Connection::getMongoDB to getDatabase

### DIFF
--- a/docs/database-collection.txt
+++ b/docs/database-collection.txt
@@ -219,7 +219,7 @@ methods in your application:
 Example
 ```````
 
-The following example accesses a database connection, then calls the
+The following example accesses the database of the connection, then calls the
 ``listCollections()`` query builder method to retrieve information about
 the collections in the database:
 

--- a/docs/database-collection.txt
+++ b/docs/database-collection.txt
@@ -225,7 +225,7 @@ the collections in the database:
 
 .. code-block:: php
 
-   $collections = DB::connection('mongodb')->getMongoDB()->listCollections();
+   $collections = DB::connection('mongodb')->getDatabase()->listCollections();
 
 List Collection Fields
 ----------------------

--- a/docs/filesystems.txt
+++ b/docs/filesystems.txt
@@ -94,7 +94,7 @@ In this case, the options ``connection`` and ``database`` are ignored:
            'driver' => 'gridfs',
            'bucket' => static function (Application $app): Bucket {
                return $app['db']->connection('mongodb')
-                   ->getMongoDB()
+                   ->getDatabase()
                    ->selectGridFSBucket([
                        'bucketName' => 'avatars',
                        'chunkSizeBytes' => 261120,
@@ -150,7 +150,7 @@ if you need to work with revisions, as shown in the following code:
 
    // Create a bucket service from the MongoDB connection
    /** @var \MongoDB\GridFS\Bucket $bucket */
-   $bucket = $app['db']->connection('mongodb')->getMongoDB()->selectGridFSBucket();
+   $bucket = $app['db']->connection('mongodb')->getDatabase()->selectGridFSBucket();
 
    // Download the last but one version of a file
    $bucket->openDownloadStreamByName('hello.txt', ['revision' => -2])


### PR DESCRIPTION
[Jira issue](https://jira.mongodb.org/browse/DOCSP-47918)

[Docs PR](https://github.com/10gen/docs-laravel/pull/166)

Didn't see any references to Connection::getMongoClient in the docs, so only renamed the usages of getMongoDB.

Staging

- <https://deploy-preview-166--docs-laravel.netlify.app/filesystems/>
- <https://deploy-preview-166--docs-laravel.netlify.app/database-collection/>
