### PR TITLE
PHPORM-330 Fix: Convert query duration time to milliseconds

### DIFF
--- a/src/CommandSubscriber.php
+++ b/src/CommandSubscriber.php
@@ -48,6 +48,6 @@ final class CommandSubscriber implements CommandSubscriberInterface
             }
         }
 
-        $this->connection->logQuery(Document::fromPHP($command)->toCanonicalExtendedJSON(), [], $event->getDurationMicros());
+        $this->connection->logQuery(Document::fromPHP($command)->toCanonicalExtendedJSON(), [], $event->getDurationMicros() / 1000);
     }
 }

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -289,6 +289,8 @@ class ConnectionTest extends TestCase
         DB::table('items')->get();
         $this->assertCount(1, $logs = DB::getQueryLog());
         $this->assertJsonStringEqualsJsonString('{"find":"items","filter":{}}', $logs[0]['query']);
+        $this->assertLessThan(10, $logs[0]['time'], 'Query time is in milliseconds');
+        $this->assertGreaterThan(0.01, $logs[0]['time'], 'Query time is in milliseconds');
 
         DB::table('items')->insert(['id' => $id = new ObjectId(), 'name' => 'test']);
         $this->assertCount(2, $logs = DB::getQueryLog());


### PR DESCRIPTION
Related Issue: https://github.com/laravel/telescope/issues/1587

This merge request addresses an issue in the `logQuery` method of Laravel, where the execution time was being passed in microseconds instead of the expected milliseconds.

https://github.com/laravel/framework/blob/797c2bbd6701d13650a24697ab62529dc3df9fb9/src/Illuminate/Database/Connection.php#L847-L860

https://github.com/laravel/framework/blob/797c2bbd6701d13650a24697ab62529dc3df9fb9/src/Illuminate/Database/Events/QueryExecuted.php#L21-L26


I verified that using `sleep` function in my query.

```php
public function create()
{
    $start = microtime(true);

    Post::whereRaw(['$where' => 'sleep(600) ||  true'])->first();

    $end = microtime(true);

    $diff = number_format(($end - $start) * 1000, 3);

    info("Execution time: $diff ms");

    return response()->noContent();
}
```

Before:

![before](https://github.com/user-attachments/assets/5bdafad2-e136-4834-a632-5b6dff1870f7)

After:

![after](https://github.com/user-attachments/assets/f530fa59-4aac-47f4-b2ad-699de507f0de)

> [2025-04-29 07:03:42] local.INFO: Execution time: 615.043 ms  