### PR TITLE
PHPORM-369: Fix ID handling when using insert method instead of save

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -745,7 +745,10 @@ class Builder extends BaseBuilder
             $values = [$values];
         }
 
-        $values = $this->aliasIdForQuery($values);
+        $values = array_map(
+            $this->aliasIdForQuery(...),
+            $values,
+        );
 
         $options = $this->inheritConnectionOptions();
 

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -25,6 +25,7 @@ use MongoDB\Laravel\Tests\Models\IdIsInt;
 use MongoDB\Laravel\Tests\Models\IdIsString;
 use MongoDB\Laravel\Tests\Models\Item;
 use MongoDB\Laravel\Tests\Models\MemberStatus;
+use MongoDB\Laravel\Tests\Models\NonIncrementing;
 use MongoDB\Laravel\Tests\Models\Soft;
 use MongoDB\Laravel\Tests\Models\SqlUser;
 use MongoDB\Laravel\Tests\Models\User;
@@ -56,6 +57,7 @@ class ModelTest extends TestCase
         Book::truncate();
         Item::truncate();
         Guarded::truncate();
+        NonIncrementing::truncate();
 
         parent::tearDown();
     }
@@ -104,6 +106,26 @@ class ModelTest extends TestCase
 
         $this->assertEquals('John Doe', $user->name);
         $this->assertEquals(35, $user->age);
+    }
+
+    public function testInsertNonIncrementable(): void
+    {
+        $connection = DB::connection('mongodb');
+        $connection->setRenameEmbeddedIdField(false);
+
+        $nonIncrementing        = new NonIncrementing();
+        $nonIncrementing->id    = '12345';
+        $nonIncrementing->name  = 'John Doe';
+
+        $nonIncrementing->save();
+
+        $this->assertTrue($nonIncrementing->exists);
+        $this->assertEquals(1, NonIncrementing::count());
+
+        $check = NonIncrementing::find($nonIncrementing->id);
+        $this->assertInstanceOf(NonIncrementing::class, $check);
+        $this->assertSame('12345', $check->id);
+        $this->assertEquals('John Doe', $check->name);
     }
 
     public function testUpdate(): void

--- a/tests/Models/NonIncrementing.php
+++ b/tests/Models/NonIncrementing.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Laravel\Tests\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use MongoDB\Laravel\Eloquent\DocumentModel;
+
+/**
+ * @property string $id
+ * @property string $name
+ */
+class NonIncrementing extends Model
+{
+    use DocumentModel;
+
+    protected $keyType = 'string';
+    protected $connection = 'mongodb';
+
+    protected $fillable = [
+        'name',
+    ];
+    protected static $unguarded = true;
+    public $incrementing = false;
+}

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -126,6 +126,22 @@ class QueryBuilderTest extends TestCase
         $this->assertIsArray($user->tags);
     }
 
+    #[TestWith([true])]
+    #[TestWith([false])]
+    public function testInsertWithCustomId(bool $renameEmbeddedIdField)
+    {
+        $connection = DB::connection('mongodb');
+        $connection->setRenameEmbeddedIdField($renameEmbeddedIdField);
+
+        $data = ['id' => 'abcdef', 'name' => 'John Doe'];
+
+        DB::table('users')->insert($data);
+
+        $user = User::find('abcdef');
+        $this->assertInstanceOf(User::class, $user);
+        $this->assertSame('abcdef', $user->id);
+    }
+
     public function testInsertGetId()
     {
         $id = DB::table('users')->insertGetId(['name' => 'John Doe']);


### PR DESCRIPTION
PHPORM-369

### Checklist

- [x] Add tests and ensure they pass

This addresses an issue highlighted in a [discussion about `rename_embedded_id_field`](https://github.com/mongodb/laravel-mongodb/issues/3428#issuecomment-3087725396): when using `DB::table()->insert`, we pass `$values` directly to `aliasIdForQuery`. Since `$values` contains a list of documents at this point, every document is treated as an embedded document and misses out on the ID handling for root documents. To work around this, we call `aliasIdForQuery` on each document through `array_map`.
I also added a test with a model that has `$incrementing` set to `false`, as the wrong behaviour is bypassed when `$incrementing` is its default `true` value.