### PR TITLE
Limit CI workflows to supported branches

### DIFF
--- a/.github/workflows/build-ci-atlas.yml
+++ b/.github/workflows/build-ci-atlas.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - "[0-9]+.[0-9x]+"
+      - "feature/*"
   pull_request:
     branches:
       - "[0-9]+.[0-9x]+"
+      - "feature/*"
 
 env:
   MONGODB_EXT_V1: mongodb-1.21.0

--- a/.github/workflows/build-ci-atlas.yml
+++ b/.github/workflows/build-ci-atlas.yml
@@ -1,94 +1,94 @@
 name: "Atlas CI"
 
 on:
-    push:
-    pull_request:
+  push:
+  pull_request:
 
 env:
   MONGODB_EXT_V1: mongodb-1.21.0
   MONGODB_EXT_V2: stable
 
 jobs:
-    build:
-        runs-on: "${{ matrix.os }}"
+  build:
+    runs-on: "${{ matrix.os }}"
 
-        name: "PHP/${{ matrix.php }} Laravel/${{ matrix.laravel }} Driver/${{ matrix.driver }}"
+    name: "PHP/${{ matrix.php }} Laravel/${{ matrix.laravel }} Driver/${{ matrix.driver }}"
 
-        strategy:
-            matrix:
-                os:
-                    - "ubuntu-latest"
-                php:
-                    - "8.2"
-                    - "8.3"
-                    - "8.4"
-                laravel:
-                    - "11.*"
-                    - "12.*"
-                driver:
-                  - 1
-                include:
-                    -   php: "8.4"
-                        laravel: "12.*"
-                        os: "ubuntu-latest"
-                        driver: 2
+    strategy:
+      matrix:
+        os:
+          - "ubuntu-latest"
+        php:
+          - "8.2"
+          - "8.3"
+          - "8.4"
+        laravel:
+          - "11.*"
+          - "12.*"
+        driver:
+          - 1
+        include:
+          - php: "8.4"
+            laravel: "12.*"
+            os: "ubuntu-latest"
+            driver: 2
 
-        steps:
-            -   uses: "actions/checkout@v4"
+    steps:
+      - uses: "actions/checkout@v4"
 
-            -   name: "Create MongoDB Atlas Local"
-                run: |
-                    docker run --name mongodb -p 27017:27017 --detach mongodb/mongodb-atlas-local:latest
-                    until docker exec --tty mongodb mongosh --eval "db.runCommand({ ping: 1 })"; do
-                      sleep 1
-                    done
-                    until docker exec --tty mongodb mongosh --eval "db.createCollection('connection_test') && db.getCollection('connection_test').createSearchIndex({mappings:{dynamic: true}})"; do
-                      sleep 1
-                    done
+      - name: "Create MongoDB Atlas Local"
+        run: |
+          docker run --name mongodb -p 27017:27017 --detach mongodb/mongodb-atlas-local:latest
+          until docker exec --tty mongodb mongosh --eval "db.runCommand({ ping: 1 })"; do
+            sleep 1
+          done
+          until docker exec --tty mongodb mongosh --eval "db.createCollection('connection_test') && db.getCollection('connection_test').createSearchIndex({mappings:{dynamic: true}})"; do
+            sleep 1
+          done
 
-            -   name: "Show MongoDB server status"
-                run: |
-                    docker exec --tty mongodb mongosh --eval "db.runCommand({ serverStatus: 1 })"
+      - name: "Show MongoDB server status"
+        run: |
+          docker exec --tty mongodb mongosh --eval "db.runCommand({ serverStatus: 1 })"
 
-            -   name: Setup cache environment
-                id: extcache
-                uses: shivammathur/cache-extensions@v1
-                with:
-                    php-version: ${{ matrix.php }}
-                    extensions: ${{ matrix.driver == 1 && env.MONGODB_EXT_V1 || env.MONGODB_EXT_V2 }}
-                    key: "extcache-v1"
+      - name: Setup cache environment
+        id: extcache
+        uses: shivammathur/cache-extensions@v1
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: ${{ matrix.driver == 1 && env.MONGODB_EXT_V1 || env.MONGODB_EXT_V2 }}
+          key: "extcache-v1"
 
-            -   name: "Installing php"
-                uses: "shivammathur/setup-php@v2"
-                with:
-                    php-version: ${{ matrix.php }}
-                    extensions: "curl,mbstring,xdebug,${{ matrix.driver == 1 && env.MONGODB_EXT_V1 || env.MONGODB_EXT_V2 }}"
-                    coverage: "xdebug"
-                    tools: "composer"
+      - name: "Installing php"
+        uses: "shivammathur/setup-php@v2"
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: "curl,mbstring,xdebug,${{ matrix.driver == 1 && env.MONGODB_EXT_V1 || env.MONGODB_EXT_V2 }}"
+          coverage: "xdebug"
+          tools: "composer"
 
