### PR TITLE
PHPORM-361 Remove autocommit of CS fixes

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -50,20 +50,9 @@ jobs:
 
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@3.1.0"
-        with:
-          composer-options: "--no-suggest"
-
-      - name: "Format the code"
-        continue-on-error: true
-        run: |
-          mkdir .cache
-          ./vendor/bin/phpcbf
 
       # The -q option is required until phpcs v4 is released
       - name: "Run PHP_CodeSniffer"
-        run: "vendor/bin/phpcs -q --no-colors --report=checkstyle | cs2pr"
-
-      - name: "Commit the changes"
-        uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          commit_message: "apply phpcbf formatting"
+        run: |
+          mkdir .cache
+          vendor/bin/phpcs -q --no-colors --report=checkstyle | cs2pr


### PR DESCRIPTION
Fix PHPORM-361

GitHub actions cannot be triggered by commits pushed using the `GITHUB_TOKEN`.

> When you use the repository's GITHUB_TOKEN to perform tasks, events triggered by the GITHUB_TOKEN, with the exception of workflow_dispatch and repository_dispatch, will not create a new workflow run. This prevents you from accidentally creating recursive workflow runs.

[Documentation](https://docs.github.com/en/actions/how-tos/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow)