### PR TITLE
Add schema validation before saving.

### DIFF
--- a/src/Eloquent/SchemaValidation.php
+++ b/src/Eloquent/SchemaValidation.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Laravel\Eloquent;
+
+use Illuminate\Support\Facades\Validator;
+use MongoDB\Laravel\Exception\SchemaValidationException;
+
+trait SchemaValidation
+{
+    protected bool $validateBeforeSave = false;
+
+    /**
+     * @param bool $validateBeforeSave
+     * @return $this
+     */
+    public function markForValidation(bool $validateBeforeSave = true): static
+    {
+        $this->validateBeforeSave = $validateBeforeSave;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function schemaRules(): array
+    {
+        return [];
+    }
+
+    /**
+     * @return void
+     * @throws SchemaValidationException
+     */
+    protected function validate(): void
+    {
+        $validator = Validator::make($this->attributesToArray(), $this->schemaRules());
+
+        if ($validator->fails()) {
+            throw new SchemaValidationException($validator);
+        }
+    }
+
+    public static function bootSchemaValidation(): void
+    {
+        static::saving(function ($model) {
+            if ($model->validateBeforeSave) {
+                $model->validate();
+            }
+        });
+
+        static::saved(function ($model) {
+            $model->validateBeforeSave = false;
+        });
+    }
+}

--- a/src/Eloquent/SchemaValidation.php
+++ b/src/Eloquent/SchemaValidation.php
@@ -12,12 +12,21 @@ trait SchemaValidation
     protected bool $validateBeforeSave = false;
 
     /**
-     * @param bool $validateBeforeSave
      * @return $this
      */
-    public function markForValidation(bool $validateBeforeSave = true): static
+    public function withValidation(): static
     {
-        $this->validateBeforeSave = $validateBeforeSave;
+        $this->validateBeforeSave = true;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function withoutValidation(): static
+    {
+        $this->validateBeforeSave = false;
 
         return $this;
     }
@@ -52,7 +61,7 @@ trait SchemaValidation
         });
 
         static::saved(function ($model) {
-            $model->validateBeforeSave = false;
+            $model->withoutValidation();
         });
     }
 }

--- a/src/Eloquent/SchemaValidation.php
+++ b/src/Eloquent/SchemaValidation.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace MongoDB\Laravel\Eloquent;
 
 use Illuminate\Support\Facades\Validator;
-use MongoDB\Laravel\Exception\SchemaValidationException;
+use MongoDB\Laravel\Exceptions\SchemaValidationException;
 
 trait SchemaValidation
 {
@@ -39,7 +39,7 @@ trait SchemaValidation
         $validator = Validator::make($this->attributesToArray(), $this->schemaRules());
 
         if ($validator->fails()) {
-            throw new SchemaValidationException($validator);
+            throw new SchemaValidationException($validator, $this);
         }
     }
 

--- a/src/Exception/SchemaValidationException.php
+++ b/src/Exception/SchemaValidationException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace MongoDB\Laravel\Exception;
+
+use Illuminate\Validation\ValidationException;
+
+class SchemaValidationException extends ValidationException
+{
+}

--- a/src/Exception/SchemaValidationException.php
+++ b/src/Exception/SchemaValidationException.php
@@ -1,9 +1,0 @@
-<?php
-
-namespace MongoDB\Laravel\Exception;
-
-use Illuminate\Validation\ValidationException;
-
-class SchemaValidationException extends ValidationException
-{
-}

--- a/src/Exceptions/SchemaValidationException.php
+++ b/src/Exceptions/SchemaValidationException.php
@@ -7,8 +7,16 @@ namespace MongoDB\Laravel\Exceptions;
 use Illuminate\Validation\ValidationException;
 use MongoDB\Laravel\Eloquent\Model;
 
+/**
+ * @template TModel of \MongoDB\Laravel\Eloquent\Model
+ */
 class SchemaValidationException extends ValidationException
 {
+    /**
+     * The affected Eloquent model.
+     *
+     * @var TModel
+     */
     protected $model;
 
     public function __construct($validator, $model = null, $response = null, $errorBag = 'default')
@@ -18,7 +26,9 @@ class SchemaValidationException extends ValidationException
     }
 
     /**
-     * @return Model|null
+     * Get the affected Eloquent model.
+     *
+     * @return TModel
      */
     public function getModel()
     {

--- a/src/Exceptions/SchemaValidationException.php
+++ b/src/Exceptions/SchemaValidationException.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Laravel\Exceptions;
+
+use Illuminate\Validation\ValidationException;
+use MongoDB\Laravel\Eloquent\Model;
+
+class SchemaValidationException extends ValidationException
+{
+    protected $model;
+
+    public function __construct($validator, $model = null, $response = null, $errorBag = 'default')
+    {
+        parent::__construct($validator, $response, $errorBag);
+        $this->model = $model;
+    }
+
+    /**
+     * @return Model|null
+     */
+    public function getModel()
+    {
+        return $this->model;
+    }
+}


### PR DESCRIPTION
I suggest introducing an automatic schema validation mechanism before saving data to the database, inspired by the schema validation system in [Mongoose (Node.js)](https://mongoosejs.com/).
This validation would be handled at the model or persistence layer using Laravel’s native validation system (Illuminate\Validation\Validator).

Goals
	•	Prevent invalid or incomplete data from being saved.
	•	Centralize validation rules close to the model or schema definition.
	•	Improve maintainability and ensure data integrity.

Example Implementation
```php
<?php

namespace App\Models;

use MongoDB\Laravel\Eloquent\Model;
use MongoDB\Laravel\Eloquent\SchemaValidation;

class Planet extends Model
{
    use SchemaValidation;

    public function schemaRules(): array
    {
        return [
            'name' => 'required|string',
            'distance' => 'integer|between:10,65535',
        ];
    }
}

```
```php
<?php

$planet = \App\Models\Planet::query()->first();
$planet->name = 'Earth';
$planet->withValidation()->save();
```

### Checklist

- [ ] Add tests and ensure they pass
