### PR TITLE
PHPORM-255 Enable disabling the `id` to `_id` field rename in embedded documents

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -54,7 +54,7 @@ class Connection extends BaseConnection
     private ?CommandSubscriber $commandSubscriber = null;
 
     /** @var bool Whether to rename the rename "id" into "_id" for embedded documents. */
-    private bool $renameEmbeddedIdField = true;
+    private bool $renameEmbeddedIdField;
 
     /**
      * Create a new database connection instance.
@@ -83,6 +83,8 @@ class Connection extends BaseConnection
         $this->useDefaultSchemaGrammar();
 
         $this->useDefaultQueryGrammar();
+
+        $this->renameEmbeddedIdField = $config['rename_embedded_id_field'] ?? true;
     }
 
     /**

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -53,6 +53,9 @@ class Connection extends BaseConnection
 
     private ?CommandSubscriber $commandSubscriber = null;
 
+    /** @var bool Whether to rename the rename "id" into "_id" for embedded documents. */
+    private bool $renameEmbeddedIdField = true;
+
     /**
      * Create a new database connection instance.
      */
@@ -393,6 +396,18 @@ class Connection extends BaseConnection
     public function __call($method, $parameters)
     {
         return $this->db->$method(...$parameters);
+    }
+
+    /** Set whether to rename "id" field into "_id" for embedded documents. */
+    public function setRenameEmbeddedIdField(bool $rename): void
+    {
+        $this->renameEmbeddedIdField = $rename;
+    }
+
+    /** Get whether to rename "id" field into "_id" for embedded documents. */
+    public function getRenameEmbeddedIdField(): bool
+    {
+        return $this->renameEmbeddedIdField;
     }
 
     /**

--- a/src/Eloquent/Builder.php
+++ b/src/Eloquent/Builder.php
@@ -18,6 +18,7 @@ use MongoDB\Laravel\Query\AggregationBuilder;
 use MongoDB\Model\BSONDocument;
 
 use function array_key_exists;
+use function array_map;
 use function array_replace;
 use function collect;
 use function is_array;
@@ -237,7 +238,7 @@ class Builder extends EloquentBuilder
         // Convert MongoCursor results to a collection of models.
         if ($results instanceof CursorInterface) {
             $results->setTypeMap(['root' => 'array', 'document' => 'array', 'array' => 'array']);
-            $results = $this->query->aliasIdForResult(iterator_to_array($results));
+            $results = array_map(fn ($document) => $this->query->aliasIdForResult($document), iterator_to_array($results));
 
             return $this->model->hydrate($results);
         }

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -126,8 +126,6 @@ class Builder extends BaseBuilder
      */
     public $options = [];
 
