### PR TITLE
PHPORM-326 Add collation to `db:table` command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     },
     "authors": [
         { "name": "Andreas Braun", "email": "andreas.braun@mongodb.com", "role": "Leader" },
+        { "name": "Pauline Vos", "email": "pauline.vos@mongodb.com", "role": "Maintainer" },
         { "name": "Jérôme Tamarelle", "email": "jerome.tamarelle@mongodb.com", "role": "Maintainer" },
         { "name": "Jeremy Mikola", "email": "jmikola@gmail.com", "role": "Maintainer" },
         { "name": "Jens Segers", "homepage": "https://jenssegers.com", "role": "Creator" }

--- a/src/Schema/Builder.php
+++ b/src/Schema/Builder.php
@@ -15,6 +15,7 @@ use MongoDB\Model\IndexInfo;
 use function array_column;
 use function array_fill_keys;
 use function array_filter;
+use function array_key_exists;
 use function array_keys;
 use function array_map;
 use function array_merge;
@@ -26,6 +27,7 @@ use function explode;
 use function implode;
 use function in_array;
 use function is_array;
+use function is_bool;
 use function is_string;
 use function iterator_to_array;
 use function sort;
@@ -380,6 +382,9 @@ class Builder extends \Illuminate\Database\Schema\Builder
                 continue;
             }
 
+            $options = $collectionInfo->getOptions();
+            $collation = $options['collation'] ?? [];
+
             // Aggregation is not supported on views
             $stats = $collectionType !== 'view' ? $db->selectCollection($collectionName)->aggregate([
                 ['$collStats' => ['storageStats' => ['scale' => 1]]],
@@ -392,7 +397,7 @@ class Builder extends \Illuminate\Database\Schema\Builder
                 'schema_qualified_name' => $db->getDatabaseName() . '.' . $collectionName,
                 'size' => $stats[0]?->storageStats?->totalSize ?? null,
                 'comment' => null,
-                'collation' => null,
+                'collation' => $this->collationToString($collation),
                 'engine' => null,
             ];
         }
@@ -400,5 +405,31 @@ class Builder extends \Illuminate\Database\Schema\Builder
         usort($collections, fn ($a, $b) => $a['name'] <=> $b['name']);
 
         return $collections;
+    }
+
+    private function collationToString(array $collation): string
+    {
+        $map = [
+            'locale' => 'l',
+            'strength' => 's',
+            'caseLevel' => 'cl',
+            'caseFirst' => 'cf',
+            'numericOrdering' => 'no',
+            'alternate' => 'a',
+            'maxVariable' => 'mv',
+            'normalization' => 'n',
+            'backwards' => 'b',
+        ];
+
+        $parts = [];
+        foreach ($collation as $key => $value) {
+            if (array_key_exists($key, $map)) {
+                $shortKey = $map[$key];
+                $shortValue = is_bool($value) ? ($value ? '1' : '0') : $value;
+                $parts[] = $shortKey . '=' . $shortValue;
+            }
+        }
+
+        return implode(';', $parts);
     }
 }

--- a/src/Schema/Builder.php
+++ b/src/Schema/Builder.php
@@ -6,6 +6,7 @@ namespace MongoDB\Laravel\Schema;
 
 use Closure;
 use MongoDB\Collection;
+use MongoDB\Database;
 use MongoDB\Driver\Exception\ServerException;
 use MongoDB\Laravel\Connection;
 use MongoDB\Model\CollectionInfo;
