### PR TITLE
Update composer.json with latest release of mongodb/mongodb v1.21

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.1",
-        "ext-mongodb": "^1.15",
+        "ext-mongodb": "^1.21",
         "composer-runtime-api": "^2.0.0",
         "illuminate/cache": "^10.36|^11|^12",
         "illuminate/container": "^10.0|^11|^12",

--- a/composer.json
+++ b/composer.json
@@ -49,8 +49,7 @@
         "illuminate/bus": "< 10.37.2"
     },
     "suggest": {
-        "league/flysystem-gridfs": "Filesystem storage in MongoDB with GridFS",
-        "mongodb/builder": "Provides a fluent aggregation builder for MongoDB pipelines"
+        "league/flysystem-gridfs": "Filesystem storage in MongoDB with GridFS"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,


### PR DESCRIPTION
- Remove suggestion of archived package `mongodb/builder`. Now part of the `mongodb/mongodb` package Fix [PHPORM-166](https://jira.mongodb.org/browse/PHPORM-166)
- Synchronise minimum version of ext-mongodb with mongodb/mongodb v1.21.
