### PR TITLE
Fix BelongsToMany Relation to Support Array Foreign Keys in Laravel MongoDB

### DIFF
--- a/docs/eloquent-models/relationships.txt
+++ b/docs/eloquent-models/relationships.txt
@@ -255,6 +255,26 @@ in the Laravel documentation.
 The following section shows an example of how to create a many to many
 relationship between model classes.
 
+.. note::
+
+   In previous versions, the `foreignPivotKey` in a `BelongsToMany` relationship
+   was expected to be a single `ObjectId` or `string`. However, in some MongoDB
+   schemas, it is common to store multiple related IDs as an array. As of this update,
+   `BelongsToMany` now supports array values for the `foreignPivotKey`.
+
+   Example:
+
+   .. code-block:: php
+
+       class User extends Model {
+           public function roles() {
+               return $this->belongsToMany(Role::class, null, 'role_ids', '_id');
+           }
+       }
+
+   Here, `role_ids` can be an array of `ObjectId`s, and the relationship will work correctly.
+
+
 Many to Many Example
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/src/Relations/BelongsToMany.php
+++ b/src/Relations/BelongsToMany.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany as EloquentBelongsToMany;
 use Illuminate\Support\Arr;
+use MongoDB\BSON\ObjectId;
 use MongoDB\Laravel\Eloquent\Model as DocumentModel;
 
 use function array_diff;
@@ -20,6 +21,7 @@ use function assert;
 use function count;
 use function in_array;
 use function is_numeric;