@@ -156,66 +157,13 @@ class Builder extends \Illuminate\Database\Schema\Builder
     /** @param string|null $schema Database name */
     public function getTables($schema = null)
     {
-        $db = $this->connection->getDatabase($schema);
-        $collections = [];
-
-        foreach ($db->listCollections() as $collectionInfo) {
-            $collectionName = $collectionInfo->getName();
-
-            // Skip views, which don't support aggregate
-            if ($collectionInfo->getType() === 'view') {
-                continue;
-            }
-
-            $stats = $db->selectCollection($collectionName)->aggregate([
-                ['$collStats' => ['storageStats' => ['scale' => 1]]],
-                ['$project' => ['storageStats.totalSize' => 1]],
-            ])->toArray();
-
-            $collections[] = [
-                'name' => $collectionName,
-                'schema' => $db->getDatabaseName(),
-                'schema_qualified_name' => $db->getDatabaseName() . '.' . $collectionName,
-                'size' => $stats[0]?->storageStats?->totalSize ?? null,
-                'comment' => null,
-                'collation' => null,
-                'engine' => null,
-            ];
-        }
-
-        usort($collections, fn ($a, $b) => $a['name'] <=> $b['name']);
-
-        return $collections;
+        return $this->getCollectionRows('collection', $schema);
     }
 
     /** @param  string|null $schema Database name */
     public function getViews($schema = null)
     {
-        $db = $this->connection->getDatabase($schema);
-        $collections = [];
-
-        foreach ($db->listCollections() as $collectionInfo) {
-            $collectionName = $collectionInfo->getName();
-
-            // Skip normal type collection
-            if ($collectionInfo->getType() !== 'view') {
-                continue;
-            }
-
-            $collections[] = [
-                'name' => $collectionName,
-                'schema' => $db->getDatabaseName(),
-                'schema_qualified_name' => $db->getDatabaseName() . '.' . $collectionName,
-                'size' => null,
-                'comment' => null,
-                'collation' => null,
-                'engine' => null,
-            ];
-        }
-
-        usort($collections, fn ($a, $b) => $a['name'] <=> $b['name']);
-
-        return $collections;
+        return $this->getCollectionRows('view', $schema);
     }
 
     /**
@@ -254,7 +202,7 @@ class Builder extends \Illuminate\Database\Schema\Builder
             [$db, $table] = explode('.', $table, 2);
         }
 
-        $stats = $this->connection->getDatabase($db)->selectCollection($table)->aggregate([
+        $stats = $this->connection->getDatabase($db)->getCollection($table)->aggregate([
             // Sample 1,000 documents to get a representative sample of the collection
             ['$sample' => ['size' => 1_000]],
             // Convert each document to an array of fields
@@ -389,7 +337,7 @@ class Builder extends \Illuminate\Database\Schema\Builder
     }
 
     /**
-     * Get all of the collections names for the database.
+     * Get all the collections names for the database.
      *
      * @deprecated
      *
@@ -417,5 +365,40 @@ class Builder extends \Illuminate\Database\Schema\Builder
             6047401, // MongoDB 7: $listSearchIndexes stage is only allowed on MongoDB Atlas
             31082,   // MongoDB 8: Using Atlas Search Database Commands and the $listSearchIndexes aggregation stage requires additional configuration.
         ], true);
+    }
+
+    /** @param string|null $schema Database name */
+    private function getCollectionRows(string $collectionType, $schema = null)
+    {
+        $db = $this->connection->getDatabase($schema);
+        $collections = [];
+
+        foreach ($db->listCollections() as $collectionInfo) {
+            $collectionName = $collectionInfo->getName();
+
+            if ($collectionInfo->getType() !== $collectionType) {
+                continue;
+            }
+
+            // Aggregation is not supported on views
+            $stats = $collectionType !== 'view' ? $db->selectCollection($collectionName)->aggregate([
+                ['$collStats' => ['storageStats' => ['scale' => 1]]],
+                ['$project' => ['storageStats.totalSize' => 1]],
+            ])->toArray() : null;
+
+            $collections[] = [
+                'name' => $collectionName,
+                'schema' => $db->getDatabaseName(),
+                'schema_qualified_name' => $db->getDatabaseName() . '.' . $collectionName,
+                'size' => $stats[0]?->storageStats?->totalSize ?? null,
+                'comment' => null,
+                'collation' => null,
+                'engine' => null,
+            ];
+        }
+
+        usort($collections, fn ($a, $b) => $a['name'] <=> $b['name']);
+
+        return $collections;
     }
 }

