### PR TITLE
Fix database name extraction from DSN containing a CA file path

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -214,7 +214,7 @@ class Connection extends BaseConnection
     protected function getDefaultDatabaseName(string $dsn, array $config): string
     {
         if (empty($config['database'])) {
-            if (! preg_match('/^mongodb(?:[+]srv)?:\\/\\/.+\\/([^?&]+)/s', $dsn, $matches)) {
+            if (! preg_match('/^mongodb(?:[+]srv)?:\\/\\/.+?\\/([^?&]+)/s', $dsn, $matches)) {
                 throw new InvalidArgumentException('Database is not properly configured.');
             }
 

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -190,6 +190,12 @@ class ConnectionTest extends TestCase
             'expectedDatabaseName' => 'tests',
             'config' => ['dsn' => 'mongodb://some-host:12345/tests'],
         ];
+
+        yield 'Database is extracted from DSN with CA path in options' => [
+            'expectedUri' => 'mongodb://some-host:12345/tests?tls=true&tlsCAFile=/path/to/ca.pem&retryWrites=false',
+            'expectedDatabaseName' => 'tests',
+            'config' => ['dsn' => 'mongodb://some-host:12345/tests?tls=true&tlsCAFile=/path/to/ca.pem&retryWrites=false'],
+        ];
     }
 
     #[DataProvider('dataConnectionConfig')]


### PR DESCRIPTION
When a DSN contains a path to a CA file for TLS, the database name is improperly extracted.

Sample:
```
$dsn = 'mongodb://db_admin:secret@abc123.docdb.amazonaws.com:27017/mydb?tls=true&tlsCAFile=/usr/share/pki/ca-trust-source/anchors/aws-rds-bundle.pem&retryWrites=false';
echo $connection->getDefaultDatabaseName($dsn, []);
```

Before:
```
aws-rds-bundle.pem
```

After:
```
mydb
```

### Checklist

- [x] Add tests and ensure they pass