-    private ?bool $renameEmbeddedIdField;
-
     /**
      * All of the available clause operators.
      *

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -29,6 +29,7 @@ use MongoDB\Builder\Type\QueryInterface;
 use MongoDB\Builder\Type\SearchOperatorInterface;
 use MongoDB\Driver\Cursor;
 use MongoDB\Driver\ReadPreference;
+use MongoDB\Laravel\Connection;
 use Override;
 use RuntimeException;
 use stdClass;
@@ -83,6 +84,7 @@ use function substr;
 use function trait_exists;
 use function var_export;
 
+/** @method Connection getConnection() */
 class Builder extends BaseBuilder
 {
     private const REGEX_DELIMITERS = ['/', '#', '~'];
@@ -123,6 +125,8 @@ class Builder extends BaseBuilder
      * @var array
      */
     public $options = [];
+
+    private ?bool $renameEmbeddedIdField;
 
     /**
      * All of the available clause operators.
@@ -1764,9 +1768,9 @@ class Builder extends BaseBuilder
         throw new BadMethodCallException('This method is not supported by MongoDB');
     }
 
-    private function aliasIdForQuery(array $values): array
+    private function aliasIdForQuery(array $values, bool $root = true): array
     {
-        if (array_key_exists('id', $values)) {
+        if (array_key_exists('id', $values) && ($root || $this->getConnection()->getRenameEmbeddedIdField())) {
             if (array_key_exists('_id', $values) && $values['id'] !== $values['_id']) {
                 throw new InvalidArgumentException('Cannot have both "id" and "_id" fields.');
             }
@@ -1793,7 +1797,7 @@ class Builder extends BaseBuilder
             }
 
             // ".id" subfield are alias for "._id"
-            if (str_ends_with($key, '.id')) {
+            if (str_ends_with($key, '.id') && ($root || $this->getConnection()->getRenameEmbeddedIdField())) {
                 $newkey = substr($key, 0, -3) . '._id';
                 if (array_key_exists($newkey, $values) && $value !== $values[$newkey]) {
                     throw new InvalidArgumentException(sprintf('Cannot have both "%s" and "%s" fields.', $key, $newkey));
@@ -1806,7 +1810,7 @@ class Builder extends BaseBuilder
 
         foreach ($values as &$value) {
             if (is_array($value)) {
-                $value = $this->aliasIdForQuery($value);
+                $value = $this->aliasIdForQuery($value, false);
             } elseif ($value instanceof DateTimeInterface) {
                 $value = new UTCDateTime($value);
             }
@@ -1824,10 +1828,13 @@ class Builder extends BaseBuilder
      *
      * @template T of array|object
      */
-    public function aliasIdForResult(array|object $values): array|object
+    public function aliasIdForResult(array|object $values, bool $root = true): array|object
     {
         if (is_array($values)) {
-            if (array_key_exists('_id', $values) && ! array_key_exists('id', $values)) {
+            if (
+                array_key_exists('_id', $values) && ! array_key_exists('id', $values)
+                && ($root || $this->getConnection()->getRenameEmbeddedIdField())
+            ) {
                 $values['id'] = $values['_id'];
                 unset($values['_id']);
             }
@@ -1837,13 +1844,16 @@ class Builder extends BaseBuilder
                     $values[$key] = Date::instance($value->toDateTime())
                         ->setTimezone(new DateTimeZone(date_default_timezone_get()));
                 } elseif (is_array($value) || is_object($value)) {
-                    $values[$key] = $this->aliasIdForResult($value);
+                    $values[$key] = $this->aliasIdForResult($value, false);
                 }
             }
         }
 
         if ($values instanceof stdClass) {
-            if (property_exists($values, '_id') && ! property_exists($values, 'id')) {
+            if (
+                property_exists($values, '_id') && ! property_exists($values, 'id')
+                && ($root || $this->getConnection()->getRenameEmbeddedIdField())
+            ) {
                 $values->id = $values->_id;
                 unset($values->_id);
             }
@@ -1853,7 +1863,7 @@ class Builder extends BaseBuilder
                     $values->{$key} = Date::instance($value->toDateTime())
                         ->setTimezone(new DateTimeZone(date_default_timezone_get()));
                 } elseif (is_array($value) || is_object($value)) {
-                    $values->{$key} = $this->aliasIdForResult($value);
+                    $values->{$key} = $this->aliasIdForResult($value, false);
                 }
             }
         }

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -84,7 +84,7 @@ use function substr;
 use function trait_exists;
 use function var_export;
 
