### PR TITLE
Support adding schema validation

### DIFF
--- a/src/Schema/Blueprint.php
+++ b/src/Schema/Blueprint.php
@@ -9,6 +9,7 @@ use MongoDB\Collection;
 use MongoDB\Laravel\Connection;
 
 use function array_flip;
+use function array_merge;
 use function implode;
 use function in_array;
 use function is_array;
@@ -115,6 +116,24 @@ class Blueprint extends BaseBlueprint
         }
 
         return false;
+    }
+
+    public function jsonSchema(
+        array $schema = [],
+        ?string $validationLevel = null,
+        ?string $validationAction = null,
+    ): void {
+        $options = array_merge(
+            [
+                'validator' => [
+                    '$jsonSchema' => $schema,
+                ],
+            ],
+            $validationLevel ? ['validationLevel' => $validationLevel] : [],
+            $validationAction ? ['validationAction' => $validationAction] : [],
+        );
+
+        $this->connection->getDatabase()->modifyCollection($this->collection->getCollectionName(), $options);
     }
 
     /**

--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -63,6 +63,39 @@ class SchemaTest extends TestCase
         $this->assertEquals(1024, $collection['options']['size']);
     }
 
+    public function testCreateWithSchemaValidator(): void
+    {
+        $schema = [
+            'bsonType' => 'object',
+            'required' => [ 'username' ],
+            'properties' => [
+                'username' => [
+                    'bsonType' => 'string',
+                    'description' => 'must be a string and is required',
+                ],
+            ],
+        ];
+
+        Schema::create(self::COLL_2, function (Blueprint $collection) use ($schema) {
+            $collection->string('username');
+            $collection->jsonSchema(schema: $schema, validationAction: 'warn');
+        });
+
+        $this->assertTrue(Schema::hasCollection(self::COLL_2));
+        $this->assertTrue(Schema::hasTable(self::COLL_2));
+
+        $collection = Schema::getCollection(self::COLL_2);
+        $this->assertEquals(
+            ['$jsonSchema' => $schema],
+            $collection['options']['validator'],
+        );
+
+        $this->assertEquals(
+            'warn',
+            $collection['options']['validationAction'],
+        );
+    }
+
     public function testDrop(): void
     {
         Schema::create(self::COLL_1);


### PR DESCRIPTION
To support the `'$jsonSchema'` operation on collections.
Closes PHPORM-72.

### Checklist

- [x] Add tests and ensure they pass