+use function is_object;
 
 /**
  * @template TRelatedModel of Model
@@ -208,11 +210,12 @@ class BelongsToMany extends EloquentBelongsToMany
 
         // Attach the new ids to the parent model.
         if (\MongoDB\Laravel\Eloquent\Model::isDocumentModel($this->parent)) {
-            if ($id instanceof \MongoDB\BSON\ObjectId) {
+            if ($id instanceof ObjectId) {
                 $id = [$id];
             } else {
                 $id = (array) $id;
             }
+
             $this->parent->push($this->relatedPivotKey, $id, true);
         } else {
             $instance = new $this->related();

--- a/src/Relations/BelongsToMany.php
+++ b/src/Relations/BelongsToMany.php
@@ -208,7 +208,12 @@ class BelongsToMany extends EloquentBelongsToMany
 
         // Attach the new ids to the parent model.
         if (\MongoDB\Laravel\Eloquent\Model::isDocumentModel($this->parent)) {
-            $this->parent->push($this->relatedPivotKey, (array) $id, true);
+            if ($id instanceof \MongoDB\BSON\ObjectId) {
+                $id = [$id];
+            } else {
+                $id = (array) $id;
+            }
+            $this->parent->push($this->relatedPivotKey, $id, true);
         } else {
             $instance = new $this->related();
             $instance->forceFill([$this->relatedKey => $id]);
@@ -275,7 +280,8 @@ class BelongsToMany extends EloquentBelongsToMany
 
         foreach ($results as $result) {
             foreach ($result->$foreign as $item) {
-                $dictionary[$item][] = $result;
+                $key = is_object($item) ? (string) $item : $item;
+                $dictionary[$key][] = $result;
             }
         }
 

--- a/tests/Models/Role.php
+++ b/tests/Models/Role.php
@@ -7,6 +7,7 @@ namespace MongoDB\Laravel\Tests\Models;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use MongoDB\Laravel\Eloquent\DocumentModel;
+use MongoDB\Laravel\Relations\BelongsToMany;
 
 class Role extends Model
 {
@@ -20,6 +21,11 @@ class Role extends Model
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
+    }
+
+    public function users(): BelongsToMany
+    {
+        return $this->belongsToMany(User::class, null, 'role_id', 'user_id');
     }
 
     public function sqlUser(): BelongsTo

--- a/tests/Models/User.php
+++ b/tests/Models/User.php
@@ -17,6 +17,7 @@ use Illuminate\Support\Str;
 use MongoDB\Laravel\Eloquent\Builder;
 use MongoDB\Laravel\Eloquent\DocumentModel;
 use MongoDB\Laravel\Eloquent\MassPrunable;
+use MongoDB\Laravel\Relations\BelongsToMany;
 
 /**
  * @property string $id
@@ -85,6 +86,11 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
     public function role()
     {
         return $this->hasOne(Role::class);
+    }
+
+    public function roles(): BelongsToMany
+    {
+        return $this->belongsToMany(Role::class, null, 'user_id', 'role_id');
     }
 
     public function sqlRole()

--- a/tests/RelationsTest.php
+++ b/tests/RelationsTest.php
@@ -350,7 +350,7 @@ class RelationsTest extends TestCase
         $this->assertCount(2, $retrievedUser->roles);
         $this->assertEqualsCanonicalizing(
             [$role1->id, $role2->id],
-            $retrievedUser->roles->pluck('id')->toArray()
+            $retrievedUser->roles->pluck('id')->toArray(),
         );
     }
 

--- a/tests/RelationsTest.php
+++ b/tests/RelationsTest.php
@@ -338,6 +338,22 @@ class RelationsTest extends TestCase
         $this->assertCount(2, $user->clients);
     }
 
+    public function testBelongsToManyRelationSupportsArrayForeignKeys(): void
+    {
+        $user = User::create(['name' => 'John Doe']);
+        $role1 = Role::create(['name' => 'Admin']);
+        $role2 = Role::create(['name' => 'Editor']);
+
+        $user->roles()->attach([$role1->id, $role2->id]);
+
+        $retrievedUser = User::with('roles')->find($user->id);
+        $this->assertCount(2, $retrievedUser->roles);
+        $this->assertEqualsCanonicalizing(
+            [$role1->id, $role2->id],
+            $retrievedUser->roles->pluck('id')->toArray()
+        );
+    }
+
     public function testBelongsToManyAttachEloquentCollection(): void
     {
         User::create(['name' => 'John Doe']);


### PR DESCRIPTION
<!--  
This PR fixes an issue where `BelongsToMany` in `mongodb/laravel-mongodb` didn't support **array-based foreign keys**, which are common in MongoDB.  
Now, foreign keys can be stored as arrays of ObjectIds, making relationships more flexible and compatible with MongoDB's schema style.  
-->  

### **🚀 What’s in This PR?**  
This PR fixes the `BelongsToMany` relationship to support **array-based foreign keys**, allowing multiple related ObjectIds to be stored in a single field.  

### **🐞 The Issue**  
- Previously, `BelongsToMany` expected foreign keys to be a **single value**, causing issues when an array was used.  
- This resulted in errors like `Illegal offset type` when working with MongoDB.  

🔍 Issue Reference
Fixes [#3015]

### **🔧 Changes Made**  
✅ Updated `attach()` in `BelongsToMany.php` to store ObjectIds as an **array** instead of a single value.  
✅ Modified `buildDictionary()` to correctly **handle arrays** when resolving relationships.  
✅ Added a new unit test: `testBelongsToManyRelationSupportsArrayForeignKeys` (in `tests/RelationsTest.php`).  
   - Ensures that array-based foreign keys work as expected.  
   - Confirms that relationships retrieve the correct data.  

### **🧪 How to Test It?**  
1. Run the tests with:  
   ```sh
   vendor/bin/phpunit tests/RelationsTest.php
   ```  
2. All tests should pass ✅  

---

### **📜 Documentation Update Checklist**  
✔️ Updated **Many-to-Many Relationship** section in the docs.  
✔️ Explained how to use **array-based foreign keys** with `BelongsToMany()`.  
✔️ Added an example showing how to define relationships with an array field.  

### Checklist

- [x] Add tests and ensure they pass
- [x] Updated **Many-to-Many Relationship** section in the docs.
