### PR TITLE
`QueryBuilder` multiply and divide support

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -890,7 +890,13 @@ class Builder extends BaseBuilder
         return $this->incrementEach($decrement, $extra, $options);
     }
 
-    /** @inheritdoc */
+    /**
+     * Multiply a column's value by a given amount.
+     *
+     * @param  string     $column
+     * @param  float|int  $amount
+     * @return int
+     */
     public function multiply($column, $amount = 1, array $extra = [], array $options = [])
     {
         $query = ['$mul' => [(string) $column => $amount]];
@@ -911,7 +917,13 @@ class Builder extends BaseBuilder
         return $this->performUpdate($query, $options);
     }
 
-    /** @inheritdoc */
+    /**
+     * Divide a column's value by a given amount.
+     *
+     * @param  string     $column
+     * @param  float|int  $amount
+     * @return int
+     */
     public function divide($column, $amount = 1, array $extra = [], array $options = [])
     {
         return $this->multiply($column, 1 / $amount, $extra, $options);

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -897,7 +897,7 @@ class Builder extends BaseBuilder
      * @param  float|int  $amount
      * @return int
      */
-    public function multiply($column, $amount = 1, array $extra = [], array $options = [])
+    public function multiply($column, $amount, array $extra = [], array $options = [])
     {
         $query = ['$mul' => [(string) $column => $amount]];
 
@@ -924,7 +924,7 @@ class Builder extends BaseBuilder
      * @param  float|int  $amount
      * @return int
      */
-    public function divide($column, $amount = 1, array $extra = [], array $options = [])
+    public function divide($column, $amount, array $extra = [], array $options = [])
     {
         return $this->multiply($column, 1 / $amount, $extra, $options);
     }

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -891,6 +891,27 @@ class Builder extends BaseBuilder
     }
 
     /** @inheritdoc */
+    public function multiply($column, $amount = 1, array $extra = [], array $options = [])
+    {
+        $query = ['$mul' => [(string) $column => $amount]];
+
+        if (! empty($extra)) {
+            $query['$set'] = $extra;
+        }
+
+        // Protect
+        $this->where(function ($query) use ($column) {
+            $query->where($column, 'exists', false);
+
+            $query->orWhereNotNull($column);
+        });
+
+        $options = $this->inheritConnectionOptions($options);
+
+        return $this->performUpdate($query, $options);
+    }
+
+    /** @inheritdoc */
     public function pluck($column, $key = null)
     {
         $results = $this->get($key === null ? [$column] : [$column, $key]);

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -893,8 +893,9 @@ class Builder extends BaseBuilder
     /**
      * Multiply a column's value by a given amount.
      *
-     * @param  string     $column
-     * @param  float|int  $amount
+     * @param  string    $column
+     * @param  float|int $amount
+     *
      * @return int
      */
     public function multiply($column, $amount, array $extra = [], array $options = [])
@@ -920,8 +921,9 @@ class Builder extends BaseBuilder
     /**
      * Divide a column's value by a given amount.
      *
-     * @param  string     $column
-     * @param  float|int  $amount
+     * @param  string    $column
+     * @param  float|int $amount
+     *
      * @return int
      */
     public function divide($column, $amount, array $extra = [], array $options = [])

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -907,9 +907,9 @@ class Builder extends BaseBuilder
 
         // Protect
         $this->where(function ($query) use ($column) {
-            $query->where($column, 'exists', false);
+            $query->where($column, 'exists', true);
 
-            $query->orWhereNotNull($column);
+            $query->whereNotNull($column);
         });
 
         $options = $this->inheritConnectionOptions($options);

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -912,6 +912,12 @@ class Builder extends BaseBuilder
     }
 
     /** @inheritdoc */
+    public function divide($column, $amount = 1, array $extra = [], array $options = [])
+    {
+        return $this->multiply($column, 1 / $amount, $extra, $options);
+    }
+
+    /** @inheritdoc */
     public function pluck($column, $key = null)
     {
         $results = $this->get($key === null ? [$column] : [$column, $key]);

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -1052,6 +1052,42 @@ class QueryBuilderTest extends TestCase
         $this->assertEquals(1, $user->age);
     }
 
+    public function testMultiply()
+    {
+        DB::table('users')->insert([
+            ['name' => 'John Doe', 'salary' => 3000, 'note' => 'adult'],
+            ['name' => 'Jane Doe', 'salary' => 1000, 'note' => 'minor'],
+            ['name' => 'Robert Roe', 'salary' => null],
+            ['name' => 'Mark Moe'],
+        ]);
+
+        $user = DB::table('users')->where('name', 'John Doe')->first();
+        $this->assertEquals(3000, $user->salary);
+
+        DB::table('users')->where('name', 'John Doe')->multiply('salary');
+        $user = DB::table('users')->where('name', 'John Doe')->first();
+        $this->assertEquals(3000, $user->salary);
+
+        DB::table('users')->where('name', 'John Doe')->multiply('salary', 2);
+        $user = DB::table('users')->where('name', 'John Doe')->first();
+        $this->assertEquals(6000, $user->salary);
+
+        DB::table('users')->where('name', 'Jane Doe')->multiply('salary', 10, ['note' => 'adult']);
+        $user = DB::table('users')->where('name', 'Jane Doe')->first();
+        $this->assertEquals(10000, $user->salary);
+        $this->assertEquals('adult', $user->note);
+
+        DB::table('users')->multiply('salary');
+        $user = DB::table('users')->where('name', 'John Doe')->first();
+        $this->assertEquals(6000, $user->salary);
+        $user = DB::table('users')->where('name', 'Jane Doe')->first();
+        $this->assertEquals(10000, $user->salary);
+        $user = DB::table('users')->where('name', 'Robert Roe')->first();
+        $this->assertNull($user->salary);
+        $user = DB::table('users')->where('name', 'Mark Moe')->first();
+        $this->assertEquals(0, $user->salary);
+    }
+
     public function testProjections()
     {
         DB::table('items')->insert([

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -1098,7 +1098,7 @@ class QueryBuilderTest extends TestCase
         $user = DB::table('users')->where('name', 'Robert Roe')->first();
         $this->assertNull($user->salary);
         $user = DB::table('users')->where('name', 'Mark Moe')->first();
-        $this->assertEquals(0, $user->salary);
+        $this->assertFalse(isset($user->salary));
     }
 
     public function testProjections()

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -1052,36 +1052,49 @@ class QueryBuilderTest extends TestCase
         $this->assertEquals(1, $user->age);
     }
 
-    public function testMultiply()
+    public function testMultiplyAndDivide()
     {
         DB::table('users')->insert([
-            ['name' => 'John Doe', 'salary' => 3000, 'note' => 'adult'],
-            ['name' => 'Jane Doe', 'salary' => 1000, 'note' => 'minor'],
+            ['name' => 'John Doe', 'salary' => 88000, 'note' => 'senior'],
+            ['name' => 'Jane Doe', 'salary' => 64000, 'note' => 'junior'],
             ['name' => 'Robert Roe', 'salary' => null],
             ['name' => 'Mark Moe'],
         ]);
 
         $user = DB::table('users')->where('name', 'John Doe')->first();
-        $this->assertEquals(3000, $user->salary);
+        $this->assertEquals(88000, $user->salary);
 
         DB::table('users')->where('name', 'John Doe')->multiply('salary');
         $user = DB::table('users')->where('name', 'John Doe')->first();
-        $this->assertEquals(3000, $user->salary);
+        $this->assertEquals(88000, $user->salary);
+
+        DB::table('users')->where('name', 'John Doe')->divide('salary');
+        $user = DB::table('users')->where('name', 'John Doe')->first();
+        $this->assertEquals(88000, $user->salary);
 
         DB::table('users')->where('name', 'John Doe')->multiply('salary', 2);
         $user = DB::table('users')->where('name', 'John Doe')->first();
-        $this->assertEquals(6000, $user->salary);
+        $this->assertEquals(176000, $user->salary);
 
-        DB::table('users')->where('name', 'Jane Doe')->multiply('salary', 10, ['note' => 'adult']);
+        DB::table('users')->where('name', 'John Doe')->divide('salary', 2);
+        $user = DB::table('users')->where('name', 'John Doe')->first();
+        $this->assertEquals(88000, $user->salary);
+
+        DB::table('users')->where('name', 'Jane Doe')->multiply('salary', 10, ['note' => 'senior']);
         $user = DB::table('users')->where('name', 'Jane Doe')->first();
-        $this->assertEquals(10000, $user->salary);
-        $this->assertEquals('adult', $user->note);
+        $this->assertEquals(640000, $user->salary);
+        $this->assertEquals('senior', $user->note);
+
+        DB::table('users')->where('name', 'John Doe')->divide('salary', 2, ['note' => 'junior']);
+        $user = DB::table('users')->where('name', 'John Doe')->first();
+        $this->assertEquals(44000, $user->salary);
+        $this->assertEquals('junior', $user->note);
 
         DB::table('users')->multiply('salary');
         $user = DB::table('users')->where('name', 'John Doe')->first();
-        $this->assertEquals(6000, $user->salary);
+        $this->assertEquals(44000, $user->salary);
         $user = DB::table('users')->where('name', 'Jane Doe')->first();
-        $this->assertEquals(10000, $user->salary);
+        $this->assertEquals(640000, $user->salary);
         $user = DB::table('users')->where('name', 'Robert Roe')->first();
         $this->assertNull($user->salary);
         $user = DB::table('users')->where('name', 'Mark Moe')->first();

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -1064,11 +1064,11 @@ class QueryBuilderTest extends TestCase
         $user = DB::table('users')->where('name', 'John Doe')->first();
         $this->assertEquals(88000, $user->salary);
 
-        DB::table('users')->where('name', 'John Doe')->multiply('salary');
+        DB::table('users')->where('name', 'John Doe')->multiply('salary', 1);
         $user = DB::table('users')->where('name', 'John Doe')->first();
         $this->assertEquals(88000, $user->salary);
 
-        DB::table('users')->where('name', 'John Doe')->divide('salary');
+        DB::table('users')->where('name', 'John Doe')->divide('salary', 1);
         $user = DB::table('users')->where('name', 'John Doe')->first();
         $this->assertEquals(88000, $user->salary);
 
@@ -1090,7 +1090,7 @@ class QueryBuilderTest extends TestCase
         $this->assertEquals(44000, $user->salary);
         $this->assertEquals('junior', $user->note);
 
-        DB::table('users')->multiply('salary');
+        DB::table('users')->multiply('salary', 1);
         $user = DB::table('users')->where('name', 'John Doe')->first();
         $this->assertEquals(44000, $user->salary);
         $user = DB::table('users')->where('name', 'Jane Doe')->first();


### PR DESCRIPTION
Hello 👋🏻 

In this PR I have added `multiply` and `divide` to `QueryBuilder` .

### Usage
```php
DB::table('users')->where('name', 'John Doe')->multiply('salary');    // "salary" * 1
DB::table('users')->where('name', 'John Doe')->multiply('salary', 2); // "salary" * 2
DB::table('users')->where('name', 'John Doe')->divide('salary');      // "salary" / 1
DB::table('users')->where('name', 'John Doe')->divide('salary', 2);   // "salary" / 2
```

### Checklist

- [x] Add tests and ensure they pass
