### PR TITLE
Fixes: getting immutable_datetime property fails if `Date::use(CarbonImmutable::class)` is set

### DIFF
--- a/src/Eloquent/DocumentModel.php
+++ b/src/Eloquent/DocumentModel.php
@@ -128,7 +128,7 @@ trait DocumentModel
      *
      * @param  mixed $value
      */
-    protected function asDateTime($value): Carbon
+    protected function asDateTime($value): DateTimeInterface
     {
         // Convert UTCDateTime instances to Carbon.
         if ($value instanceof UTCDateTime) {

--- a/src/Eloquent/DocumentModel.php
+++ b/src/Eloquent/DocumentModel.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace MongoDB\Laravel\Eloquent;
 
 use BackedEnum;
-use Carbon\Carbon;
 use Carbon\CarbonInterface;
 use DateTimeInterface;
 use DateTimeZone;

--- a/tests/DateTimeImmutableTest.php
+++ b/tests/DateTimeImmutableTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Laravel\Tests\Eloquent;
+
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Facades\Date;
+use MongoDB\Laravel\Eloquent\DocumentModel;
+use MongoDB\Laravel\Tests\Models\Anniversary;
+use MongoDB\Laravel\Tests\TestCase;
+
+use function assert;
+
+final class DateTimeImmutableTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Date::use(CarbonImmutable::class);
+        Anniversary::truncate();
+    }
+
+    public function testCanReturnCarbonImmutableObject(): void
+    {
+        Date::use(CarbonImmutable::class);
+
+        Anniversary::create([
+            'name' => 'John',
+            'anniversary' => new CarbonImmutable('2020-01-01 00:00:00'),
+        ]);
+
+        $anniversary = Anniversary::sole();
+        assert($anniversary instanceof Anniversary);
+        self::assertInstanceOf(CarbonImmutable::class, $anniversary->anniversary);
+
+        Date::useDefault();
+    }
+}

--- a/tests/DateTimeImmutableTest.php
+++ b/tests/DateTimeImmutableTest.php
@@ -23,6 +23,8 @@ final class DateTimeImmutableTest extends TestCase
     protected function tearDown(): void
     {
         Date::useDefault();
+
+        parent::tearDown();
     }
 
     public function testCanReturnCarbonImmutableObject(): void

--- a/tests/DateTimeImmutableTest.php
+++ b/tests/DateTimeImmutableTest.php
@@ -20,6 +20,11 @@ final class DateTimeImmutableTest extends TestCase
         Anniversary::truncate();
     }
 
+    protected function tearDown(): void
+    {
+        Date::useDefault();
+    }
+
     public function testCanReturnCarbonImmutableObject(): void
     {
         Date::use(CarbonImmutable::class);
@@ -32,7 +37,5 @@ final class DateTimeImmutableTest extends TestCase
         $anniversary = Anniversary::sole();
         assert($anniversary instanceof Anniversary);
         self::assertInstanceOf(CarbonImmutable::class, $anniversary->anniversary);
-
-        Date::useDefault();
     }
 }

--- a/tests/DateTimeImmutableTest.php
+++ b/tests/DateTimeImmutableTest.php
@@ -18,7 +18,6 @@ final class DateTimeImmutableTest extends TestCase
     {
         parent::setUp();
 
-        Date::use(CarbonImmutable::class);
         Anniversary::truncate();
     }
 

--- a/tests/Models/Anniversary.php
+++ b/tests/Models/Anniversary.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Laravel\Tests\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use MongoDB\Laravel\Eloquent\DocumentModel;
+use MongoDB\Laravel\Eloquent\Model as Eloquent;
+use MongoDB\Laravel\Query\Builder;
+
+/**
+ * @property string $name
+ * @property string $anniversary
+ * @mixin Eloquent
+ * @method static Builder create(...$values)
+ * @method static Builder truncate()
+ * @method static Eloquent sole(...$parameters)
+ */
+class Anniversary extends Model
+{
+    use DocumentModel;
+
+    protected $keyType = 'string';
+    protected $connection = 'mongodb';
+    protected $table = 'anniversary';
+    protected $fillable   = ['name', 'anniversary'];
+
+    protected $casts = ['anniversary' => 'immutable_datetime'];
+}

--- a/tests/PropertyTest.php
+++ b/tests/PropertyTest.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace MongoDB\Laravel\Tests\Eloquent;
 
-use Carbon\CarbonImmutable;
-use Illuminate\Support\Facades\Date;
-use MongoDB\Laravel\Tests\Models\Anniversary;
 use MongoDB\Laravel\Tests\Models\HiddenAnimal;
 use MongoDB\Laravel\Tests\TestCase;
 
@@ -19,7 +16,6 @@ final class PropertyTest extends TestCase
         parent::setUp();
 
         HiddenAnimal::truncate();
-        Anniversary::truncate();
     }
 
     public function testCanHideCertainProperties(): void
@@ -38,19 +34,5 @@ final class PropertyTest extends TestCase
         self::assertArrayHasKey('name', $hiddenAnimal->toArray());
         self::assertArrayNotHasKey('country', $hiddenAnimal->toArray(), 'the country column should be hidden');
         self::assertArrayHasKey('can_be_eaten', $hiddenAnimal->toArray());
-    }
-
-    public function testCanReturnCarbonImmutableObject(): void
-    {
-        Date::use(CarbonImmutable::class);
-
-        Anniversary::create([
-            'name' => 'John',
-            'anniversary' => new CarbonImmutable('2020-01-01 00:00:00'),
-        ]);
-
-        $anniversary = Anniversary::sole();
-        assert($anniversary instanceof Anniversary);
-        self::assertInstanceOf(CarbonImmutable::class, $anniversary->anniversary);
     }
 }

--- a/tests/PropertyTest.php
+++ b/tests/PropertyTest.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace MongoDB\Laravel\Tests\Eloquent;
 
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Facades\Date;
+use MongoDB\Laravel\Tests\Models\Anniversary;
 use MongoDB\Laravel\Tests\Models\HiddenAnimal;
 use MongoDB\Laravel\Tests\TestCase;
 
@@ -16,6 +19,7 @@ final class PropertyTest extends TestCase
         parent::setUp();
 
         HiddenAnimal::truncate();
+        Anniversary::truncate();
     }
 
     public function testCanHideCertainProperties(): void
@@ -34,5 +38,19 @@ final class PropertyTest extends TestCase
         self::assertArrayHasKey('name', $hiddenAnimal->toArray());
         self::assertArrayNotHasKey('country', $hiddenAnimal->toArray(), 'the country column should be hidden');
         self::assertArrayHasKey('can_be_eaten', $hiddenAnimal->toArray());
+    }
+
+    public function testCanReturnCarbonImmutableObject(): void
+    {
+        Date::use(CarbonImmutable::class);
+
+        Anniversary::create([
+            'name' => 'John',
+            'anniversary' => new CarbonImmutable('2020-01-01 00:00:00'),
+        ]);
+
+        $anniversary = Anniversary::sole();
+        assert($anniversary instanceof Anniversary);
+        self::assertInstanceOf(CarbonImmutable::class, $anniversary->anniversary);
     }
 }


### PR DESCRIPTION
This PR fixes the issue #3341 .

Basically when `Date::use(CarbonImmutable::class);` is added. The method `asDateTime` in `DocumentModel` trait throws an exception. I've changed the return type of `asDateTime` method from `Carbon` to `DateTimeInterface`.

### Checklist

- [x] Add tests and ensure they pass