--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -20,12 +20,15 @@ use function sprintf;
 
 class SchemaTest extends TestCase
 {
+    private const COLL_WITH_COLLATION = 'collection_with_collation';
+
     public function tearDown(): void
     {
         $database = $this->getConnection('mongodb')->getDatabase();
         assert($database instanceof Database);
         $database->dropCollection('newcollection');
         $database->dropCollection('newcollection_two');
+        $database->dropCollection(self::COLL_WITH_COLLATION);
         $database->dropCollection('test_view');
 
         parent::tearDown();
@@ -394,9 +397,17 @@ class SchemaTest extends TestCase
 
     public function testGetTables()
     {
+        $db = DB::connection('mongodb')->getDatabase();
+        $db->createCollection(self::COLL_WITH_COLLATION, [
+            'collation' => [
+                'locale' => 'fr',
+                'strength' => 2,
+            ],
+        ]);
+
         DB::connection('mongodb')->table('newcollection')->insert(['test' => 'value']);
         DB::connection('mongodb')->table('newcollection_two')->insert(['test' => 'value']);
-        DB::connection('mongodb')->getDatabase()->createCollection('test_view', ['viewOn' => 'newcollection']);
+        $db->createCollection('test_view', ['viewOn' => 'newcollection']);
         $dbName = DB::connection('mongodb')->getDatabaseName();
 
         $tables = Schema::getTables();
@@ -407,6 +418,7 @@ class SchemaTest extends TestCase
             $this->assertArrayHasKey('name', $table);
             $this->assertArrayHasKey('size', $table);
             $this->assertArrayHasKey('schema', $table);
+            $this->assertArrayHasKey('collation', $table);
             $this->assertArrayHasKey('schema_qualified_name', $table);
             $this->assertNotEquals('test_view', $table['name'], 'Standard views should not be included in the result of getTables.');
 
@@ -415,6 +427,10 @@ class SchemaTest extends TestCase
                 $this->assertEquals($dbName, $table['schema']);
                 $this->assertEquals($dbName . '.newcollection', $table['schema_qualified_name']);
                 $found = true;
+            }
+
+            if ($table['name'] === self::COLL_WITH_COLLATION) {
+                $this->assertEquals('l=fr;cl=0;cf=off;s=2;no=0;a=non-ignorable;mv=punct;n=0;b=0', $table['collation']);
             }
         }
 

--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -20,14 +20,16 @@ use function sprintf;
 
 class SchemaTest extends TestCase
 {
+    private const COLL_1 = 'new_collection';
+    private const COLL_2 = 'new_collection_two';
     private const COLL_WITH_COLLATION = 'collection_with_collation';
 
     public function tearDown(): void
     {
         $database = $this->getConnection('mongodb')->getDatabase();
         assert($database instanceof Database);
-        $database->dropCollection('newcollection');
-        $database->dropCollection('newcollection_two');
+        $database->dropCollection(self::COLL_1);
+        $database->dropCollection(self::COLL_2);
         $database->dropCollection(self::COLL_WITH_COLLATION);
         $database->dropCollection('test_view');
 
@@ -36,204 +38,204 @@ class SchemaTest extends TestCase
 
     public function testCreate(): void
     {
-        Schema::create('newcollection');
-        $this->assertTrue(Schema::hasCollection('newcollection'));
-        $this->assertTrue(Schema::hasTable('newcollection'));
+        Schema::create(self::COLL_1);
+        $this->assertTrue(Schema::hasCollection(self::COLL_1));
+        $this->assertTrue(Schema::hasTable(self::COLL_1));
     }
 
     public function testCreateWithCallback(): void
     {
-        Schema::create('newcollection', static function ($collection) {
+        Schema::create(self::COLL_1, static function ($collection) {
             self::assertInstanceOf(Blueprint::class, $collection);
         });
 
-        $this->assertTrue(Schema::hasCollection('newcollection'));
+        $this->assertTrue(Schema::hasCollection(self::COLL_1));
     }
 
     public function testCreateWithOptions(): void
     {
-        Schema::create('newcollection_two', null, ['capped' => true, 'size' => 1024]);
-        $this->assertTrue(Schema::hasCollection('newcollection_two'));
-        $this->assertTrue(Schema::hasTable('newcollection_two'));
+        Schema::create(self::COLL_2, null, ['capped' => true, 'size' => 1024]);
+        $this->assertTrue(Schema::hasCollection(self::COLL_2));
+        $this->assertTrue(Schema::hasTable(self::COLL_2));
 
-        $collection = Schema::getCollection('newcollection_two');
+        $collection = Schema::getCollection(self::COLL_2);
         $this->assertTrue($collection['options']['capped']);
         $this->assertEquals(1024, $collection['options']['size']);
     }
 
     public function testDrop(): void
     {
-        Schema::create('newcollection');
-        Schema::drop('newcollection');
-        $this->assertFalse(Schema::hasCollection('newcollection'));
+        Schema::create(self::COLL_1);
+        Schema::drop(self::COLL_1);
+        $this->assertFalse(Schema::hasCollection(self::COLL_1));
     }
 
     public function testBluePrint(): void
     {
-        Schema::table('newcollection', static function ($collection) {
+        Schema::table(self::COLL_1, static function ($collection) {
             self::assertInstanceOf(Blueprint::class, $collection);
         });
 
-        Schema::table('newcollection', static function ($collection) {
+        Schema::table(self::COLL_1, static function ($collection) {
             self::assertInstanceOf(Blueprint::class, $collection);
         });
     }
 
     public function testIndex(): void
     {
-        Schema::table('newcollection', function ($collection) {
+        Schema::table(self::COLL_1, function ($collection) {
             $collection->index('mykey1');
         });
 
-        $index = $this->assertIndexExists('newcollection', 'mykey1_1');
+        $index = $this->assertIndexExists(self::COLL_1, 'mykey1_1');
         $this->assertEquals(1, $index['key']['mykey1']);
 
-        Schema::table('newcollection', function ($collection) {
+        Schema::table(self::COLL_1, function ($collection) {
             $collection->index(['mykey2']);
         });
 
-        $index = $this->assertIndexExists('newcollection', 'mykey2_1');
+        $index = $this->assertIndexExists(self::COLL_1, 'mykey2_1');
         $this->assertEquals(1, $index['key']['mykey2']);
 
-        Schema::table('newcollection', function ($collection) {
+        Schema::table(self::COLL_1, function ($collection) {
             $collection->string('mykey3')->index();
         });
 
-        $index = $this->assertIndexExists('newcollection', 'mykey3_1');
+        $index = $this->assertIndexExists(self::COLL_1, 'mykey3_1');
         $this->assertEquals(1, $index['key']['mykey3']);
     }
 
     public function testPrimary(): void
     {
-        Schema::table('newcollection', function ($collection) {
+        Schema::table(self::COLL_1, function ($collection) {
             $collection->string('mykey', 100)->primary();
         });
 
-        $index = $this->assertIndexExists('newcollection', 'mykey_1');
+        $index = $this->assertIndexExists(self::COLL_1, 'mykey_1');
         $this->assertEquals(1, $index['unique']);
     }
 
     public function testUnique(): void
     {
-        Schema::table('newcollection', function ($collection) {
+        Schema::table(self::COLL_1, function ($collection) {
             $collection->unique('uniquekey');
         });
 
-        $index = $this->assertIndexExists('newcollection', 'uniquekey_1');
+        $index = $this->assertIndexExists(self::COLL_1, 'uniquekey_1');
         $this->assertEquals(1, $index['unique']);
     }
 
     public function testDropIndex(): void
     {
-        Schema::table('newcollection', function ($collection) {
+        Schema::table(self::COLL_1, function ($collection) {
             $collection->unique('uniquekey');
             $collection->dropIndex('uniquekey_1');
         });
 
-        $this->assertIndexNotExists('newcollection', 'uniquekey_1');
+        $this->assertIndexNotExists(self::COLL_1, 'uniquekey_1');
 
-        Schema::table('newcollection', function ($collection) {
+        Schema::table(self::COLL_1, function ($collection) {
             $collection->unique('uniquekey');
             $collection->dropIndex(['uniquekey']);
         });
 
-        $this->assertIndexNotExists('newcollection', 'uniquekey_1');
+        $this->assertIndexNotExists(self::COLL_1, 'uniquekey_1');
 
-        Schema::table('newcollection', function ($collection) {
+        Schema::table(self::COLL_1, function ($collection) {
             $collection->index(['field_a', 'field_b']);
         });
 
-        $this->assertIndexExists('newcollection', 'field_a_1_field_b_1');
+        $this->assertIndexExists(self::COLL_1, 'field_a_1_field_b_1');
 
-        Schema::table('newcollection', function ($collection) {
+        Schema::table(self::COLL_1, function ($collection) {
             $collection->dropIndex(['field_a', 'field_b']);
         });
 
-        $this->assertIndexNotExists('newcollection', 'field_a_1_field_b_1');
+        $this->assertIndexNotExists(self::COLL_1, 'field_a_1_field_b_1');
 
         $indexName = 'field_a_-1_field_b_1';
-        Schema::table('newcollection', function ($collection) {
+        Schema::table(self::COLL_1, function ($collection) {
             $collection->index(['field_a' => -1, 'field_b' => 1]);
         });
 
-        $this->assertIndexExists('newcollection', $indexName);
+        $this->assertIndexExists(self::COLL_1, $indexName);
 
-        Schema::table('newcollection', function ($collection) {
+        Schema::table(self::COLL_1, function ($collection) {
             $collection->dropIndex(['field_a' => -1, 'field_b' => 1]);
         });
 
-        $this->assertIndexNotExists('newcollection', $indexName);
+        $this->assertIndexNotExists(self::COLL_1, $indexName);
 
         $indexName = 'custom_index_name';
-        Schema::table('newcollection', function ($collection) use ($indexName) {
+        Schema::table(self::COLL_1, function ($collection) use ($indexName) {
             $collection->index(['field_a', 'field_b'], $indexName);
         });
 
-        $this->assertIndexExists('newcollection', $indexName);
+        $this->assertIndexExists(self::COLL_1, $indexName);
 
-        Schema::table('newcollection', function ($collection) use ($indexName) {
+        Schema::table(self::COLL_1, function ($collection) use ($indexName) {
             $collection->dropIndex($indexName);
         });
 
-        $this->assertIndexNotExists('newcollection', $indexName);
+        $this->assertIndexNotExists(self::COLL_1, $indexName);
     }
 
     public function testDropIndexIfExists(): void
     {
-        Schema::table('newcollection', function (Blueprint $collection) {
+        Schema::table(self::COLL_1, function (Blueprint $collection) {
             $collection->unique('uniquekey');
             $collection->dropIndexIfExists('uniquekey_1');
         });
 
-        $this->assertIndexNotExists('newcollection', 'uniquekey');
+        $this->assertIndexNotExists(self::COLL_1, 'uniquekey');
 
-        Schema::table('newcollection', function (Blueprint $collection) {
+        Schema::table(self::COLL_1, function (Blueprint $collection) {
             $collection->unique('uniquekey');
             $collection->dropIndexIfExists(['uniquekey']);
         });
 
-        $this->assertIndexNotExists('newcollection', 'uniquekey');
+        $this->assertIndexNotExists(self::COLL_1, 'uniquekey');
 
-        Schema::table('newcollection', function (Blueprint $collection) {
+        Schema::table(self::COLL_1, function (Blueprint $collection) {
             $collection->index(['field_a', 'field_b']);
         });
 
-        $this->assertIndexExists('newcollection', 'field_a_1_field_b_1');
+        $this->assertIndexExists(self::COLL_1, 'field_a_1_field_b_1');
 
-        Schema::table('newcollection', function (Blueprint $collection) {
+        Schema::table(self::COLL_1, function (Blueprint $collection) {
             $collection->dropIndexIfExists(['field_a', 'field_b']);
         });
 
-        $this->assertIndexNotExists('newcollection', 'field_a_1_field_b_1');
+        $this->assertIndexNotExists(self::COLL_1, 'field_a_1_field_b_1');
 
-        Schema::table('newcollection', function (Blueprint $collection) {
+        Schema::table(self::COLL_1, function (Blueprint $collection) {
             $collection->index(['field_a', 'field_b'], 'custom_index_name');
         });
 
-        $this->assertIndexExists('newcollection', 'custom_index_name');
+        $this->assertIndexExists(self::COLL_1, 'custom_index_name');
 
-        Schema::table('newcollection', function (Blueprint $collection) {
+        Schema::table(self::COLL_1, function (Blueprint $collection) {
             $collection->dropIndexIfExists('custom_index_name');
         });
 
-        $this->assertIndexNotExists('newcollection', 'custom_index_name');
+        $this->assertIndexNotExists(self::COLL_1, 'custom_index_name');
     }
 
     public function testHasIndex(): void
     {
-        Schema::table('newcollection', function (Blueprint $collection) {
+        Schema::table(self::COLL_1, function (Blueprint $collection) {
             $collection->index('myhaskey1');
             $this->assertTrue($collection->hasIndex('myhaskey1_1'));
             $this->assertFalse($collection->hasIndex('myhaskey1'));
         });
 
-        Schema::table('newcollection', function (Blueprint $collection) {
+        Schema::table(self::COLL_1, function (Blueprint $collection) {
             $collection->index('myhaskey2');
             $this->assertTrue($collection->hasIndex(['myhaskey2']));
             $this->assertFalse($collection->hasIndex(['myhaskey2_1']));
         });
 
-        Schema::table('newcollection', function (Blueprint $collection) {
+        Schema::table(self::COLL_1, function (Blueprint $collection) {
             $collection->index(['field_a', 'field_b']);
             $this->assertTrue($collection->hasIndex(['field_a_1_field_b']));
             $this->assertFalse($collection->hasIndex(['field_a_1_field_b_1']));
@@ -242,74 +244,74 @@ class SchemaTest extends TestCase
 
     public function testSparse(): void
     {
-        Schema::table('newcollection', function ($collection) {
+        Schema::table(self::COLL_1, function ($collection) {
             $collection->sparse('sparsekey');
         });
 
-        $index = $this->assertIndexExists('newcollection', 'sparsekey_1');
+        $index = $this->assertIndexExists(self::COLL_1, 'sparsekey_1');
         $this->assertEquals(1, $index['sparse']);
     }
 
     public function testExpire(): void
     {
-        Schema::table('newcollection', function ($collection) {
+        Schema::table(self::COLL_1, function ($collection) {
             $collection->expire('expirekey', 60);
         });
 
-        $index = $this->assertIndexExists('newcollection', 'expirekey_1');
+        $index = $this->assertIndexExists(self::COLL_1, 'expirekey_1');
         $this->assertEquals(60, $index['expireAfterSeconds']);
     }
 
     public function testSoftDeletes(): void
     {
-        Schema::table('newcollection', function ($collection) {
+        Schema::table(self::COLL_1, function ($collection) {
             $collection->softDeletes();
         });
 
-        Schema::table('newcollection', function ($collection) {
+        Schema::table(self::COLL_1, function ($collection) {
             $collection->string('email')->nullable()->index();
         });
 
-        $index = $this->assertIndexExists('newcollection', 'email_1');
+        $index = $this->assertIndexExists(self::COLL_1, 'email_1');
         $this->assertEquals(1, $index['key']['email']);
     }
 
     public function testFluent(): void
     {
-        Schema::table('newcollection', function ($collection) {
+        Schema::table(self::COLL_1, function ($collection) {
             $collection->string('email')->index();
             $collection->string('token')->index();
             $collection->timestamp('created_at');
         });
 
-        $index = $this->assertIndexExists('newcollection', 'email_1');
+        $index = $this->assertIndexExists(self::COLL_1, 'email_1');
         $this->assertEquals(1, $index['key']['email']);
 
-        $index = $this->assertIndexExists('newcollection', 'token_1');
+        $index = $this->assertIndexExists(self::COLL_1, 'token_1');
         $this->assertEquals(1, $index['key']['token']);
     }
 
     public function testGeospatial(): void
     {
-        Schema::table('newcollection', function ($collection) {
+        Schema::table(self::COLL_1, function ($collection) {
             $collection->geospatial('point');
             $collection->geospatial('area', '2d');
             $collection->geospatial('continent', '2dsphere');
         });
 
-        $index = $this->assertIndexExists('newcollection', 'point_2d');
+        $index = $this->assertIndexExists(self::COLL_1, 'point_2d');
         $this->assertEquals('2d', $index['key']['point']);
 
-        $index = $this->assertIndexExists('newcollection', 'area_2d');
+        $index = $this->assertIndexExists(self::COLL_1, 'area_2d');
         $this->assertEquals('2d', $index['key']['area']);
 
-        $index = $this->assertIndexExists('newcollection', 'continent_2dsphere');
+        $index = $this->assertIndexExists(self::COLL_1, 'continent_2dsphere');
         $this->assertEquals('2dsphere', $index['key']['continent']);
     }
 
     public function testDummies(): void
     {
-        Schema::table('newcollection', function ($collection) {
+        Schema::table(self::COLL_1, function ($collection) {
             $collection->boolean('activated')->default(0);
             $collection->integer('user_id')->unsigned();
         });
@@ -318,22 +320,22 @@ class SchemaTest extends TestCase
 
     public function testSparseUnique(): void
     {
-        Schema::table('newcollection', function ($collection) {
+        Schema::table(self::COLL_1, function ($collection) {
             $collection->sparse_and_unique('sparseuniquekey');
         });
 
-        $index = $this->assertIndexExists('newcollection', 'sparseuniquekey_1');
+        $index = $this->assertIndexExists(self::COLL_1, 'sparseuniquekey_1');
         $this->assertEquals(1, $index['sparse']);
         $this->assertEquals(1, $index['unique']);
     }
 
     public function testRenameColumn(): void
     {
-        DB::connection()->table('newcollection')->insert(['test' => 'value']);
-        DB::connection()->table('newcollection')->insert(['test' => 'value 2']);
-        DB::connection()->table('newcollection')->insert(['column' => 'column value']);
+        DB::connection()->table(self::COLL_1)->insert(['test' => 'value']);
+        DB::connection()->table(self::COLL_1)->insert(['test' => 'value 2']);
+        DB::connection()->table(self::COLL_1)->insert(['column' => 'column value']);
 
-        $check = DB::connection()->table('newcollection')->get();
+        $check = DB::connection()->table(self::COLL_1)->get();
         $this->assertCount(3, $check);
 
         $this->assertObjectHasProperty('test', $check[0]);
@@ -346,11 +348,11 @@ class SchemaTest extends TestCase
         $this->assertObjectNotHasProperty('test', $check[2]);
         $this->assertObjectNotHasProperty('newtest', $check[2]);
 
-        Schema::table('newcollection', function (Blueprint $collection) {
+        Schema::table(self::COLL_1, function (Blueprint $collection) {
             $collection->renameColumn('test', 'newtest');
         });
 
-        $check2 = DB::connection()->table('newcollection')->get();
+        $check2 = DB::connection()->table(self::COLL_1)->get();
         $this->assertCount(3, $check2);
 
         $this->assertObjectHasProperty('newtest', $check2[0]);
@@ -369,30 +371,30 @@ class SchemaTest extends TestCase
 
     public function testHasColumn(): void
     {
-        $this->assertTrue(Schema::hasColumn('newcollection', '_id'));
-        $this->assertTrue(Schema::hasColumn('newcollection', 'id'));
+        $this->assertTrue(Schema::hasColumn(self::COLL_1, '_id'));
+        $this->assertTrue(Schema::hasColumn(self::COLL_1, 'id'));
 
-        DB::connection()->table('newcollection')->insert(['column1' => 'value', 'embed' => ['_id' => 1]]);
+        DB::connection()->table(self::COLL_1)->insert(['column1' => 'value', 'embed' => ['_id' => 1]]);
 
-        $this->assertTrue(Schema::hasColumn('newcollection', 'column1'));
-        $this->assertFalse(Schema::hasColumn('newcollection', 'column2'));
-        $this->assertTrue(Schema::hasColumn('newcollection', 'embed._id'));
-        $this->assertTrue(Schema::hasColumn('newcollection', 'embed.id'));
+        $this->assertTrue(Schema::hasColumn(self::COLL_1, 'column1'));
+        $this->assertFalse(Schema::hasColumn(self::COLL_1, 'column2'));
+        $this->assertTrue(Schema::hasColumn(self::COLL_1, 'embed._id'));
+        $this->assertTrue(Schema::hasColumn(self::COLL_1, 'embed.id'));
     }
 
     public function testHasColumns(): void
     {
-        $this->assertTrue(Schema::hasColumns('newcollection', ['_id']));
-        $this->assertTrue(Schema::hasColumns('newcollection', ['id']));
+        $this->assertTrue(Schema::hasColumns(self::COLL_1, ['_id']));
+        $this->assertTrue(Schema::hasColumns(self::COLL_1, ['id']));
 
         // Insert documents with both column1 and column2
-        DB::connection()->table('newcollection')->insert([
+        DB::connection()->table(self::COLL_1)->insert([
             ['column1' => 'value1', 'column2' => 'value2'],
             ['column1' => 'value3'],
         ]);
 
-        $this->assertTrue(Schema::hasColumns('newcollection', ['column1', 'column2']));
-        $this->assertFalse(Schema::hasColumns('newcollection', ['column1', 'column3']));
+        $this->assertTrue(Schema::hasColumns(self::COLL_1, ['column1', 'column2']));
+        $this->assertFalse(Schema::hasColumns(self::COLL_1, ['column1', 'column3']));
     }
 
     public function testGetTables()
@@ -405,9 +407,9 @@ class SchemaTest extends TestCase
             ],
         ]);
 
-        DB::connection('mongodb')->table('newcollection')->insert(['test' => 'value']);
-        DB::connection('mongodb')->table('newcollection_two')->insert(['test' => 'value']);
-        $db->createCollection('test_view', ['viewOn' => 'newcollection']);
+        DB::connection('mongodb')->table(self::COLL_1)->insert(['test' => 'value']);
+        DB::connection('mongodb')->table(self::COLL_2)->insert(['test' => 'value']);
+        $db->createCollection('test_view', ['viewOn' => self::COLL_1]);
         $dbName = DB::connection('mongodb')->getDatabaseName();
 
         $tables = Schema::getTables();
@@ -422,10 +424,10 @@ class SchemaTest extends TestCase
             $this->assertArrayHasKey('schema_qualified_name', $table);
             $this->assertNotEquals('test_view', $table['name'], 'Standard views should not be included in the result of getTables.');
 
-            if ($table['name'] === 'newcollection') {
+            if ($table['name'] === self::COLL_1) {
                 $this->assertEquals(8192, $table['size']);
                 $this->assertEquals($dbName, $table['schema']);
-                $this->assertEquals($dbName . '.newcollection', $table['schema_qualified_name']);
+                $this->assertEquals($dbName . '.' . self::COLL_1, $table['schema_qualified_name']);
                 $found = true;
             }
 
@@ -435,17 +437,17 @@ class SchemaTest extends TestCase
         }
 
         if (! $found) {
-            $this->fail('Collection "newcollection" not found');
+            $this->fail('Collection "' . self::COLL_1 . '" not found');
         }
     }
 
     public function testGetViews()
     {
-        DB::connection('mongodb')->table('newcollection')->insert(['test' => 'value']);
-        DB::connection('mongodb')->table('newcollection_two')->insert(['test' => 'value']);
+        DB::connection('mongodb')->table(self::COLL_1)->insert(['test' => 'value']);
+        DB::connection('mongodb')->table(self::COLL_2)->insert(['test' => 'value']);
         $dbName = DB::connection('mongodb')->getDatabaseName();
 
-        DB::connection('mongodb')->getDatabase()->createCollection('test_view', ['viewOn' => 'newcollection']);
+        DB::connection('mongodb')->getDatabase()->createCollection('test_view', ['viewOn' => self::COLL_1]);
 
         $tables = Schema::getViews();
 
@@ -459,7 +461,7 @@ class SchemaTest extends TestCase
             $this->assertArrayHasKey('schema_qualified_name', $table);
 
             // Ensure "normal collections" are not in the views list
-            $this->assertNotEquals('newcollection', $table['name'], 'Normal collections should not be included in the result of getViews.');
+            $this->assertNotEquals(self::COLL_1, $table['name'], 'Normal collections should not be included in the result of getViews.');
 
             if ($table['name'] === 'test_view') {
                 $this->assertEquals($dbName, $table['schema']);
@@ -475,45 +477,45 @@ class SchemaTest extends TestCase
 
     public function testGetTableListing()
     {
-        DB::connection('mongodb')->table('newcollection')->insert(['test' => 'value']);
-        DB::connection('mongodb')->table('newcollection_two')->insert(['test' => 'value']);
+        DB::connection('mongodb')->table(self::COLL_1)->insert(['test' => 'value']);
+        DB::connection('mongodb')->table(self::COLL_2)->insert(['test' => 'value']);
 
         $tables = Schema::getTableListing();
 
         $this->assertIsArray($tables);
         $this->assertGreaterThanOrEqual(2, count($tables));
-        $this->assertContains('newcollection', $tables);
-        $this->assertContains('newcollection_two', $tables);
+        $this->assertContains(self::COLL_1, $tables);
+        $this->assertContains(self::COLL_2, $tables);
     }
 
     public function testGetTableListingBySchema()
     {
-        DB::connection('mongodb')->table('newcollection')->insert(['test' => 'value']);
-        DB::connection('mongodb')->table('newcollection_two')->insert(['test' => 'value']);
+        DB::connection('mongodb')->table(self::COLL_1)->insert(['test' => 'value']);
+        DB::connection('mongodb')->table(self::COLL_2)->insert(['test' => 'value']);
         $dbName = DB::connection('mongodb')->getDatabaseName();
 
         $tables = Schema::getTableListing([$dbName, 'database__that_does_not_exists'], schemaQualified: true);
 
         $this->assertIsArray($tables);
         $this->assertGreaterThanOrEqual(2, count($tables));
-        $this->assertContains($dbName . '.newcollection', $tables);
-        $this->assertContains($dbName . '.newcollection_two', $tables);
+        $this->assertContains($dbName . '.' . self::COLL_1, $tables);
+        $this->assertContains($dbName . '.' . self::COLL_2, $tables);
 
         $tables = Schema::getTableListing([$dbName, 'database__that_does_not_exists'], schemaQualified: false);
 
         $this->assertIsArray($tables);
         $this->assertGreaterThanOrEqual(2, count($tables));
-        $this->assertContains('newcollection', $tables);
-        $this->assertContains('newcollection_two', $tables);
+        $this->assertContains(self::COLL_1, $tables);
+        $this->assertContains(self::COLL_2, $tables);
     }
 
     public function testGetColumns()
     {
-        $collection = DB::connection('mongodb')->table('newcollection');
+        $collection = DB::connection('mongodb')->table(self::COLL_1);
         $collection->insert(['text' => 'value', 'mixed' => ['key' => 'value']]);
         $collection->insert(['date' => new UTCDateTime(), 'binary' => new Binary('binary'), 'mixed' => true]);
 
-        $columns = Schema::getColumns('newcollection');
+        $columns = Schema::getColumns(self::COLL_1);
         $this->assertIsArray($columns);
         $this->assertCount(5, $columns);
 
@@ -544,7 +546,7 @@ class SchemaTest extends TestCase
         $this->assertSame([], $columns);
 
         // Qualified table name
-        $columns = Schema::getColumns(DB::getDatabaseName() . '.newcollection');
+        $columns = Schema::getColumns(DB::getDatabaseName() . '.' . self::COLL_1);
         $this->assertIsArray($columns);
         $this->assertCount(5, $columns);
     }
@@ -552,12 +554,12 @@ class SchemaTest extends TestCase
     /** @see AtlasSearchTest::testGetIndexes() */
     public function testGetIndexes()
     {
-        Schema::create('newcollection', function (Blueprint $collection) {
+        Schema::create(self::COLL_1, function (Blueprint $collection) {
             $collection->index('mykey1');
             $collection->string('mykey2')->unique('unique_index');
             $collection->string('mykey3')->index();
         });
-        $indexes = Schema::getIndexes('newcollection');
+        $indexes = Schema::getIndexes(self::COLL_1);
         self::assertIsArray($indexes);
         self::assertCount(4, $indexes);
 
@@ -603,7 +605,7 @@ class SchemaTest extends TestCase
     {
         $this->skipIfSearchIndexManagementIsNotSupported();
 
-        Schema::create('newcollection', function (Blueprint $collection) {
+        Schema::create(self::COLL_1, function (Blueprint $collection) {
             $collection->searchIndex([
                 'mappings' => [
                     'dynamic' => false,
@@ -614,7 +616,7 @@ class SchemaTest extends TestCase
             ]);
         });
 
-        $index = $this->getSearchIndex('newcollection', 'default');
+        $index = $this->getSearchIndex(self::COLL_1, 'default');
         self::assertNotNull($index);
 
         self::assertSame('default', $index['name']);
@@ -622,11 +624,11 @@ class SchemaTest extends TestCase
         self::assertFalse($index['latestDefinition']['mappings']['dynamic']);
         self::assertSame('lucene.whitespace', $index['latestDefinition']['mappings']['fields']['foo']['analyzer']);
 
-        Schema::table('newcollection', function (Blueprint $collection) {
+        Schema::table(self::COLL_1, function (Blueprint $collection) {
             $collection->dropSearchIndex('default');
         });
 
-        $index = $this->getSearchIndex('newcollection', 'default');
+        $index = $this->getSearchIndex(self::COLL_1, 'default');
         self::assertNull($index);
     }
 
@@ -634,7 +636,7 @@ class SchemaTest extends TestCase
     {
         $this->skipIfSearchIndexManagementIsNotSupported();
 
-        Schema::create('newcollection', function (Blueprint $collection) {
+        Schema::create(self::COLL_1, function (Blueprint $collection) {
             $collection->vectorSearchIndex([
                 'fields' => [
                     ['type' => 'vector', 'path' => 'foo', 'numDimensions' => 128, 'similarity' => 'euclidean', 'quantization' => 'none'],
@@ -642,7 +644,7 @@ class SchemaTest extends TestCase
             ], 'vector');
         });
 
-        $index = $this->getSearchIndex('newcollection', 'vector');
+        $index = $this->getSearchIndex(self::COLL_1, 'vector');
         self::assertNotNull($index);
 
         self::assertSame('vector', $index['name']);
@@ -650,11 +652,11 @@ class SchemaTest extends TestCase
         self::assertSame('vector', $index['latestDefinition']['fields'][0]['type']);
 
         // Drop the index
-        Schema::table('newcollection', function (Blueprint $collection) {
+        Schema::table(self::COLL_1, function (Blueprint $collection) {
             $collection->dropSearchIndex('vector');
         });
 
-        $index = $this->getSearchIndex('newcollection', 'vector');
+        $index = $this->getSearchIndex(self::COLL_1, 'vector');
         self::assertNull($index);
     }
 


### PR DESCRIPTION
Fix PHPORM-326

Adds `collation` to the `db:table` command. Actually also adds it everywhere else in the command layer (i.e. in `ShowCommand`, both for views and collections), but those are not displayed when you run `db:show`.

### Checklist

- [x] Add tests and ensure they pass
