### PR TITLE
PHPORM-310 Create dedicated session handler

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -11,6 +11,9 @@ parameters:
 
     editorUrl: 'phpstorm://open?file=%%file%%&line=%%line%%'
 
+    universalObjectCratesClasses:
+        - MongoDB\BSON\Document
+
     ignoreErrors:
         - '#Unsafe usage of new static#'
         - '#Call to an undefined method [a-zA-Z0-9\\_\<\>\(\)]+::[a-zA-Z]+\(\)#'

--- a/src/MongoDBServiceProvider.php
+++ b/src/MongoDBServiceProvider.php
@@ -23,8 +23,8 @@ use MongoDB\Laravel\Cache\MongoStore;
 use MongoDB\Laravel\Eloquent\Model;
 use MongoDB\Laravel\Queue\MongoConnector;
 use MongoDB\Laravel\Scout\ScoutEngine;
+use MongoDB\Laravel\Session\MongoDbSessionHandler;
 use RuntimeException;
-use Symfony\Component\HttpFoundation\Session\Storage\Handler\MongoDbSessionHandler;
 
 use function assert;
 use function class_exists;
@@ -67,12 +67,10 @@ class MongoDBServiceProvider extends ServiceProvider
                 assert($connection instanceof Connection, new InvalidArgumentException(sprintf('The database connection "%s" used for the session does not use the "mongodb" driver.', $connectionName)));
 
                 return new MongoDbSessionHandler(
-                    $connection->getClient(),
-                    $app->config->get('session.options', []) + [
-                        'database' => $connection->getDatabaseName(),
-                        'collection' => $app->config->get('session.table') ?: 'sessions',
-                        'ttl' => $app->config->get('session.lifetime'),
-                    ],
+                    $connection,
+                    $app->config->get('session.table', 'sessions'),
+                    $app->config->get('session.lifetime'),
+                    $app,
                 );
             });
         });

--- a/src/Session/MongoDbSessionHandler.php
+++ b/src/Session/MongoDbSessionHandler.php
@@ -1,0 +1,112 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace MongoDB\Laravel\Session;
+
+use Illuminate\Session\DatabaseSessionHandler;
+use MongoDB\BSON\Binary;
+use MongoDB\BSON\UTCDateTime;
+use MongoDB\Collection;
+
+use function tap;
+use function time;
+
+/**
+ * Session handler using the MongoDB driver extension.
+ */
+final class MongoDbSessionHandler extends DatabaseSessionHandler
+{
+    private Collection $collection;
+
+    public function close(): bool
+    {
+        return true;
+    }
+
+    public function gc($lifetime): int
+    {
+        $result = $this->getCollection()->deleteMany(['last_activity' => ['$lt' => $this->getUTCDateTime(-$lifetime)]]);
+
+        return $result->getDeletedCount() ?? 0;
+    }
+
+    public function destroy($sessionId): bool
+    {
+        $this->getCollection()->deleteOne(['_id' => (string) $sessionId]);
+
+        return true;
+    }
+
+    public function read($sessionId): string|false
+    {
+        $result = $this->getCollection()->findOne(
+            ['_id' => (string) $sessionId, 'expires_at' => ['$gte' => $this->getUTCDateTime()]],
+            [
+                'projection' => ['_id' => false, 'payload' => true],
+                'typeMap' => ['root' => 'bson'],
+            ],
+        );
+
+        return $result ? (string) $result->payload : false;
+    }
+
+    public function write($sessionId, $data): bool
+    {
+        $payload = $this->getDefaultPayload($data);
+
+        $this->getCollection()->replaceOne(
+            ['_id' => (string) $sessionId],
+            $payload,
+            ['upsert' => true],
+        );
+
+        return true;
+    }
+
+    /** Creates a TTL index that automatically deletes expired objects. */
+    public function createTTLIndex(): void
+    {
+        $this->collection->createIndex(
+            // UTCDateTime field that holds the expiration date
+            ['expires_at' => 1],
+            // Delay to remove items after expiration
+            ['expireAfterSeconds' => 0],
+        );
+    }
+
+    protected function getDefaultPayload($data): array
+    {
+        $payload = [
+            'payload' => new Binary($data),
+            'last_activity' => $this->getUTCDateTime(),
+            'expires_at' => $this->getUTCDateTime($this->minutes * 60),
+        ];
+
+        if (! $this->container) {
+            return $payload;
+        }
+
+        return tap($payload, function (&$payload) {
+            $this->addUserInformation($payload)
+                ->addRequestInformation($payload);
+        });
+    }
+
+    private function getCollection(): Collection
+    {
+        return $this->collection ??= $this->connection->getCollection($this->table);
+    }
+
+    private function getUTCDateTime(int $additionalSeconds = 0): UTCDateTime
+    {
+        return new UTCDateTime((time() + $additionalSeconds * 60) * 1000);
+    }
+}

--- a/src/Session/MongoDbSessionHandler.php
+++ b/src/Session/MongoDbSessionHandler.php
@@ -107,6 +107,6 @@ final class MongoDbSessionHandler extends DatabaseSessionHandler
 
     private function getUTCDateTime(int $additionalSeconds = 0): UTCDateTime
     {
-        return new UTCDateTime((time() + $additionalSeconds * 60) * 1000);
+        return new UTCDateTime((time() + $additionalSeconds) * 1000);
     }
 }

--- a/src/Session/MongoDbSessionHandler.php
+++ b/src/Session/MongoDbSessionHandler.php
@@ -13,9 +13,11 @@ namespace MongoDB\Laravel\Session;
 
 use Illuminate\Session\DatabaseSessionHandler;
 use MongoDB\BSON\Binary;
+use MongoDB\BSON\Document;
 use MongoDB\BSON\UTCDateTime;
 use MongoDB\Collection;
 
+use function assert;
 use function tap;
 use function time;
 
@@ -54,6 +56,7 @@ final class MongoDbSessionHandler extends DatabaseSessionHandler
                 'typeMap' => ['root' => 'bson'],
             ],
         );
+        assert($result instanceof Document);
 
         return $result ? (string) $result->payload : false;
     }

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -868,7 +868,7 @@ class BuilderTest extends TestCase
                     [],
                 ],
             ],
-            fn (Builder $builder) => $builder->whereDate('created_at', '=', new DateTimeImmutable('2018-09-30 15:00:00 +02:00')),
+            fn (Builder $builder) => $builder->whereDate('created_at', '=', new DateTimeImmutable('2018-09-30 15:00:00 +00:00')),
         ];
 
         yield 'where date !=' => [

--- a/tests/SessionTest.php
+++ b/tests/SessionTest.php
@@ -5,7 +5,9 @@ namespace MongoDB\Laravel\Tests;
 use Illuminate\Session\DatabaseSessionHandler;
 use Illuminate\Session\SessionManager;
 use Illuminate\Support\Facades\DB;
-use Symfony\Component\HttpFoundation\Session\Storage\Handler\MongoDbSessionHandler;
+use MongoDB\Laravel\Session\MongoDbSessionHandler;
+use PHPUnit\Framework\Attributes\TestWith;
+use SessionHandlerInterface;
 
 class SessionTest extends TestCase
 {
@@ -16,21 +18,31 @@ class SessionTest extends TestCase
         parent::tearDown();
     }
 
-    public function testDatabaseSessionHandlerCompatibility()
+    /** @param class-string<SessionHandlerInterface> $class */
+    #[TestWith([DatabaseSessionHandler::class])]
+    #[TestWith([MongoDbSessionHandler::class])]
+    public function testSessionHandlerFunctionality(string $class)
     {
-        $sessionId = '123';
-
-        $handler = new DatabaseSessionHandler(
+        $handler = new $class(
             $this->app['db']->connection('mongodb'),
             'sessions',
             10,
         );
+
+        $sessionId = '123';
 
         $handler->write($sessionId, 'foo');
         $this->assertEquals('foo', $handler->read($sessionId));
 
         $handler->write($sessionId, 'bar');
         $this->assertEquals('bar', $handler->read($sessionId));
+
+        $handler->destroy($sessionId);
+        $this->assertEmpty($handler->read($sessionId));
+
+        $handler->write($sessionId, 'bar');
+        $handler->gc(-1);
+        $this->assertEmpty($handler->read($sessionId));
     }
 
     public function testDatabaseSessionHandlerRegistration()
@@ -64,6 +76,14 @@ class SessionTest extends TestCase
 
         $this->assertNotNull($session->getId());
 
+        $data = DB::connection('mongodb')
+            ->getCollection('sessions')
+            ->findOne(['_id' => $session->getId()]);
+
+        self::assertIsObject($data);
+        self::assertSame($session->getId(), $data->_id);
+
+        $session->remove('foo');
         $data = DB::connection('mongodb')
             ->getCollection('sessions')
             ->findOne(['_id' => $session->getId()]);


### PR DESCRIPTION
Fix PHPORM-310

The Symfony MongoDB SessionHandler doesn't work well with the Laravel framework; even if they implement the same interface, they are not used in the same way.

Creating a dedicated session handler that extends Laravel's `DatabaseSessionHandler` to leverage the its additional user and request informations.

The configuration is still the exact same: https://www.mongodb.com/docs/drivers/php/laravel-mongodb/upcoming/sessions/

### Checklist

- [x] Add tests and ensure they pass
