### PR TITLE
PHPORM-311 Fix Update of numeric field name

### DIFF
--- a/src/Eloquent/Builder.php
+++ b/src/Eloquent/Builder.php
@@ -309,7 +309,7 @@ class Builder extends EloquentBuilder
         }
 
         $column = $this->model->getUpdatedAtColumn();
-        $values = array_merge(
+        $values = array_replace(
             [$column => $this->model->freshTimestampString()],
             $values,
         );

--- a/src/Eloquent/Builder.php
+++ b/src/Eloquent/Builder.php
@@ -18,7 +18,7 @@ use MongoDB\Laravel\Query\AggregationBuilder;
 use MongoDB\Model\BSONDocument;
 
 use function array_key_exists;
-use function array_merge;
+use function array_replace;
 use function collect;
 use function is_array;
 use function is_object;
@@ -270,7 +270,7 @@ class Builder extends EloquentBuilder
 
         // createOrFirst is not supported in transaction.
         if ($this->getConnection()->getSession()?->isInTransaction()) {
-            return $this->create(array_merge($attributes, $values));
+            return $this->create(array_replace($attributes, $values));
         }
 
         return $this->createOrFirst($attributes, $values);
@@ -284,7 +284,7 @@ class Builder extends EloquentBuilder
         }
 
         try {
-            return $this->create(array_merge($attributes, $values));
+            return $this->create(array_replace($attributes, $values));
         } catch (BulkWriteException $e) {
             if ($e->getCode() === self::DUPLICATE_KEY_ERROR) {
                 return $this->where($attributes)->first() ?? throw $e;

--- a/src/Eloquent/DocumentModel.php
+++ b/src/Eloquent/DocumentModel.php
@@ -30,7 +30,7 @@ use ValueError;
 
 use function array_key_exists;
 use function array_keys;
-use function array_merge;
+use function array_replace;
 use function array_unique;
 use function array_values;
 use function class_basename;
@@ -192,7 +192,7 @@ trait DocumentModel
         // to a Carbon or CarbonImmutable instance.
         // @see Model::setAttribute()
         if ($this->hasCast($key) && $value instanceof CarbonInterface) {
-            $value->settings(array_merge($value->getSettings(), ['toStringFormat' => $this->getDateFormat()]));
+            $value->settings(array_replace($value->getSettings(), ['toStringFormat' => $this->getDateFormat()]));
 
             // "date" cast resets the time to 00:00:00.
             $castType = $this->getCasts()[$key];

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -40,6 +40,7 @@ use function array_is_list;
 use function array_key_exists;
 use function array_map;
 use function array_merge;
+use function array_replace;
 use function array_values;
 use function assert;
 use function blank;
@@ -426,7 +427,7 @@ class Builder extends BaseBuilder
 
             // Add custom query options
             if (count($this->options)) {
-                $options = array_merge($options, $this->options);
+                $options = array_replace($options, $this->options);
             }
 
             $options = $this->inheritConnectionOptions($options);
@@ -450,7 +451,7 @@ class Builder extends BaseBuilder
 
         // Add custom projections.
         if ($this->projections) {
-            $projection = array_merge($projection, $this->projections);
+            $projection = array_replace($projection, $this->projections);
         }
 
         $options = [];
@@ -484,7 +485,7 @@ class Builder extends BaseBuilder
 
         // Add custom query options
         if (count($this->options)) {
-            $options = array_merge($options, $this->options);
+            $options = array_replace($options, $this->options);
         }
 
         $options = $this->inheritConnectionOptions($options);

--- a/src/Relations/BelongsToMany.php
+++ b/src/Relations/BelongsToMany.php
@@ -14,7 +14,7 @@ use MongoDB\Laravel\Eloquent\Model as DocumentModel;
 use function array_diff;
 use function array_keys;
 use function array_map;
-use function array_merge;
+use function array_replace;
 use function array_values;
 use function assert;
 use function count;
@@ -164,7 +164,7 @@ class BelongsToMany extends EloquentBelongsToMany
         // Now we are finally ready to attach the new records. Note that we'll disable
         // touching until after the entire operation is complete so we don't fire a
         // ton of touch operations until we are totally done syncing the records.
-        $changes = array_merge(
+        $changes = array_replace(
             $changes,
             $this->attachNew($records, $current, false),
         );

--- a/src/Relations/MorphToMany.php
+++ b/src/Relations/MorphToMany.php
@@ -15,8 +15,8 @@ use function array_diff;
 use function array_key_exists;
 use function array_keys;
 use function array_map;
-use function array_merge;
 use function array_reduce;
+use function array_replace;
 use function array_values;
 use function collect;
 use function count;
@@ -190,7 +190,7 @@ class MorphToMany extends EloquentMorphToMany
         // Now we are finally ready to attach the new records. Note that we'll disable
         // touching until after the entire operation is complete so we don't fire a
         // ton of touch operations until we are totally done syncing the records.
-        $changes = array_merge(
+        $changes = array_replace(
             $changes,
             $this->attachNew($records, $current, false),
         );

--- a/src/Scout/ScoutEngine.php
+++ b/src/Scout/ScoutEngine.php
@@ -29,7 +29,7 @@ use TypeError;
 use function array_column;
 use function array_flip;
 use function array_map;
-use function array_merge;
+use function array_replace;
 use function assert;
 use function call_user_func;
 use function class_uses_recursive;
@@ -117,7 +117,7 @@ final class ScoutEngine extends Engine
 
             unset($searchableData['_id']);
 
-            $searchableData = array_merge($searchableData, $model->scoutMetadata());
+            $searchableData = array_replace($searchableData, $model->scoutMetadata());
 
             /** Convert the __soft_deleted set by {@see Searchable::pushSoftDeleteMetadata()}
              * into a boolean for efficient storage and indexing. */

--- a/tests/Ticket/GH3335Test.php
+++ b/tests/Ticket/GH3335Test.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Laravel\Tests\Ticket;
+
+use MongoDB\Laravel\Tests\Models\Location;
+use MongoDB\Laravel\Tests\TestCase;
+
+/** @see https://github.com/mongodb/laravel-mongodb/discussions/3335 */
+class GH3335Test extends TestCase
+{
+    public function tearDown(): void
+    {
+        Location::truncate();
+
+        parent::tearDown();
+    }
+
+    public function testNumericalFieldName()
+    {
+        $model = new Location();
+        $model->id = 'foo';
+        $model->save();
+
+        $model = Location::find('foo');
+        $model->{'38'} = 'PHP';
+        $model->save();
+
+        $model = Location::find('foo');
+        self::assertSame('PHP', $model->{'38'});
+    }
+}


### PR DESCRIPTION
Fix PHPORM-311
Fix https://github.com/mongodb/laravel-mongodb/discussions/3335 @vipinpapnai

`array_merge` changes the index of numeric keys, whereas `array_replace` keeps the keys.

### Checklist

- [x] Add tests and ensure they pass
