### PR TITLE
PHPORM-327 Fix invalid `assert` in `DatabaseSessionHandler::read()`

### DIFF
--- a/.github/workflows/build-ci-atlas.yml
+++ b/.github/workflows/build-ci-atlas.yml
@@ -91,4 +91,4 @@ jobs:
             -   name: "Run tests"
                 run: |
                   export MONGODB_URI="mongodb://127.0.0.1:27017/?directConnection=true"
-                  ./vendor/bin/phpunit --coverage-clover coverage.xml --group atlas-search
+                  php -d zend.assertions=1 ./vendor/bin/phpunit --coverage-clover coverage.xml --group atlas-search

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -118,4 +118,4 @@ jobs:
             -   name: "Run tests"
                 run: |
                   export MONGODB_URI="mongodb://127.0.0.1:27017/?replicaSet=rs"
-                  ./vendor/bin/phpunit --coverage-clover coverage.xml --exclude-group atlas-search
+                  php -d zend.assertions=1 ./vendor/bin/phpunit --coverage-clover coverage.xml --exclude-group atlas-search

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -23,6 +23,8 @@
         <env name="QUEUE_CONNECTION" value="database"/>
         <ini name="xdebug.mode" value="coverage"/>
         <ini name="memory_limit" value="-1"/>
+        <!-- Evaluate assertions, requires running with "php -d zend.assertions=1 vendor/bin/phpunit" -->
+        <!-- <ini name="zend.assertions=1" value="1" /> -->
     </php>
 
     <source restrictDeprecations="true"

--- a/src/Session/MongoDbSessionHandler.php
+++ b/src/Session/MongoDbSessionHandler.php
@@ -17,7 +17,6 @@ use MongoDB\BSON\Document;
 use MongoDB\BSON\UTCDateTime;
 use MongoDB\Collection;
 
-use function assert;
 use function tap;
 use function time;
 
@@ -56,9 +55,12 @@ final class MongoDbSessionHandler extends DatabaseSessionHandler
                 'typeMap' => ['root' => 'bson'],
             ],
         );
-        assert($result instanceof Document);
 
-        return $result ? (string) $result->payload : false;
+        if ($result instanceof Document) {
+            return (string) $result->payload;
+        }
+
+        return false;
     }
 
     public function write($sessionId, $data): bool


### PR DESCRIPTION
Fix PHPORM-327
Backports #3366 into branch 5.4
