### PR TITLE
Remove manual dirty _id check when updating a model

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -783,13 +783,6 @@ class Builder extends BaseBuilder
             unset($values[$key]);
         }
 
-        // Since "id" is an alias for "_id", we prevent updating it
-        foreach ($values as $fields) {
-            if (array_key_exists('id', $fields)) {
-                throw new InvalidArgumentException('Cannot update "id" field.');
-            }
-        }
-
         return $this->performUpdate($values, $options);
     }
 

--- a/tests/Ticket/GH3326Test.php
+++ b/tests/Ticket/GH3326Test.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Laravel\Tests\Ticket;
+
+use MongoDB\Laravel\Eloquent\Model;
+use MongoDB\Laravel\Tests\TestCase;
+
+/**
+ * @see https://github.com/mongodb/laravel-mongodb/issues/3326
+ * @see https://jira.mongodb.org/browse/PHPORM-309
+ */
+class GH3326Test extends TestCase
+{
+    public function testCreatedEventCanSafelyCallSave(): void
+    {
+        $model = new GH3326Model();
+        $model->foo = 'bar';
+        $model->save();
+
+        $fresh = $model->fresh();
+
+        $this->assertEquals('bar', $fresh->foo);
+        $this->assertEquals('written-in-created', $fresh->extra);
+    }
+}
+
+class GH3326Model extends Model
+{
+    protected $connection = 'mongodb';
+    protected $collection = 'test_gh3326';
+    protected $guarded = [];
+
+    protected static function booted(): void
+    {
+        static::created(function ($model) {
+            $model->extra = 'written-in-created';
+            $model->saveQuietly();
+        });
+    }
+}


### PR DESCRIPTION
Fixes an issue where calling `save()` or `saveQuietly()` inside a model's `created` event throws:

`InvalidArgumentException: Cannot update "id" field
`

### Related Issue

Closes [#3326](https://github.com/mongodb/laravel-mongodb/issues/3326)

### Background

After inserting the model, Laravel's internal state still sees `_id` as dirty — so `save()` tries to update it again, which MongoDB doesn't allow.

### Fix

The explicit check for dirty _id has been removed, and the behavior now relies on MongoDB itself to throw an error if _id is mutated.

### Checklist

- [x] Tests added