-            -   name: "Show Docker version"
-                if: ${{ runner.debug }}
-                run: "docker version && env"
+      - name: "Show Docker version"
+        if: ${{ runner.debug }}
+        run: "docker version && env"
 
-            -   name: "Restrict Laravel version"
-                run: "composer require --dev --no-update 'laravel/framework:${{ matrix.laravel }}'"
+      - name: "Restrict Laravel version"
+        run: "composer require --dev --no-update 'laravel/framework:${{ matrix.laravel }}'"
 
-            -   name: "Download Composer cache dependencies from cache"
-                id: "composer-cache"
-                run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+      - name: "Download Composer cache dependencies from cache"
+        id: "composer-cache"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
-            -   name: "Cache Composer dependencies"
-                uses: "actions/cache@v4"
-                with:
-                    path: ${{ steps.composer-cache.outputs.dir }}
-                    key: "${{ matrix.os }}-composer-${{ hashFiles('**/composer.json') }}"
-                    restore-keys: "${{ matrix.os }}-composer-"
+      - name: "Cache Composer dependencies"
+        uses: "actions/cache@v4"
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: "${{ matrix.os }}-composer-${{ hashFiles('**/composer.json') }}"
+          restore-keys: "${{ matrix.os }}-composer-"
 
-            -   name: "Install dependencies"
-                run: |
-                  composer update --no-interaction
+      - name: "Install dependencies"
+        run: |
+          composer update --no-interaction
 
-            -   name: "Run tests"
-                run: |
-                  export MONGODB_URI="mongodb://127.0.0.1:27017/?directConnection=true"
-                  php -d zend.assertions=1 ./vendor/bin/phpunit --coverage-clover coverage.xml --group atlas-search
+      - name: "Run tests"
+        run: |
+          export MONGODB_URI="mongodb://127.0.0.1:27017/?directConnection=true"
+          php -d zend.assertions=1 ./vendor/bin/phpunit --coverage-clover coverage.xml --group atlas-search

--- a/.github/workflows/build-ci-atlas.yml
+++ b/.github/workflows/build-ci-atlas.yml
@@ -2,7 +2,11 @@ name: "Atlas CI"
 
 on:
   push:
+    branches:
+      - "[0-9]+.[0-9x]+"
   pull_request:
+    branches:
+      - "[0-9]+.[0-9x]+"
 
 env:
   MONGODB_EXT_V1: mongodb-1.21.0

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - "[0-9]+.[0-9x]+"
+      - "feature/*"
   pull_request:
     branches:
       - "[0-9]+.[0-9x]+"
+      - "feature/*"
 
 env:
   MONGODB_EXT_V1: mongodb-1.21.0

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -1,121 +1,121 @@
 name: "CI"
 
 on:
-    push:
-    pull_request:
+  push:
+  pull_request:
 
 env:
   MONGODB_EXT_V1: mongodb-1.21.0
   MONGODB_EXT_V2: stable
 
 jobs:
-    build:
-        runs-on: "${{ matrix.os }}"
+  build:
+    runs-on: "${{ matrix.os }}"
 
-        name: "PHP/${{ matrix.php }} Laravel/${{ matrix.laravel }} Driver/${{ matrix.driver }} Server/${{ matrix.mongodb }} ${{ matrix.mode }}"
+    name: "PHP/${{ matrix.php }} Laravel/${{ matrix.laravel }} Driver/${{ matrix.driver }} Server/${{ matrix.mongodb }} ${{ matrix.mode }}"
 
