### PR TITLE
DOCSP-49217: disable id alias conversion in embedded docs

### DIFF
--- a/docs/fundamentals/connection/connection-options.txt
+++ b/docs/fundamentals/connection/connection-options.txt
@@ -362,10 +362,28 @@ to ``_id`` for both top level and embedded fields when querying and
 storing data.
 
 When using {+odm-long+} v5.3 or later, you can disable the automatic
-conversion of ``id`` to ``_id`` for embedded documents. To do so, set
-the ``renameEmbeddedIdField`` connection setting to ``false``, as
-shown in the following code:
+conversion of ``id`` to ``_id`` for embedded documents. To do so,
+perform either of the following actions:
 
-.. code-block:: php
+1. Set the ``rename_embedded_id_field`` setting to ``false`` in your
+   ``config/database.php`` file:
 
-   DB::connection('mongodb')->setRenameEmbeddedIdField(false);
+   .. code-block:: php
+      :emphasize-lines: 6
+   
+      'connections' => [
+          'mongodb' => [
+              'dsn' => 'mongodb+srv://mongodb0.example.com/',
+              'driver' => 'mongodb',
+              'database' => 'sample_mflix',
+              'rename_embedded_id_field' => false,
+              // Other settings
+          ],
+      ],
+
+#. Pass ``false`` to the ``setRenameEmbeddedIdField()`` method in your
+   application:
+
+   .. code-block:: php
+   
+      DB::connection('mongodb')->setRenameEmbeddedIdField(false);

--- a/docs/fundamentals/connection/connection-options.txt
+++ b/docs/fundamentals/connection/connection-options.txt
@@ -32,6 +32,7 @@ This guide covers the following topics:
 
 - :ref:`laravel-connection-auth-options`
 - :ref:`laravel-driver-options`
+- :ref:`laravel-disable-id-alias`
 
 .. _laravel-connection-auth-options:
 
@@ -349,3 +350,22 @@ item, as shown in the following example:
 
 See the `$driverOptions: array <https://www.mongodb.com/docs/php-library/current/reference/method/MongoDBClient__construct/#parameters>`__
 section of the {+php-library+} documentation for a list of driver options.
+
+.. _laravel-disable-id-alias:
+
+Disable Use of id Field Name Conversion
+---------------------------------------
+
+Starting in {+odm-long+} v5.0, ``id`` is an alias for the ``_id`` field
+in MongoDB documents, and the library automatically converts ``id``
+to ``_id`` for both top level and embedded fields when querying and
+storing data.
+
+When using {+odm-long+} v5.3 or later, you can disable the automatic
+conversion of ``id`` to ``_id`` for embedded documents. To do so, set
+the ``renameEmbeddedIdField`` connection setting to ``false``, as
+shown in the following code:
+
+.. code-block:: php
+
+   DB::connection('mongodb')->setRenameEmbeddedIdField(false);

--- a/docs/fundamentals/connection/connection-options.txt
+++ b/docs/fundamentals/connection/connection-options.txt
@@ -387,3 +387,10 @@ perform either of the following actions:
    .. code-block:: php
    
       DB::connection('mongodb')->setRenameEmbeddedIdField(false);
+
+.. important::
+
+   We recommend using this option only to provide backwards
+   compatibility with existing document schemas. In new projects,
+   avoid using ``id`` for field names in embedded documents so that
+   you can maintain {+odm-long+}'s default behavior.

--- a/docs/query-builder.txt
+++ b/docs/query-builder.txt
@@ -195,7 +195,7 @@ the value of the ``title`` field is ``"Back to the Future"``:
    :start-after: begin query orWhere
    :end-before: end query orWhere
 
-.. note::
+.. note:: id Alias
 
    You can use the ``id`` alias in your queries to represent the
    ``_id`` field in MongoDB documents, as shown in the preceding
@@ -207,6 +207,9 @@ the value of the ``title`` field is ``"Back to the Future"``:
    
    Because of this behavior, you cannot have two separate ``id`` and ``_id``
    fields in your documents.
+
+   To learn how to disable this behavior for embedded documents, see the
+   :ref:`laravel-disable-id-alias` section of the Connection Options guide.
 
 .. _laravel-query-builder-logical-and:
 

--- a/docs/upgrade.txt
+++ b/docs/upgrade.txt
@@ -128,7 +128,9 @@ This library version introduces the following breaking changes:
   filter, use the ``DB::where()`` method instead of ``Model::raw()``.
 
   Starting in v5.3, you can disable automatic conversion of ``id`` to
-  ``_id`` for embedded documents. To learn more, see the :ref:`laravel-disable-id-alias` section of the Connection Options guide..
+  ``_id`` for embedded documents. To learn more, see the
+  :ref:`laravel-disable-id-alias` section of the Connection Options
+  guide.
 
 - Removes support for the ``$collection`` property. The following code shows
   how to assign a MongoDB collection to a variable in your ``User`` class in

--- a/docs/upgrade.txt
+++ b/docs/upgrade.txt
@@ -127,6 +127,9 @@ This library version introduces the following breaking changes:
   method results before hydrating a Model instance. When passing a complex query
   filter, use the ``DB::where()`` method instead of ``Model::raw()``.
 
+  Starting in v5.3, you can disable automatic conversion of ``id`` to
+  ``_id`` for embedded documents. To learn more, see the :ref:`laravel-disable-id-alias` section of the Connection Options guide..
+
 - Removes support for the ``$collection`` property. The following code shows
   how to assign a MongoDB collection to a variable in your ``User`` class in
   older versions compared to v5.0:


### PR DESCRIPTION
https://jira.mongodb.org/browse/DOCSP-49217

Adds documentation about disabling id -> _id conversion in embedded fields.

[STAGING](https://deploy-preview-180--docs-laravel.netlify.app/fundamentals/connection/connection-options/#disable-use-of-id-field-name-conversion)

cross links:
[QB page](https://deploy-preview-180--docs-laravel.netlify.app/query-builder/#logical-or-example)
[Upgrade page](https://deploy-preview-180--docs-laravel.netlify.app/upgrade/#version-5.x-breaking-changes)

### Checklist

- [ ] Add tests and ensure they pass