-/** @method Connection getConnection() */
+/** @property Connection $connection */
 class Builder extends BaseBuilder
 {
     private const REGEX_DELIMITERS = ['/', '#', '~'];
@@ -1770,7 +1770,7 @@ class Builder extends BaseBuilder
 
     private function aliasIdForQuery(array $values, bool $root = true): array
     {
-        if (array_key_exists('id', $values) && ($root || $this->getConnection()->getRenameEmbeddedIdField())) {
+        if (array_key_exists('id', $values) && ($root || $this->connection->getRenameEmbeddedIdField())) {
             if (array_key_exists('_id', $values) && $values['id'] !== $values['_id']) {
                 throw new InvalidArgumentException('Cannot have both "id" and "_id" fields.');
             }
@@ -1797,7 +1797,7 @@ class Builder extends BaseBuilder
             }
 
             // ".id" subfield are alias for "._id"
-            if (str_ends_with($key, '.id') && ($root || $this->getConnection()->getRenameEmbeddedIdField())) {
+            if (str_ends_with($key, '.id') && ($root || $this->connection->getRenameEmbeddedIdField())) {
                 $newkey = substr($key, 0, -3) . '._id';
                 if (array_key_exists($newkey, $values) && $value !== $values[$newkey]) {
                     throw new InvalidArgumentException(sprintf('Cannot have both "%s" and "%s" fields.', $key, $newkey));
@@ -1833,7 +1833,7 @@ class Builder extends BaseBuilder
         if (is_array($values)) {
             if (
                 array_key_exists('_id', $values) && ! array_key_exists('id', $values)
-                && ($root || $this->getConnection()->getRenameEmbeddedIdField())
+                && ($root || $this->connection->getRenameEmbeddedIdField())
             ) {
                 $values['id'] = $values['_id'];
                 unset($values['_id']);
@@ -1852,7 +1852,7 @@ class Builder extends BaseBuilder
         if ($values instanceof stdClass) {
             if (
                 property_exists($values, '_id') && ! property_exists($values, 'id')
-                && ($root || $this->getConnection()->getRenameEmbeddedIdField())
+                && ($root || $this->connection->getRenameEmbeddedIdField())
             ) {
                 $values->id = $values->_id;
                 unset($values->_id);

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -12,7 +12,6 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Tests\Database\DatabaseQueryBuilderTest;
 use InvalidArgumentException;
 use LogicException;
-use Mockery as m;
 use MongoDB\BSON\Regex;
 use MongoDB\BSON\UTCDateTime;
 use MongoDB\Driver\ReadPreference;
@@ -39,7 +38,7 @@ class BuilderTest extends TestCase
             $this->markTestSkipped(sprintf('Method "%s::%s()" does not exist.', Builder::class, $requiredMethod));
         }
 
-        $builder = $build(self::getBuilder());
+        $builder = $build($this->getBuilder());
         $this->assertInstanceOf(Builder::class, $builder);
         $mql = $builder->toMql();
 
@@ -1447,7 +1446,7 @@ class BuilderTest extends TestCase
     #[DataProvider('provideExceptions')]
     public function testException($class, $message, Closure $build): void
     {
-        $builder = self::getBuilder();
+        $builder = $this->getBuilder();
 
         $this->expectException($class);
         $this->expectExceptionMessage($message);
@@ -1545,7 +1544,7 @@ class BuilderTest extends TestCase
     #[DataProvider('getEloquentMethodsNotSupported')]
     public function testEloquentMethodsNotSupported(Closure $callback)
     {
-        $builder = self::getBuilder();
+        $builder = $this->getBuilder();
 
         $this->expectException(BadMethodCallException::class);
         $this->expectExceptionMessage('This method is not supported by MongoDB');
@@ -1600,12 +1599,38 @@ class BuilderTest extends TestCase
         yield 'orWhereIntegerNotInRaw' => [fn (Builder $builder) => $builder->orWhereIntegerNotInRaw('id', ['1a', 2])];
     }
 
-    private static function getBuilder(): Builder
+    public function testRenameEmbeddedIdFieldCanBeDisabled()
     {
-        $connection = m::mock(Connection::class);
-        $processor  = m::mock(Processor::class);
-        $connection->shouldReceive('getSession')->andReturn(null);
-        $connection->shouldReceive('getQueryGrammar')->andReturn(new Grammar($connection));
+        $builder = $this->getBuilder(false);
+        $this->assertFalse($builder->getConnection()->getRenameEmbeddedIdField());
+
+        $mql = $builder
+            ->where('id', '=', 10)
+            ->where('nested.id', '=', 20)
+            ->where('embed', '=', ['id' => 30])
+            ->toMql();
+
+        $this->assertEquals([
+            'find' => [
+                [
+                    '$and' => [
+                        ['_id' => 10],
+                        ['nested.id' => 20],
+                        ['embed' => ['id' => 30]],
+                    ],
+                ],
+                ['typeMap' => ['root' => 'object', 'document' => 'array']],
+            ],
+        ], $mql);
+    }
+
+    private function getBuilder(bool $renameEmbeddedIdField = true): Builder
+    {
+        $connection = $this->createStub(Connection::class);
+        $connection->method('getRenameEmbeddedIdField')->willReturn($renameEmbeddedIdField);
+        $processor  = $this->createStub(Processor::class);
+        $connection->method('getSession')->willReturn(null);
+        $connection->method('getQueryGrammar')->willReturn(new Grammar($connection));
 
         return new Builder($connection, null, $processor);
     }

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -20,10 +20,12 @@ use MongoDB\BSON\Regex;
 use MongoDB\BSON\UTCDateTime;
 use MongoDB\Collection;
 use MongoDB\Driver\Cursor;
+use MongoDB\Driver\CursorInterface;
 use MongoDB\Driver\Monitoring\CommandFailedEvent;
 use MongoDB\Driver\Monitoring\CommandStartedEvent;
 use MongoDB\Driver\Monitoring\CommandSubscriber;
 use MongoDB\Driver\Monitoring\CommandSucceededEvent;
+use MongoDB\Laravel\Connection;
 use MongoDB\Laravel\Query\Builder;
 use MongoDB\Laravel\Tests\Models\Item;
 use MongoDB\Laravel\Tests\Models\User;
@@ -334,6 +336,93 @@ class QueryBuilderTest extends TestCase
         $results = DB::table('users')->whereRaw(['age' => 20])->get();
         $this->assertCount(1, $results);
         $this->assertEquals('Jane Doe', $results[0]->name);
+    }
+
+    public function testRawResultRenameId()
+    {
+        $connection = DB::connection('mongodb');
+        self::assertInstanceOf(Connection::class, $connection);
+
+        $date = Carbon::createFromDate(1986, 12, 31)->setTime(12, 0, 0);
+        User::insert([
+            ['id' => 1, 'name' => 'Jane Doe', 'address' => ['id' => 11, 'city' => 'Ghent'], 'birthday' => $date],
+            ['id' => 2, 'name' => 'John Doe', 'address' => ['id' => 12, 'city' => 'Brussels'], 'birthday' => $date],
+        ]);
+
+        // Using raw database query, result is not altered
+        $results = $connection->table('users')->raw(fn (Collection $collection) => $collection->find([]));
+        self::assertInstanceOf(CursorInterface::class, $results);
+        $results = $results->toArray();
+        self::assertCount(2, $results);
+
+        self::assertObjectHasProperty('_id', $results[0]);
+        self::assertObjectNotHasProperty('id', $results[0]);
+        self::assertSame(1, $results[0]->_id);
+
+        self::assertObjectHasProperty('_id', $results[0]->address);
+        self::assertObjectNotHasProperty('id', $results[0]->address);
+        self::assertSame(11, $results[0]->address->_id);
+
+        self::assertInstanceOf(UTCDateTime::class, $results[0]->birthday);
+
+        // Using Eloquent query, result is transformed
+        self::assertTrue($connection->getRenameEmbeddedIdField());
+        $results = User::raw(fn (Collection $collection) => $collection->find([]));
+        self::assertInstanceOf(LaravelCollection::class, $results);
+        self::assertCount(2, $results);
+
+        $attributes = $results->first()->getAttributes();
+        self::assertArrayHasKey('id', $attributes);
+        self::assertArrayNotHasKey('_id', $attributes);
+        self::assertSame(1, $attributes['id']);
+
+        self::assertArrayHasKey('id', $attributes['address']);
+        self::assertArrayNotHasKey('_id', $attributes['address']);
+        self::assertSame(11, $attributes['address']['id']);
+
+        self::assertEquals($date, $attributes['birthday']);
+
+        // Single result
+        $result = User::raw(fn (Collection $collection) => $collection->findOne([], ['typeMap' => ['root' => 'object', 'document' => 'array']]));
+        self::assertInstanceOf(User::class, $result);
+
+        $attributes = $result->getAttributes();
+        self::assertArrayHasKey('id', $attributes);
+        self::assertArrayNotHasKey('_id', $attributes);
+        self::assertSame(1, $attributes['id']);
+
+        self::assertArrayHasKey('id', $attributes['address']);
+        self::assertArrayNotHasKey('_id', $attributes['address']);
+        self::assertSame(11, $attributes['address']['id']);
+
+        // Change the renameEmbeddedIdField option
+        $connection->setRenameEmbeddedIdField(false);
+
+        $results = User::raw(fn (Collection $collection) => $collection->find([]));
+        self::assertInstanceOf(LaravelCollection::class, $results);
+        self::assertCount(2, $results);
+
+        $attributes = $results->first()->getAttributes();
+        self::assertArrayHasKey('id', $attributes);
+        self::assertArrayNotHasKey('_id', $attributes);
+        self::assertSame(1, $attributes['id']);
+
+        self::assertArrayHasKey('_id', $attributes['address']);
+        self::assertArrayNotHasKey('id', $attributes['address']);
+        self::assertSame(11, $attributes['address']['_id']);
+
+        // Single result
+        $result = User::raw(fn (Collection $collection) => $collection->findOne([]));
+        self::assertInstanceOf(User::class, $result);
+
+        $attributes = $result->getAttributes();
+        self::assertArrayHasKey('id', $attributes);
+        self::assertArrayNotHasKey('_id', $attributes);
+        self::assertSame(1, $attributes['id']);
+
+        self::assertArrayHasKey('_id', $attributes['address']);
+        self::assertArrayNotHasKey('id', $attributes['address']);
+        self::assertSame(11, $attributes['address']['_id']);
     }
 
     public function testPush()


### PR DESCRIPTION
Fix PHPORM-255 
Fix #3184

To disable the automatic conversion of `id` to `_id` and store `id` fields in the database for embedded documents, set the connection setting using the new method:
```php
DB::connection('mongodb')->setRenameEmbeddedIdField(false);
```

### Checklist

- [x] Add tests and ensure they pass
