### PR TITLE
DOCSP-50023: remove eol server version mentions

### DIFF
--- a/docs/compatibility.txt
+++ b/docs/compatibility.txt
@@ -15,7 +15,7 @@ Compatibility
    :class: singlecol
 
 .. meta::
-   :keywords: laravel 9, laravel 10, laravel 11, laravel 12, 4.0, 4.1, 4.2, 5.0, 5.1, 5.2, 5.3
+   :keywords: laravel 9, laravel 10, laravel 11, laravel 12, 4.0, 4.1, 4.2, 5.0, 5.1, 5.2, 5.3, 5.4
 
 Laravel Compatibility
 ---------------------

--- a/docs/includes/framework-compatibility-laravel.rst
+++ b/docs/includes/framework-compatibility-laravel.rst
@@ -8,7 +8,7 @@
      - Laravel 10.x
      - Laravel 9.x
 
-   * - 5.2 to 5.3
+   * - 5.2 to 5.4
      - ✓
      - ✓
      - ✓

--- a/docs/transactions.txt
+++ b/docs/transactions.txt
@@ -60,20 +60,7 @@ This guide contains the following sections:
 Requirements and Limitations
 ----------------------------
 
-To perform transactions in MongoDB, you must use the following MongoDB
-version and topology:
-
-- MongoDB version 4.0 or later
-- A replica set deployment or sharded cluster
-
 MongoDB Server and the {+odm-short+} have the following limitations:
-
-- In MongoDB versions 4.2 and earlier, write operations performed within a
-  transaction must be on existing collections. In MongoDB versions 4.4 and
-  later, the server automatically creates collections as necessary when
-  you perform write operations in a transaction. To learn more about this
-  limitation, see :manual:`Create Collections and Indexes in a Transaction </core/transactions/#create-collections-and-indexes-in-a-transaction>`
-  in the {+server-docs-name+}.
 
 - MongoDB does not support nested transactions. If you attempt to start a
   transaction within another one, the extension raises a ``RuntimeException``.


### PR DESCRIPTION
https://jira.mongodb.org/browse/DOCSP-50023

removes references to pre MDB 6.0 server versions

### Checklist

- [ ] Add tests and ensure they pass
