### PR TITLE
Fix array casts as string

### DIFF
--- a/src/Eloquent/DocumentModel.php
+++ b/src/Eloquent/DocumentModel.php
@@ -11,7 +11,6 @@ use DateTimeZone;
 use Illuminate\Contracts\Queue\QueueableCollection;
 use Illuminate\Contracts\Queue\QueueableEntity;
 use Illuminate\Contracts\Support\Arrayable;
-use Illuminate\Database\Eloquent\Casts\Json;
 use Illuminate\Database\Eloquent\Concerns\HasAttributes;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;

--- a/src/Eloquent/DocumentModel.php
+++ b/src/Eloquent/DocumentModel.php
@@ -11,6 +11,7 @@ use DateTimeZone;
 use Illuminate\Contracts\Queue\QueueableCollection;
 use Illuminate\Contracts\Queue\QueueableEntity;
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Database\Eloquent\Casts\Json;
 use Illuminate\Database\Eloquent\Concerns\HasAttributes;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
@@ -267,6 +268,16 @@ trait DocumentModel
         return parent::setAttribute($key, $value);
     }
 
+    /** @inheritdoc */
+    protected function isJsonCastable($key)
+    {
+        if ($this->hasCast($key, ['array'])) {
+            return false;
+        }
+
+        return parent::isJsonCastable($key);
+    }
+
     /**
      * @param mixed $value
      *
@@ -286,6 +297,15 @@ trait DocumentModel
         }
 
         return parent::asDecimal($value, $decimals);
+    }
+
+    public function fromJson($value, $asObject = false)
+    {
+        if (is_array($value)) {
+            return $value;
+        }
+
+        return parent::fromJson($value, $asObject);
     }
 
     /**

--- a/tests/Casts/ArrayTest.php
+++ b/tests/Casts/ArrayTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Laravel\Tests\Casts;
+
+use Illuminate\Support\Facades\DB;
+use MongoDB\Laravel\Tests\Models\Casting;
+use MongoDB\Laravel\Tests\TestCase;
+
+class ArrayTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Casting::truncate();
+    }
+
+    public function testArray(): void
+    {
+        $model = Casting::query()->create(['arrayValue' => ["Dreamin' 'bout the spot that right now, I'm actually in", 'g-eazy' => 'Still']]);
+
+        self::assertIsArray($model->arrayValue);
+        self::assertIsArray(
+            DB::connection()
+              ->table((new Casting())->getTable())
+              ->where('id', $model->id)
+              ->first()->arrayValue
+        );
+        self::assertEquals(["Dreamin' 'bout the spot that right now, I'm actually in", 'g-eazy' => 'Still'], $model->arrayValue);
+
+        $model->update(['arrayValue' => ['What if I just said, f*ck it, never followed my dreams?']]);
+
+        self::assertIsArray($model->arrayValue);
+        self::assertIsArray(
+            DB::connection()
+              ->table((new Casting())->getTable())
+              ->where('id', $model->id)
+              ->first()->arrayValue
+        );
+        self::assertEquals(['What if I just said, f*ck it, never followed my dreams?'], $model->arrayValue);
+    }
+}

--- a/tests/Casts/ArrayTest.php
+++ b/tests/Casts/ArrayTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MongoDB\Laravel\Tests\Casts;
 
 use Illuminate\Support\Facades\DB;
+use MongoDB\BSON\ObjectId;
 use MongoDB\Laravel\Tests\Models\Casting;
 use MongoDB\Laravel\Tests\TestCase;
 
@@ -19,6 +20,7 @@ class ArrayTest extends TestCase
 
     public function testArray(): void
     {
+        /** @var Casting $model */
         $model = Casting::query()->create(['arrayValue' => ["Dreamin' 'bout the spot that right now, I'm actually in", 'g-eazy' => 'Still']]);
 
         self::assertIsArray($model->arrayValue);
@@ -40,5 +42,22 @@ class ArrayTest extends TestCase
               ->first()->arrayValue,
         );
         self::assertEquals(['What if I just said, f*ck it, never followed my dreams?'], $model->arrayValue);
+    }
+
+    public function testArrayLegacyJsonStringIsStillReadable(): void
+    {
+        // Simulate data previously saved with the old behavior (JSON-encoded string).
+        $id = new ObjectId();
+        $table = (new Casting())->getTable();
+        DB::connection()->table($table)->insert([
+            '_id' => $id,
+            'arrayValue' => '{"key":"value","nested":{"a":1}}',
+        ]);
+
+        /** @var Casting $model */
+        $model = Casting::query()->find($id);
+
+        self::assertIsArray($model->arrayValue);
+        self::assertSame(['key' => 'value', 'nested' => ['a' => 1]], $model->arrayValue);
     }
 }

--- a/tests/Casts/ArrayTest.php
+++ b/tests/Casts/ArrayTest.php
@@ -26,7 +26,7 @@ class ArrayTest extends TestCase
             DB::connection()
               ->table((new Casting())->getTable())
               ->where('id', $model->id)
-              ->first()->arrayValue
+              ->first()->arrayValue,
         );
         self::assertEquals(["Dreamin' 'bout the spot that right now, I'm actually in", 'g-eazy' => 'Still'], $model->arrayValue);
 
@@ -37,7 +37,7 @@ class ArrayTest extends TestCase
             DB::connection()
               ->table((new Casting())->getTable())
               ->where('id', $model->id)
-              ->first()->arrayValue
+              ->first()->arrayValue,
         );
         self::assertEquals(['What if I just said, f*ck it, never followed my dreams?'], $model->arrayValue);
     }

--- a/tests/Models/Casting.php
+++ b/tests/Models/Casting.php
@@ -7,6 +7,10 @@ namespace MongoDB\Laravel\Tests\Models;
 use MongoDB\Laravel\Eloquent\Casts\BinaryUuid;
 use MongoDB\Laravel\Eloquent\Model;
 
+/**
+ * @property mixed $id
+ * @property array $arrayValue
+ */
 class Casting extends Model
 {
     protected $connection = 'mongodb';

--- a/tests/Models/Casting.php
+++ b/tests/Models/Casting.php
@@ -36,6 +36,7 @@ class Casting extends Model
         'encryptedArray',
         'encryptedObject',
         'encryptedCollection',
+        'arrayValue',
     ];
 
     protected $casts = [
@@ -60,5 +61,6 @@ class Casting extends Model
         'encryptedArray' => 'encrypted:array',
         'encryptedObject' => 'encrypted:object',
         'encryptedCollection' => 'encrypted:collection',
+        'arrayValue' => 'array',
     ];
 }


### PR DESCRIPTION
Hello everyone :)
As described here #3306, when casting an array attribute as `array`, it will save as a JSON-encoded string.
In this PR, I prevent casting an array to a string.