-        strategy:
-            matrix:
-                os:
-                    - "ubuntu-latest"
-                mongodb:
-                    - "4.4"
-                    - "5.0"
-                    - "6.0"
-                    - "7.0"
-                    - "8.0"
-                php:
-                    - "8.1"
-                    - "8.2"
-                    - "8.3"
-                    - "8.4"
-                laravel:
-                    - "10.*"
-                    - "11.*"
-                    - "12.*"
-                driver:
-                    - 2
-                include:
-                    - php: "8.1"
-                      laravel: "10.*"
-                      mongodb: "5.0"
-                      mode: "low-deps"
-                      os: "ubuntu-latest"
-                      driver: 1
-                    - php: "8.3"
-                      laravel: "11.*"
-                      mongodb: "8.0"
-                      os: "ubuntu-latest"
-                      driver: 1
-                    - php: "8.4"
-                      laravel: "12.*"
-                      mongodb: "8.0"
-                      os: "ubuntu-latest"
-                      driver: 1
-                exclude:
-                    - php: "8.1"
-                      laravel: "11.*"
-                    - php: "8.1"
-                      laravel: "12.*"
+    strategy:
+      matrix:
+        os:
+          - "ubuntu-latest"
+        mongodb:
+          - "4.4"
+          - "5.0"
+          - "6.0"
+          - "7.0"
+          - "8.0"
+        php:
+          - "8.1"
+          - "8.2"
+          - "8.3"
+          - "8.4"
+        laravel:
+          - "10.*"
+          - "11.*"
+          - "12.*"
+        driver:
+          - 2
+        include:
+          - php: "8.1"
+            laravel: "10.*"
+            mongodb: "5.0"
+            mode: "low-deps"
+            os: "ubuntu-latest"
+            driver: 1
+          - php: "8.3"
+            laravel: "11.*"
+            mongodb: "8.0"
+            os: "ubuntu-latest"
+            driver: 1
+          - php: "8.4"
+            laravel: "12.*"
+            mongodb: "8.0"
+            os: "ubuntu-latest"
+            driver: 1
+        exclude:
+          - php: "8.1"
+            laravel: "11.*"
+          - php: "8.1"
+            laravel: "12.*"
 
-        steps:
-            -   uses: "actions/checkout@v4"
+    steps:
+      - uses: "actions/checkout@v4"
 
-            -   name: "Create MongoDB Replica Set"
-                run: |
-                    docker run --name mongodb -p 27017:27017 -e MONGO_INITDB_DATABASE=unittest --detach mongo:${{ matrix.mongodb }} mongod --replSet rs --setParameter transactionLifetimeLimitSeconds=5
+      - name: "Create MongoDB Replica Set"
+        run: |
+          docker run --name mongodb -p 27017:27017 -e MONGO_INITDB_DATABASE=unittest --detach mongo:${{ matrix.mongodb }} mongod --replSet rs --setParameter transactionLifetimeLimitSeconds=5
 
-                    if [ "${{ matrix.mongodb }}" = "4.4" ]; then MONGOSH_BIN="mongo"; else MONGOSH_BIN="mongosh"; fi
-                    until docker exec --tty mongodb $MONGOSH_BIN --eval "db.runCommand({ ping: 1 })"; do
-                      sleep 1
-                    done
-                    sudo docker exec --tty mongodb $MONGOSH_BIN --eval "rs.initiate({\"_id\":\"rs\",\"members\":[{\"_id\":0,\"host\":\"127.0.0.1:27017\" }]})"
+          if [ "${{ matrix.mongodb }}" = "4.4" ]; then MONGOSH_BIN="mongo"; else MONGOSH_BIN="mongosh"; fi
+          until docker exec --tty mongodb $MONGOSH_BIN --eval "db.runCommand({ ping: 1 })"; do
+            sleep 1
+          done
+          sudo docker exec --tty mongodb $MONGOSH_BIN --eval "rs.initiate({\"_id\":\"rs\",\"members\":[{\"_id\":0,\"host\":\"127.0.0.1:27017\" }]})"
 
-            -   name: "Show MongoDB server status"
-                run: |
-                    if [ "${{ matrix.mongodb }}" = "4.4" ]; then MONGOSH_BIN="mongo"; else MONGOSH_BIN="mongosh"; fi
-                    docker exec --tty mongodb $MONGOSH_BIN --eval "db.runCommand({ serverStatus: 1 })"
+      - name: "Show MongoDB server status"
+        run: |
+          if [ "${{ matrix.mongodb }}" = "4.4" ]; then MONGOSH_BIN="mongo"; else MONGOSH_BIN="mongosh"; fi
+          docker exec --tty mongodb $MONGOSH_BIN --eval "db.runCommand({ serverStatus: 1 })"
 
-            -   name: Setup cache environment
-                id: extcache
-                uses: shivammathur/cache-extensions@v1
-                with:
-                    php-version: ${{ matrix.php }}
-                    extensions: ${{ matrix.driver == 1 && env.MONGODB_EXT_V1 || env.MONGODB_EXT_V2 }}
-                    key: "extcache-v1"
+      - name: Setup cache environment
+        id: extcache
+        uses: shivammathur/cache-extensions@v1
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: ${{ matrix.driver == 1 && env.MONGODB_EXT_V1 || env.MONGODB_EXT_V2 }}
+          key: "extcache-v1"
 
-            -   name: "Installing php"
-                uses: "shivammathur/setup-php@v2"
-                with:
-                    php-version: ${{ matrix.php }}
-                    extensions: "curl,mbstring,xdebug,${{ matrix.driver == 1 && env.MONGODB_EXT_V1 || env.MONGODB_EXT_V2 }}"
-                    coverage: "xdebug"
-                    tools: "composer"
+      - name: "Installing php"
+        uses: "shivammathur/setup-php@v2"
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: "curl,mbstring,xdebug,${{ matrix.driver == 1 && env.MONGODB_EXT_V1 || env.MONGODB_EXT_V2 }}"
+          coverage: "xdebug"
+          tools: "composer"
 
