### PR TITLE
Validate PSR namespaces in CI

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -53,6 +53,9 @@ jobs:
         with:
           composer-options: "--no-suggest"
 
+      - name: "Validate PSR class names"
+        run: "composer dump-autoload --optimize --strict-psr"
+
       - name: "Format the code"
         continue-on-error: true
         run: |


### PR DESCRIPTION
Following https://github.com/mongodb/laravel-mongodb/pull/3361

I did not create a dedicated job as this is fast.