### PR TITLE
PHPORM-264: Deprecate Mongo soft deletes trait

### DIFF
--- a/docs/includes/eloquent-models/PlanetSoftDelete.php
+++ b/docs/includes/eloquent-models/PlanetSoftDelete.php
@@ -2,8 +2,8 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\SoftDeletes;
 use MongoDB\Laravel\Eloquent\Model;
-use MongoDB\Laravel\Eloquent\SoftDeletes;
 
 class Planet extends Model
 {

--- a/src/Eloquent/MassPrunable.php
+++ b/src/Eloquent/MassPrunable.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MongoDB\Laravel\Eloquent;
 
 use Illuminate\Database\Eloquent\MassPrunable as EloquentMassPrunable;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Events\ModelsPruned;
 
 use function class_uses_recursive;

--- a/src/Eloquent/SoftDeletes.php
+++ b/src/Eloquent/SoftDeletes.php
@@ -4,7 +4,14 @@ declare(strict_types=1);
 
 namespace MongoDB\Laravel\Eloquent;
 
-/** @deprecated 6.0.0 in favor of \Illuminate\Database\Eloquent\SoftDeletes */
+use function sprintf;
+use function trigger_error;
+
+use const E_USER_DEPRECATED;
+
+trigger_error(sprintf('Since mongodb/laravel-mongodb:5.5, trait "%s" is deprecated, use "%s" instead.', SoftDeletes::class, \Illuminate\Database\Eloquent\SoftDeletes::class), E_USER_DEPRECATED);
+
+/** @deprecated since mongodb/laravel-mongodb:5.5, use \Illuminate\Database\Eloquent\SoftDeletes instead */
 trait SoftDeletes
 {
     use \Illuminate\Database\Eloquent\SoftDeletes;

--- a/src/Eloquent/SoftDeletes.php
+++ b/src/Eloquent/SoftDeletes.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Laravel\Eloquent;
 
+/** @deprecated 6.0.0 in favor of \Illuminate\Database\Eloquent\SoftDeletes */
 trait SoftDeletes
 {
     use \Illuminate\Database\Eloquent\SoftDeletes;

--- a/tests/Models/Soft.php
+++ b/tests/Models/Soft.php
@@ -6,10 +6,10 @@ namespace MongoDB\Laravel\Tests\Models;
 
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use MongoDB\Laravel\Eloquent\Builder;
 use MongoDB\Laravel\Eloquent\DocumentModel;
 use MongoDB\Laravel\Eloquent\MassPrunable;
-use MongoDB\Laravel\Eloquent\SoftDeletes;
 
 /** @property Carbon $deleted_at */
 class Soft extends Model

--- a/tests/Scout/Models/ScoutUser.php
+++ b/tests/Scout/Models/ScoutUser.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace MongoDB\Laravel\Tests\Scout\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\SQLiteBuilder;
 use Illuminate\Support\Facades\Schema;
 use Laravel\Scout\Searchable;
-use MongoDB\Laravel\Eloquent\SoftDeletes;
 
 use function assert;
 


### PR DESCRIPTION
In favor of the Laravel one. Ours is now obsolete; the SoftDeletes trait is only necessary to remove the call to qualifyColumn in the parent trait. But the DocumentModel::qualifyColumn is already disabled.

Also replaces some internal/test usages with the recommended trait.

Closes PHPORM-264 

### Checklist

- [x] Ensure tests still pass