-            -   name: "Show Docker version"
-                if: ${{ runner.debug }}
-                run: "docker version && env"
+      - name: "Show Docker version"
+        if: ${{ runner.debug }}
+        run: "docker version && env"
 
-            -   name: "Restrict Laravel version"
-                run: "composer require --dev --no-update 'laravel/framework:${{ matrix.laravel }}'"
+      - name: "Restrict Laravel version"
+        run: "composer require --dev --no-update 'laravel/framework:${{ matrix.laravel }}'"
 
-            -   name: "Download Composer cache dependencies from cache"
-                id: "composer-cache"
-                run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+      - name: "Download Composer cache dependencies from cache"
+        id: "composer-cache"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
-            -   name: "Cache Composer dependencies"
-                uses: "actions/cache@v4"
-                with:
-                    path: ${{ steps.composer-cache.outputs.dir }}
-                    key: "${{ matrix.os }}-composer-${{ hashFiles('**/composer.json') }}"
-                    restore-keys: "${{ matrix.os }}-composer-"
+      - name: "Cache Composer dependencies"
+        uses: "actions/cache@v4"
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: "${{ matrix.os }}-composer-${{ hashFiles('**/composer.json') }}"
+          restore-keys: "${{ matrix.os }}-composer-"
 
-            -   name: "Install dependencies"
-                run: |
-                  composer update --no-interaction \
-                    $([[ "${{ matrix.mode }}" == low-deps ]] && echo ' --prefer-lowest') \
-                    $([[ "${{ matrix.mode }}" == ignore-php-req ]] && echo ' --ignore-platform-req=php+')
-            -   name: "Run tests"
-                run: |
-                  export MONGODB_URI="mongodb://127.0.0.1:27017/?replicaSet=rs"
-                  php -d zend.assertions=1 ./vendor/bin/phpunit --coverage-clover coverage.xml --exclude-group atlas-search
+      - name: "Install dependencies"
+        run: |
+          composer update --no-interaction \
+          $([[ "${{ matrix.mode }}" == low-deps ]] && echo ' --prefer-lowest') \
+          $([[ "${{ matrix.mode }}" == ignore-php-req ]] && echo ' --ignore-platform-req=php+')
+      - name: "Run tests"
+        run: |
+          export MONGODB_URI="mongodb://127.0.0.1:27017/?replicaSet=rs"
+          php -d zend.assertions=1 ./vendor/bin/phpunit --coverage-clover coverage.xml --exclude-group atlas-search

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -2,7 +2,11 @@ name: "CI"
 
 on:
   push:
+    branches:
+      - "[0-9]+.[0-9x]+"
   pull_request:
+    branches:
+      - "[0-9]+.[0-9x]+"
 
 env:
   MONGODB_EXT_V1: mongodb-1.21.0

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - "[0-9]+.[0-9x]+"
+      - "feature/*"
   pull_request:
     branches:
       - "[0-9]+.[0-9x]+"
+      - "feature/*"
 
 env:
   PHP_VERSION: "8.4"

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -2,7 +2,11 @@ name: "Coding Standards"
 
 on:
   push:
+    branches:
+      - "[0-9]+.[0-9x]+"
   pull_request:
+    branches:
+      - "[0-9]+.[0-9x]+"
 
 env:
   PHP_VERSION: "8.4"

--- a/.github/workflows/merge-up.yml
+++ b/.github/workflows/merge-up.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "[0-9]+.[0-9x]+"
+      - "feature/*"
 
 env:
   GH_TOKEN: ${{ secrets.MERGE_UP_TOKEN }}

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - "[0-9]+.[0-9x]+"
+      - "feature/*"
   pull_request:
     branches:
       - "[0-9]+.[0-9x]+"
+      - "feature/*"
   workflow_call:
     inputs:
       ref:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -2,7 +2,11 @@ name: "Static Analysis"
 
 on:
   push:
+    branches:
+      - "[0-9]+.[0-9x]+"
   pull_request:
+    branches:
+      - "[0-9]+.[0-9x]+"
   workflow_call:
     inputs:
       ref:


### PR DESCRIPTION
This PR adds branch restrictions to the `push` and `pull_request` triggers for workflows. CI used to run on all branches pushed, whereas we now only run it for supported branches. This avoids failing runs for the static-analysis workflow but makes sense for all workflows.

Note: I changed indentation in the build-ci workflow files to two spaces for consistency with other workflow files. I recommend viewing changes ignoring whitespace to cut through the noise. The actual changes are contained in the second commit.