### PR TITLE
PHPORM-146: Add override attribute everywhere

### DIFF
--- a/src/Bus/MongoBatchRepository.php
+++ b/src/Bus/MongoBatchRepository.php
@@ -216,6 +216,7 @@ class MongoBatchRepository extends DatabaseBatchRepository implements PrunableBa
     }
 
     /** Prune all the unfinished entries older than the given date. */
+    #[Override]
     public function pruneUnfinished(DateTimeInterface $before): int
     {
         $result = $this->collection->deleteMany(
@@ -229,6 +230,7 @@ class MongoBatchRepository extends DatabaseBatchRepository implements PrunableBa
     }
 
     /** Prune all the cancelled entries older than the given date. */
+    #[Override]
     public function pruneCancelled(DateTimeInterface $before): int
     {
         $result = $this->collection->deleteMany(

--- a/src/Cache/MongoLock.php
+++ b/src/Cache/MongoLock.php
@@ -41,6 +41,7 @@ final class MongoLock extends Lock
     /**
      * Attempt to acquire the lock.
      */
+    #[Override]
     public function acquire(): bool
     {
         // The lock can be acquired if: it doesn't exist, it has expired,

--- a/src/CommandSubscriber.php
+++ b/src/CommandSubscriber.php
@@ -7,6 +7,7 @@ use MongoDB\Driver\Monitoring\CommandFailedEvent;
 use MongoDB\Driver\Monitoring\CommandStartedEvent;
 use MongoDB\Driver\Monitoring\CommandSubscriber as CommandSubscriberInterface;
 use MongoDB\Driver\Monitoring\CommandSucceededEvent;
+use Override;
 
 use function get_object_vars;
 use function in_array;
@@ -21,16 +22,19 @@ final class CommandSubscriber implements CommandSubscriberInterface
     {
     }
 
+    #[Override]
     public function commandStarted(CommandStartedEvent $event): void
     {
         $this->commands[$event->getOperationId()] = $event;
     }
 
+    #[Override]
     public function commandFailed(CommandFailedEvent $event): void
     {
         $this->logQuery($event);
     }
 
+    #[Override]
     public function commandSucceeded(CommandSucceededEvent $event): void
     {
         $this->logQuery($event);

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -16,6 +16,7 @@ use MongoDB\Driver\Exception\RuntimeException;
 use MongoDB\Driver\ReadPreference;
 use MongoDB\Laravel\Concerns\ManagesTransactions;
 use OutOfBoundsException;
+use Override;
 use Throwable;
 
 use function filter_var;
@@ -95,6 +96,7 @@ class Connection extends BaseConnection
      *
      * @return Query\Builder
      */
+    #[Override]
     public function table($table, $as = null)
     {
         $query = new Query\Builder($this, $this->getQueryGrammar(), $this->getPostProcessor());
@@ -115,6 +117,7 @@ class Connection extends BaseConnection
     }
 
     /** @inheritdoc */
+    #[Override]
     public function getSchemaBuilder()
     {
         return new Schema\Builder($this);
@@ -172,6 +175,8 @@ class Connection extends BaseConnection
         return $this->connection;
     }
 
+    /** @inheritdoc  */
+    #[Override]
     public function enableQueryLog()
     {
         parent::enableQueryLog();
@@ -182,6 +187,7 @@ class Connection extends BaseConnection
         }
     }
 
+    #[Override]
     public function disableQueryLog()
     {
         parent::disableQueryLog();
@@ -192,6 +198,7 @@ class Connection extends BaseConnection
         }
     }
 
+    #[Override]
     protected function withFreshQueryLog($callback)
     {
         try {
@@ -340,6 +347,7 @@ class Connection extends BaseConnection
     }
 
     /** @inheritdoc */
+    #[Override]
     public function getDriverName()
     {
         return 'mongodb';
@@ -352,12 +360,14 @@ class Connection extends BaseConnection
     }
 
     /** @inheritdoc */
+    #[Override]
     protected function getDefaultPostProcessor()
     {
         return new Query\Processor();
     }
 
     /** @inheritdoc */
+    #[Override]
     protected function getDefaultQueryGrammar()
     {
         // Argument added in Laravel 12
@@ -365,6 +375,7 @@ class Connection extends BaseConnection
     }
 
     /** @inheritdoc */
+    #[Override]
     protected function getDefaultSchemaGrammar()
     {
         // Argument added in Laravel 12

--- a/src/Eloquent/Builder.php
+++ b/src/Eloquent/Builder.php
@@ -18,6 +18,7 @@ use MongoDB\Laravel\Connection;
 use MongoDB\Laravel\Helpers\QueriesRelationships;
 use MongoDB\Laravel\Query\AggregationBuilder;
 use MongoDB\Model\BSONDocument;
+use Override;
 
 use function array_key_exists;
 use function array_map;
@@ -127,7 +128,12 @@ class Builder extends EloquentBuilder
         return $this->model->hydrate($results->all());
     }
 
-    /** @inheritdoc */
+    /**
+     * @param array $options
+     *
+     * @inheritdoc
+     */
+    #[Override]
     public function update(array $values, array $options = [])
     {
         // Intercept operations on embedded models and delegate logic
@@ -270,6 +276,7 @@ class Builder extends EloquentBuilder
         return $results;
     }
 
+    #[Override]
     public function firstOrCreate(array $attributes = [], array $values = [])
     {
         $instance = (clone $this)->where($attributes)->first();
@@ -285,6 +292,7 @@ class Builder extends EloquentBuilder
         return $this->createOrFirst($attributes, $values);
     }
 
+    #[Override]
     public function createOrFirst(array $attributes = [], array $values = [])
     {
         // The duplicate key error would abort the transaction. Using the regular firstOrCreate in that case.
@@ -308,9 +316,8 @@ class Builder extends EloquentBuilder
      * TODO Remove if https://github.com/laravel/framework/commit/6484744326531829341e1ff886cc9b628b20d73e
      * will be reverted
      * Issue in laravel/frawework https://github.com/laravel/framework/issues/27791.
-     *
-     * @return array
      */
+    #[Override]
     protected function addUpdatedAtColumn(array $values)
     {
         if (! $this->model->usesTimestamps() || $this->model->getUpdatedAtColumn() === null) {
@@ -332,6 +339,7 @@ class Builder extends EloquentBuilder
     }
 
     /** @inheritdoc */
+    #[Override]
     protected function ensureOrderForCursorPagination($shouldReverse = false)
     {
         if (empty($this->query->orders)) {

--- a/src/MongoDBBusServiceProvider.php
+++ b/src/MongoDBBusServiceProvider.php
@@ -10,6 +10,7 @@ use Illuminate\Contracts\Support\DeferrableProvider;
 use Illuminate\Support\ServiceProvider;
 use InvalidArgumentException;
 use MongoDB\Laravel\Bus\MongoBatchRepository;
+use Override;
 
 use function sprintf;
 
@@ -18,6 +19,7 @@ class MongoDBBusServiceProvider extends ServiceProvider implements DeferrablePro
     /**
      * Register the service provider.
      */
+    #[Override]
     public function register()
     {
         $this->app->singleton(MongoBatchRepository::class, function (Container $app) {
@@ -46,6 +48,8 @@ class MongoDBBusServiceProvider extends ServiceProvider implements DeferrablePro
         });
     }
 
+    /** @inheritdoc */
+    #[Override]
     public function provides()
     {
         return [

--- a/src/MongoDBServiceProvider.php
+++ b/src/MongoDBServiceProvider.php
@@ -24,6 +24,7 @@ use MongoDB\Laravel\Eloquent\Model;
 use MongoDB\Laravel\Queue\MongoConnector;
 use MongoDB\Laravel\Scout\ScoutEngine;
 use MongoDB\Laravel\Session\MongoDbSessionHandler;
+use Override;
 use RuntimeException;
 
 use function assert;
@@ -47,6 +48,7 @@ class MongoDBServiceProvider extends ServiceProvider
     /**
      * Register the service provider.
      */
+    #[Override]
     public function register()
     {
         // Add database driver.

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -243,12 +243,14 @@ class Builder extends BaseBuilder
     }
 
     /** @inheritdoc */
+    #[Override]
     public function find($id, $columns = [])
     {
         return $this->where('_id', '=', $this->convertKey($id))->first($columns);
     }
 
     /** @inheritdoc */
+    #[Override]
     public function value($column)
     {
         $result = (array) $this->first([$column]);
@@ -257,12 +259,14 @@ class Builder extends BaseBuilder
     }
 
     /** @inheritdoc */
+    #[Override]
     public function get($columns = [])
     {
         return $this->getFresh($columns);
     }
 
     /** @inheritdoc */
+    #[Override]
     public function cursor($columns = [])
     {
         $result = $this->getFresh($columns, true);
@@ -579,6 +583,7 @@ class Builder extends BaseBuilder
     }
 
     /** @return ($function is null ? AggregationBuilder : mixed) */
+    #[Override]
     public function aggregate($function = null, $columns = ['*'])
     {
         assert(is_array($columns), new TypeError(sprintf('Argument #2 ($columns) must be of type array, %s given', get_debug_type($columns))));
@@ -640,9 +645,10 @@ class Builder extends BaseBuilder
     }
 
     /**
-     * {@inheritDoc}
+     * @param string $function
+     * @param array  $columns
      *
-     * @see \Illuminate\Database\Query\Builder::aggregateByGroup()
+     * @return mixed
      */
     public function aggregateByGroup(string $function, array $columns = ['*'])
     {
@@ -654,6 +660,7 @@ class Builder extends BaseBuilder
     }
 
     /** @inheritdoc */
+    #[Override]
     public function exists()
     {
         return $this->first(['id']) !== null;
@@ -676,6 +683,7 @@ class Builder extends BaseBuilder
      *
      * @inheritdoc
      */
+    #[Override]
     public function orderBy($column, $direction = 'asc')
     {
         if (is_string($direction)) {
@@ -697,6 +705,7 @@ class Builder extends BaseBuilder
     }
 
     /** @inheritdoc */
+    #[Override]
     public function whereBetween($column, iterable $values, $boolean = 'and', $not = false)
     {
         $type = 'between';
@@ -721,6 +730,7 @@ class Builder extends BaseBuilder
     }
 
     /** @inheritdoc */
+    #[Override]
     public function insert(array $values)
     {
         // Allow empty insert batch for consistency with Eloquent SQL
@@ -755,6 +765,7 @@ class Builder extends BaseBuilder
     }
 
     /** @inheritdoc */
+    #[Override]
     public function insertGetId(array $values, $sequence = null)
     {
         $options = $this->inheritConnectionOptions();
@@ -774,6 +785,7 @@ class Builder extends BaseBuilder
     }
 
     /** @inheritdoc */
+    #[Override]
     public function update(array $values, array $options = [])
     {
         // Use $set as default operator for field names that are not in an operator
@@ -790,6 +802,7 @@ class Builder extends BaseBuilder
     }
 
     /** @inheritdoc */
+    #[Override]
     public function upsert(array $values, $uniqueBy, $update = null): int
     {
         if ($values === []) {
@@ -836,6 +849,7 @@ class Builder extends BaseBuilder
     }
 
     /** @inheritdoc */
+    #[Override]
     public function increment($column, $amount = 1, array $extra = [], array $options = [])
     {
         $query = ['$inc' => [(string) $column => $amount]];
@@ -856,6 +870,12 @@ class Builder extends BaseBuilder
         return $this->performUpdate($query, $options);
     }
 
+    /**
+     * @param array $options
+     *
+     * @inheritdoc
+     */
+    #[Override]
     public function incrementEach(array $columns, array $extra = [], array $options = [])
     {
         $stage['$addFields'] = $extra;
@@ -873,12 +893,14 @@ class Builder extends BaseBuilder
     }
 
     /** @inheritdoc */
+    #[Override]
     public function decrement($column, $amount = 1, array $extra = [], array $options = [])
     {
         return $this->increment($column, -1 * $amount, $extra, $options);
     }
 
     /** @inheritdoc */
+    #[Override]
     public function decrementEach(array $columns, array $extra = [], array $options = [])
     {
         $decrement = [];
@@ -932,6 +954,7 @@ class Builder extends BaseBuilder
     }
 
     /** @inheritdoc */
+    #[Override]
     public function pluck($column, $key = null)
     {
         $results = $this->get($key === null ? [$column] : [$column, $key]);
@@ -942,6 +965,7 @@ class Builder extends BaseBuilder
     }
 
     /** @inheritdoc */
+    #[Override]
     public function delete($id = null)
     {
         // If an ID is passed to the method, we will set the where clause to check
@@ -973,6 +997,7 @@ class Builder extends BaseBuilder
     }
 
     /** @inheritdoc */
+    #[Override]
     public function from($collection, $as = null)
     {
         if ($collection) {
@@ -1012,6 +1037,7 @@ class Builder extends BaseBuilder
      *
      * @template T
      */
+    #[Override]
     public function raw($value = null)
     {
         // Execute the closure on the mongodb collection
@@ -1114,11 +1140,13 @@ class Builder extends BaseBuilder
      *
      * @inheritdoc
      */
+    #[Override]
     public function newQuery()
     {
         return new static($this->connection, $this->grammar, $this->processor);
     }
 
+    #[Override]
     public function runPaginationCountQuery($columns = ['*'])
     {
         if ($this->distinct) {
@@ -1201,6 +1229,7 @@ class Builder extends BaseBuilder
      *
      * @return $this
      */
+    #[Override]
     public function where($column, $operator = null, $value = null, $boolean = 'and')
     {
         $params = func_get_args();
@@ -1714,6 +1743,7 @@ class Builder extends BaseBuilder
     }
 
     /** @inheritdoc */
+    #[Override]
     public function __call($method, $parameters)
     {
         if ($method === 'unset') {
@@ -1724,90 +1754,105 @@ class Builder extends BaseBuilder
     }
 
     /** @internal This method is not supported by MongoDB. */
+    #[Override]
     public function toSql()
     {
         throw new BadMethodCallException('This method is not supported by MongoDB. Try "toMql()" instead.');
     }
 
     /** @internal This method is not supported by MongoDB. */
+    #[Override]
     public function toRawSql()
     {
         throw new BadMethodCallException('This method is not supported by MongoDB. Try "toMql()" instead.');
     }
 
     /** @internal This method is not supported by MongoDB. */
+    #[Override]
     public function whereColumn($first, $operator = null, $second = null, $boolean = 'and')
     {
         throw new BadMethodCallException('This method is not supported by MongoDB');
     }
 
     /** @internal This method is not supported by MongoDB. */
+    #[Override]
     public function whereFullText($columns, $value, array $options = [], $boolean = 'and')
     {
         throw new BadMethodCallException('This method is not supported by MongoDB');
     }
 
     /** @internal This method is not supported by MongoDB. */
+    #[Override]
     public function groupByRaw($sql, array $bindings = [])
     {
         throw new BadMethodCallException('This method is not supported by MongoDB');
     }
 
     /** @internal This method is not supported by MongoDB. */
+    #[Override]
     public function orderByRaw($sql, $bindings = [])
     {
         throw new BadMethodCallException('This method is not supported by MongoDB');
     }
 
     /** @internal This method is not supported by MongoDB. */
+    #[Override]
     public function unionAll($query)
     {
         throw new BadMethodCallException('This method is not supported by MongoDB');
     }
 
     /** @internal This method is not supported by MongoDB. */
+    #[Override]
     public function union($query, $all = false)
     {
         throw new BadMethodCallException('This method is not supported by MongoDB');
     }
 
     /** @internal This method is not supported by MongoDB. */
+    #[Override]
     public function having($column, $operator = null, $value = null, $boolean = 'and')
     {
         throw new BadMethodCallException('This method is not supported by MongoDB');
     }
 
     /** @internal This method is not supported by MongoDB. */
+    #[Override]
     public function havingRaw($sql, array $bindings = [], $boolean = 'and')
     {
         throw new BadMethodCallException('This method is not supported by MongoDB');
     }
 
     /** @internal This method is not supported by MongoDB. */
+    #[Override]
     public function havingBetween($column, iterable $values, $boolean = 'and', $not = false)
     {
         throw new BadMethodCallException('This method is not supported by MongoDB');
     }
 
     /** @internal This method is not supported by MongoDB. */
+    #[Override]
     public function whereIntegerInRaw($column, $values, $boolean = 'and', $not = false)
     {
         throw new BadMethodCallException('This method is not supported by MongoDB');
     }
 
     /** @internal This method is not supported by MongoDB. */
+    #[Override]
     public function orWhereIntegerInRaw($column, $values)
     {
         throw new BadMethodCallException('This method is not supported by MongoDB');
     }
 
     /** @internal This method is not supported by MongoDB. */
+    #[Override]
     public function whereIntegerNotInRaw($column, $values, $boolean = 'and')
     {
         throw new BadMethodCallException('This method is not supported by MongoDB');
     }
 
     /** @internal This method is not supported by MongoDB. */
+    #[Override]
     public function orWhereIntegerNotInRaw($column, $values, $boolean = 'and')
     {
         throw new BadMethodCallException('This method is not supported by MongoDB');

--- a/src/Queue/MongoQueue.php
+++ b/src/Queue/MongoQueue.php
@@ -8,6 +8,7 @@ use Carbon\Carbon;
 use Illuminate\Queue\DatabaseQueue;
 use MongoDB\Laravel\Connection;
 use MongoDB\Operation\FindOneAndUpdate;
+use Override;
 use stdClass;
 
 class MongoQueue extends DatabaseQueue
@@ -34,7 +35,12 @@ class MongoQueue extends DatabaseQueue
         $this->retryAfter = $retryAfter;
     }
 
-    /** @inheritdoc */
+    /**
+     * @return MongoJob|null
+     *
+     * @inheritdoc
+     */
+    #[Override]
     public function pop($queue = null)
     {
         $queue = $this->getQueue($queue);
@@ -138,12 +144,14 @@ class MongoQueue extends DatabaseQueue
     }
 
     /** @inheritdoc */
+    #[Override]
     public function deleteReserved($queue, $id)
     {
         $this->database->table($this->table)->where('_id', $id)->delete();
     }
 
     /** @inheritdoc */
+    #[Override]
     public function deleteAndRelease($queue, $job, $delay)
     {
         $this->deleteReserved($queue, $job->getJobId());

--- a/src/Relations/BelongsTo.php
+++ b/src/Relations/BelongsTo.php
@@ -7,6 +7,7 @@ namespace MongoDB\Laravel\Relations;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo as EloquentBelongsTo;
+use Override;
 
 /**
  * @template TRelatedModel of Model
@@ -26,6 +27,7 @@ class BelongsTo extends EloquentBelongsTo
     }
 
     /** @inheritdoc */
+    #[Override]
     public function addConstraints()
     {
         if (static::$constraints) {
@@ -37,6 +39,7 @@ class BelongsTo extends EloquentBelongsTo
     }
 
     /** @inheritdoc */
+    #[Override]
     public function addEagerConstraints(array $models)
     {
         // We'll grab the primary key name of the related models since it could be set to
@@ -46,6 +49,7 @@ class BelongsTo extends EloquentBelongsTo
     }
 
     /** @inheritdoc */
+    #[Override]
     public function getRelationExistenceQuery(Builder $query, Builder $parentQuery, $columns = ['*'])
     {
         return $query;
@@ -58,11 +62,13 @@ class BelongsTo extends EloquentBelongsTo
      *
      * @return string
      */
+    #[Override]
     protected function whereInMethod(Model $model, $key)
     {
         return 'whereIn';
     }
 
+    #[Override]
     public function getQualifiedForeignKeyName(): string
     {
         return $this->foreignKey;

--- a/src/Relations/BelongsToMany.php
+++ b/src/Relations/BelongsToMany.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany as EloquentBelongsToMany;
 use Illuminate\Support\Arr;
 use MongoDB\Laravel\Eloquent\Model as DocumentModel;
+use Override;
 
 use function array_diff;
 use function array_keys;
@@ -39,12 +40,14 @@ class BelongsToMany extends EloquentBelongsToMany
     }
 
     /** @inheritdoc */
+    #[Override]
     public function getRelationExistenceQuery(Builder $query, Builder $parentQuery, $columns = ['*'])
     {
         return $query;
     }
 
     /** @inheritdoc */
+    #[Override]
     protected function hydratePivotRelation(array $models)
     {
         // Do nothing.
@@ -61,12 +64,14 @@ class BelongsToMany extends EloquentBelongsToMany
     }
 
     /** @inheritdoc */
+    #[Override]
     protected function shouldSelect(array $columns = ['*'])
     {
         return $columns;
     }
 
     /** @inheritdoc */
+    #[Override]
     public function addConstraints()
     {
         if (static::$constraints) {
@@ -89,6 +94,7 @@ class BelongsToMany extends EloquentBelongsToMany
     }
 
     /** @inheritdoc */
+    #[Override]
     public function save(Model $model, array $pivotAttributes = [], $touch = true)
     {
         $model->save(['touch' => false]);
@@ -99,6 +105,7 @@ class BelongsToMany extends EloquentBelongsToMany
     }
 
     /** @inheritdoc */
+    #[Override]
     public function create(array $attributes = [], array $joining = [], $touch = true)
     {
         $instance = $this->related->newInstance($attributes);
@@ -114,6 +121,7 @@ class BelongsToMany extends EloquentBelongsToMany
     }
 
     /** @inheritdoc */
+    #[Override]
     public function sync($ids, $detaching = true)
     {
         $changes = [
@@ -177,6 +185,7 @@ class BelongsToMany extends EloquentBelongsToMany
     }
 
     /** @inheritdoc */
+    #[Override]
     public function updateExistingPivot($id, array $attributes, $touch = true)
     {
         // Do nothing, we have no pivot table.
@@ -184,6 +193,7 @@ class BelongsToMany extends EloquentBelongsToMany
     }
 
     /** @inheritdoc */
+    #[Override]
     public function attach($id, array $attributes = [], $touch = true)
     {
         if ($id instanceof Model) {
@@ -224,6 +234,7 @@ class BelongsToMany extends EloquentBelongsToMany
     }
 
     /** @inheritdoc */
+    #[Override]
     public function detach($ids = [], $touch = true)
     {
         if ($ids instanceof Model) {
@@ -264,6 +275,7 @@ class BelongsToMany extends EloquentBelongsToMany
     }
 
     /** @inheritdoc */
+    #[Override]
     protected function buildDictionary(Collection $results)
     {
         $foreign = $this->foreignPivotKey;
@@ -283,6 +295,7 @@ class BelongsToMany extends EloquentBelongsToMany
     }
 
     /** @inheritdoc */
+    #[Override]
     public function newPivotQuery()
     {
         return $this->newRelatedQuery();
@@ -309,12 +322,14 @@ class BelongsToMany extends EloquentBelongsToMany
     }
 
     /** @inheritdoc */
+    #[Override]
     public function getQualifiedForeignPivotKeyName()
     {
         return $this->foreignPivotKey;
     }
 
     /** @inheritdoc */
+    #[Override]
     public function getQualifiedRelatedPivotKeyName()
     {
         return $this->relatedPivotKey;
@@ -323,10 +338,9 @@ class BelongsToMany extends EloquentBelongsToMany
     /**
      * Get the name of the "where in" method for eager loading.
      *
-     * @param string $key
-     *
-     * @return string
+     * @inheritdoc
      */
+    #[Override]
     protected function whereInMethod(Model $model, $key)
     {
         return 'whereIn';

--- a/src/Relations/EmbedsOneOrMany.php
+++ b/src/Relations/EmbedsOneOrMany.php
@@ -12,6 +12,7 @@ use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Query\Expression;
 use MongoDB\Driver\Exception\LogicException;
 use MongoDB\Laravel\Eloquent\Model as DocumentModel;
+use Override;
 use Throwable;
 
 use function array_merge;
@@ -78,6 +79,7 @@ abstract class EmbedsOneOrMany extends Relation
     }
 
     /** @inheritdoc */
+    #[Override]
     public function addConstraints()
     {
         if (static::$constraints) {
@@ -86,12 +88,14 @@ abstract class EmbedsOneOrMany extends Relation
     }
 
     /** @inheritdoc */
+    #[Override]
     public function addEagerConstraints(array $models)
     {
         // There are no eager loading constraints.
     }
 
     /** @inheritdoc */
+    #[Override]
     public function match(array $models, Collection $results, $relation)
     {
         foreach ($models as $model) {
@@ -105,13 +109,7 @@ abstract class EmbedsOneOrMany extends Relation
         return $models;
     }
 
-    /**
-     * Shorthand to get the results of the relationship.
-     *
-     * @param  array $columns
-     *
-     * @return Collection
-     */
+    #[Override]
     public function get($columns = ['*'])
     {
         return $this->getResults();
@@ -324,6 +322,7 @@ abstract class EmbedsOneOrMany extends Relation
     }
 
     /** @inheritdoc */
+    #[Override]
     public function getQuery()
     {
         // Because we are sharing this relation instance to models, we need
@@ -332,6 +331,7 @@ abstract class EmbedsOneOrMany extends Relation
     }
 
     /** @inheritdoc */
+    #[Override]
     public function toBase()
     {
         // Because we are sharing this relation instance to models, we need
@@ -367,6 +367,7 @@ abstract class EmbedsOneOrMany extends Relation
     }
 
     /** @inheritdoc */
+    #[Override]
     public function getQualifiedParentKeyName()
     {
         $parentRelation = $this->getParentRelation();
@@ -425,10 +426,10 @@ abstract class EmbedsOneOrMany extends Relation
      * Get the name of the "where in" method for eager loading.
      *
      * @param EloquentModel $model
-     * @param  string        $key
      *
-     * @return string
+     * @inheritdoc
      */
+    #[Override]
     protected function whereInMethod(EloquentModel $model, $key)
     {
         return 'whereIn';

--- a/src/Relations/HasMany.php
+++ b/src/Relations/HasMany.php
@@ -7,6 +7,7 @@ namespace MongoDB\Laravel\Relations;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany as EloquentHasMany;
+use Override;
 
 /**
  * @template TRelatedModel of Model
@@ -20,6 +21,7 @@ class HasMany extends EloquentHasMany
      *
      * @return string
      */
+    #[Override]
     public function getForeignKeyName()
     {
         return $this->foreignKey;
@@ -36,6 +38,7 @@ class HasMany extends EloquentHasMany
     }
 
     /** @inheritdoc */
+    #[Override]
     public function getRelationExistenceQuery(Builder $query, Builder $parentQuery, $columns = ['*'])
     {
         $foreignKey = $this->getHasCompareKey();
@@ -46,10 +49,9 @@ class HasMany extends EloquentHasMany
     /**
      * Get the name of the "where in" method for eager loading.
      *
-     * @param string $key
-     *
-     * @return string
+     * @inheritdoc
      */
+    #[Override]
     protected function whereInMethod(Model $model, $key)
     {
         return 'whereIn';

--- a/src/Relations/HasOne.php
+++ b/src/Relations/HasOne.php
@@ -7,6 +7,7 @@ namespace MongoDB\Laravel\Relations;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasOne as EloquentHasOne;
+use Override;
 
 /**
  * @template TRelatedModel of Model
@@ -20,6 +21,7 @@ class HasOne extends EloquentHasOne
      *
      * @return string
      */
+    #[Override]
     public function getForeignKeyName()
     {
         return $this->foreignKey;
@@ -36,6 +38,7 @@ class HasOne extends EloquentHasOne
     }
 
     /** @inheritdoc */
+    #[Override]
     public function getRelationExistenceQuery(Builder $query, Builder $parentQuery, $columns = ['*'])
     {
         $foreignKey = $this->getForeignKeyName();
@@ -43,13 +46,8 @@ class HasOne extends EloquentHasOne
         return $query->select($foreignKey)->where($foreignKey, 'exists', true);
     }
 
-    /**
-     * Get the name of the "where in" method for eager loading.
-     *
-     * @param string $key
-     *
-     * @return string
-     */
+    /** Get the name of the "where in" method for eager loading. */
+    #[Override]
     protected function whereInMethod(Model $model, $key)
     {
         return 'whereIn';

--- a/src/Relations/MorphMany.php
+++ b/src/Relations/MorphMany.php
@@ -6,6 +6,7 @@ namespace MongoDB\Laravel\Relations;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphMany as EloquentMorphMany;
+use Override;
 
 /**
  * @template TRelatedModel of Model
@@ -14,13 +15,7 @@ use Illuminate\Database\Eloquent\Relations\MorphMany as EloquentMorphMany;
  */
 class MorphMany extends EloquentMorphMany
 {
-    /**
-     * Get the name of the "where in" method for eager loading.
-     *
-     * @param string $key
-     *
-     * @return string
-     */
+    #[Override]
     protected function whereInMethod(Model $model, $key)
     {
         return 'whereIn';

--- a/src/Relations/MorphTo.php
+++ b/src/Relations/MorphTo.php
@@ -6,6 +6,7 @@ namespace MongoDB\Laravel\Relations;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo as EloquentMorphTo;
+use Override;
 
 /**
  * @template TRelatedModel of Model
@@ -15,6 +16,7 @@ use Illuminate\Database\Eloquent\Relations\MorphTo as EloquentMorphTo;
 class MorphTo extends EloquentMorphTo
 {
     /** @inheritdoc */
+    #[Override]
     public function addConstraints()
     {
         if (static::$constraints) {
@@ -30,6 +32,7 @@ class MorphTo extends EloquentMorphTo
     }
 
     /** @inheritdoc */
+    #[Override]
     protected function getResultsByType($type)
     {
         $instance = $this->createModelByType($type);
@@ -41,13 +44,8 @@ class MorphTo extends EloquentMorphTo
         return $query->whereIn($key, $this->gatherKeysByType($type, $instance->getKeyType()))->get();
     }
 
-    /**
-     * Get the name of the "where in" method for eager loading.
-     *
-     * @param string $key
-     *
-     * @return string
-     */
+    /** Get the name of the "where in" method for eager loading. */
+    #[Override]
     protected function whereInMethod(Model $model, $key)
     {
         return 'whereIn';

--- a/src/Relations/MorphToMany.php
+++ b/src/Relations/MorphToMany.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphToMany as EloquentMorphToMany;
 use Illuminate\Support\Arr;
 use MongoDB\BSON\ObjectId;
+use Override;
 
 use function array_diff;
 use function array_key_exists;
@@ -31,25 +32,25 @@ use function is_numeric;
  */
 class MorphToMany extends EloquentMorphToMany
 {
-    /** @inheritdoc */
+    #[Override]
     public function getRelationExistenceQuery(Builder $query, Builder $parentQuery, $columns = ['*'])
     {
         return $query;
     }
 
-    /** @inheritdoc */
+    #[Override]
     protected function hydratePivotRelation(array $models)
     {
         // Do nothing.
     }
 
-    /** @inheritdoc */
+    #[Override]
     protected function shouldSelect(array $columns = ['*'])
     {
         return $columns;
     }
 
-    /** @inheritdoc */
+    #[Override]
     public function addConstraints()
     {
         if (static::$constraints) {
@@ -57,7 +58,7 @@ class MorphToMany extends EloquentMorphToMany
         }
     }
 
-    /** @inheritdoc */
+    #[Override]
     public function addEagerConstraints(array $models)
     {
         // To load relation's data, we act normally on MorphToMany relation,
@@ -102,6 +103,7 @@ class MorphToMany extends EloquentMorphToMany
     }
 
     /** @inheritdoc */
+    #[Override]
     public function save(Model $model, array $pivotAttributes = [], $touch = true)
     {
         $model->save(['touch' => false]);
@@ -112,6 +114,7 @@ class MorphToMany extends EloquentMorphToMany
     }
 
     /** @inheritdoc */
+    #[Override]
     public function create(array $attributes = [], array $joining = [], $touch = true)
     {
         $instance = $this->related->newInstance($attributes);
@@ -127,6 +130,7 @@ class MorphToMany extends EloquentMorphToMany
     }
 
     /** @inheritdoc */
+    #[Override]
     public function sync($ids, $detaching = true)
     {
         $changes = [
@@ -203,12 +207,14 @@ class MorphToMany extends EloquentMorphToMany
     }
 
     /** @inheritdoc */
+    #[Override]
     public function updateExistingPivot($id, array $attributes, $touch = true): void
     {
         // Do nothing, we have no pivot table.
     }
 
     /** @inheritdoc */
+    #[Override]
     public function attach($id, array $attributes = [], $touch = true)
     {
         if ($id instanceof Model) {
@@ -302,6 +308,7 @@ class MorphToMany extends EloquentMorphToMany
     }
 
     /** @inheritdoc */
+    #[Override]
     public function detach($ids = [], $touch = true)
     {
         if ($ids instanceof Model) {
@@ -376,6 +383,7 @@ class MorphToMany extends EloquentMorphToMany
     }
 
     /** @inheritdoc */
+    #[Override]
     protected function buildDictionary(Collection $results)
     {
         $foreign = $this->foreignPivotKey;
@@ -403,6 +411,7 @@ class MorphToMany extends EloquentMorphToMany
     }
 
     /** @inheritdoc */
+    #[Override]
     public function newPivotQuery()
     {
         return $this->newRelatedQuery();
@@ -418,19 +427,13 @@ class MorphToMany extends EloquentMorphToMany
         return $this->related->newQuery();
     }
 
-    /** @inheritdoc */
+    #[Override]
     public function getQualifiedRelatedPivotKeyName()
     {
         return $this->relatedPivotKey;
     }
 
-    /**
-     * Get the name of the "where in" method for eager loading.
-     *
-     * @param string $key
-     *
-     * @return string
-     */
+    #[Override]
     protected function whereInMethod(Model $model, $key)
     {
         return 'whereIn';

--- a/src/Schema/Blueprint.php
+++ b/src/Schema/Blueprint.php
@@ -7,6 +7,7 @@ namespace MongoDB\Laravel\Schema;
 use Illuminate\Database\Schema\Blueprint as BaseBlueprint;
 use MongoDB\Collection;
 use MongoDB\Laravel\Connection;
+use Override;
 
 use function array_flip;
 use function array_merge;
@@ -38,6 +39,7 @@ class Blueprint extends BaseBlueprint
     protected $columns = [];
 
     /** @inheritdoc */
+    #[Override]
     public function index($columns = null, $name = null, $algorithm = null, $options = [])
     {
         $columns = $this->fluent($columns);
@@ -64,12 +66,14 @@ class Blueprint extends BaseBlueprint
     }
 
     /** @inheritdoc */
+    #[Override]
     public function primary($columns = null, $name = null, $algorithm = null, $options = [])
     {
         return $this->unique($columns, $name, $algorithm, $options);
     }
 
     /** @inheritdoc */
+    #[Override]
     public function dropIndex($index = null)
     {
         $index = $this->transformColumns($index);
@@ -170,6 +174,7 @@ class Blueprint extends BaseBlueprint
     }
 
     /** @inheritdoc */
+    #[Override]
     public function unique($columns = null, $name = null, $algorithm = null, $options = [])
     {
         $columns = $this->fluent($columns);
@@ -251,6 +256,7 @@ class Blueprint extends BaseBlueprint
      *
      * @return void
      */
+    #[Override]
     public function create($options = [])
     {
         $collection = $this->collection->getCollectionName();
@@ -262,6 +268,7 @@ class Blueprint extends BaseBlueprint
     }
 
     /** @inheritdoc */
+    #[Override]
     public function drop()
     {
         $this->collection->drop();
@@ -270,6 +277,7 @@ class Blueprint extends BaseBlueprint
     }
 
     /** @inheritdoc */
+    #[Override]
     public function renameColumn($from, $to)
     {
         $this->collection->updateMany([$from => ['$exists' => true]], ['$rename' => [$from => $to]]);
@@ -278,6 +286,7 @@ class Blueprint extends BaseBlueprint
     }
 
     /** @inheritdoc */
+    #[Override]
     public function addColumn($type, $name, array $parameters = [])
     {
         $this->fluent($name);

--- a/src/Schema/Builder.php
+++ b/src/Schema/Builder.php
@@ -6,11 +6,11 @@ namespace MongoDB\Laravel\Schema;
 
 use Closure;
 use MongoDB\Collection;
-use MongoDB\Database;
 use MongoDB\Driver\Exception\ServerException;
 use MongoDB\Laravel\Connection;
 use MongoDB\Model\CollectionInfo;
 use MongoDB\Model\IndexInfo;
+use Override;
 
 use function array_column;
 use function array_fill_keys;
@@ -99,12 +99,14 @@ class Builder extends \Illuminate\Database\Schema\Builder
     }
 
     /** @inheritdoc */
+    #[Override]
     public function hasTable($table)
     {
         return $this->hasCollection($table);
     }
 
     /** @inheritdoc */
+    #[Override]
     public function table($table, Closure $callback)
     {
         $blueprint = $this->createBlueprint($table);
@@ -115,6 +117,7 @@ class Builder extends \Illuminate\Database\Schema\Builder
     }
 
     /** @inheritdoc */
+    #[Override]
     public function create($table, ?Closure $callback = null, array $options = [])
     {
         $blueprint = $this->createBlueprint($table);
@@ -127,6 +130,7 @@ class Builder extends \Illuminate\Database\Schema\Builder
     }
 
     /** @inheritdoc */
+    #[Override]
     public function dropIfExists($table)
     {
         if ($this->hasCollection($table)) {
@@ -135,6 +139,7 @@ class Builder extends \Illuminate\Database\Schema\Builder
     }
 
     /** @inheritdoc */
+    #[Override]
     public function drop($table)
     {
         $blueprint = $this->createBlueprint($table);
@@ -151,18 +156,29 @@ class Builder extends \Illuminate\Database\Schema\Builder
      * one by one. The database will be automatically recreated when a new connection
      * writes to it.
      */
+    #[Override]
     public function dropAllTables()
     {
         $this->connection->getDatabase()->drop();
     }
 
-    /** @param string|null $schema Database name */
+    /**
+     * @param string|null $schema Database name
+     *
+     * @inheritdoc
+     */
+    #[Override]
     public function getTables($schema = null)
     {
         return $this->getCollectionRows('collection', $schema);
     }
 
-    /** @param  string|null $schema Database name */
+    /**
+     * @param  string|null $schema Database name
+     *
+     * @inheritdoc
+     */
+    #[Override]
     public function getViews($schema = null)
     {
         return $this->getCollectionRows('view', $schema);
@@ -174,6 +190,7 @@ class Builder extends \Illuminate\Database\Schema\Builder
      *
      * @return array
      */
+    #[Override]
     public function getTableListing($schema = null, $schemaQualified = false)
     {
         $collections = [];
@@ -197,6 +214,7 @@ class Builder extends \Illuminate\Database\Schema\Builder
         return $collections;
     }
 
+    #[Override]
     public function getColumns($table)
     {
         $db = null;
@@ -255,6 +273,7 @@ class Builder extends \Illuminate\Database\Schema\Builder
         return $columns;
     }
 
+    #[Override]
     public function getIndexes($table)
     {
         $collection = $this->connection->getDatabase()->selectCollection($table);
@@ -309,12 +328,18 @@ class Builder extends \Illuminate\Database\Schema\Builder
         return $indexList;
     }
 
+    #[Override]
     public function getForeignKeys($table)
     {
         return [];
     }
 
-    /** @inheritdoc */
+    /**
+     * @return Blueprint
+     *
+     * @inheritdoc
+     */
+    #[Override]
     protected function createBlueprint($table, ?Closure $callback = null)
     {
         return new Blueprint($this->connection, $table);

--- a/src/Session/MongoDbSessionHandler.php
+++ b/src/Session/MongoDbSessionHandler.php
@@ -16,6 +16,7 @@ use MongoDB\BSON\Binary;
 use MongoDB\BSON\Document;
 use MongoDB\BSON\UTCDateTime;
 use MongoDB\Collection;
+use Override;
 
 use function tap;
 use function time;
@@ -32,6 +33,7 @@ final class MongoDbSessionHandler extends DatabaseSessionHandler
         return true;
     }
 
+    #[Override]
     public function gc($lifetime): int
     {
         $result = $this->getCollection()->deleteMany(['last_activity' => ['$lt' => $this->getUTCDateTime(-$lifetime)]]);
@@ -39,6 +41,7 @@ final class MongoDbSessionHandler extends DatabaseSessionHandler
         return $result->getDeletedCount() ?? 0;
     }
 
+    #[Override]
     public function destroy($sessionId): bool
     {
         $this->getCollection()->deleteOne(['_id' => (string) $sessionId]);
@@ -46,6 +49,7 @@ final class MongoDbSessionHandler extends DatabaseSessionHandler
         return true;
     }
 
+    #[Override]
     public function read($sessionId): string|false
     {
         $result = $this->getCollection()->findOne(
@@ -63,6 +67,7 @@ final class MongoDbSessionHandler extends DatabaseSessionHandler
         return false;
     }
 
+    #[Override]
     public function write($sessionId, $data): bool
     {
         $payload = $this->getDefaultPayload($data);
@@ -87,6 +92,7 @@ final class MongoDbSessionHandler extends DatabaseSessionHandler
         );
     }
 
+    #[Override]
     protected function getDefaultPayload($data): array
     {
         $payload = [

--- a/src/Validation/DatabasePresenceVerifier.php
+++ b/src/Validation/DatabasePresenceVerifier.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MongoDB\Laravel\Validation;
 
 use MongoDB\BSON\Regex;
+use Override;
 
 use function array_map;
 use function implode;
@@ -12,17 +13,8 @@ use function preg_quote;
 
 class DatabasePresenceVerifier extends \Illuminate\Validation\DatabasePresenceVerifier
 {
-    /**
-     * Count the number of objects in a collection having the given value.
-     *
-     * @param string $collection
-     * @param string $column
-     * @param string $value
-     * @param int    $excludeId
-     * @param string $idColumn
-     *
-     * @return int
-     */
+    /** Count the number of objects in a collection having the given value. */
+    #[Override]
     public function getCount($collection, $column, $value, $excludeId = null, $idColumn = null, array $extra = [])
     {
         $query = $this->table($collection)->where($column, new Regex('^' . preg_quote($value) . '$', '/i'));
@@ -38,16 +30,8 @@ class DatabasePresenceVerifier extends \Illuminate\Validation\DatabasePresenceVe
         return $query->count();
     }
 
-    /**
-     * Count the number of objects in a collection with the given values.
-     *
-     * @param string $collection
-     * @param string $column
-     * @param array  $values
-     * @param array  $extra
-     *
-     * @return int
-     */
+    /** Count the number of objects in a collection with the given values. */
+    #[Override]
     public function getMultiCount($collection, $column, array $values, array $extra = [])
     {
         // Nothing can match an empty array. Return early to avoid matching an empty string.

--- a/src/Validation/ValidationServiceProvider.php
+++ b/src/Validation/ValidationServiceProvider.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace MongoDB\Laravel\Validation;
 
 use Illuminate\Validation\ValidationServiceProvider as BaseProvider;
+use Override;
 
 class ValidationServiceProvider extends BaseProvider
 {
+    #[Override]
     protected function registerPresenceVerifier()
     {
         $this->app->singleton('validation.presence', function ($app) {


### PR DESCRIPTION
Closes PHPORM-146

Adds the override attribute in every class that extends a Laravel base class, so that PHP will show errors if ever the base methods are renamed or removed.

Also adds in a few corrections to phpdoc declarations where necessary.

### Checklist

- [ ] ~~Add tests and ensure they pass~~ (not applicable)
