### PR TITLE
Replace extra substr() call

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -1893,7 +1893,7 @@ class Builder extends BaseBuilder
                     throw new InvalidArgumentException(sprintf('Cannot have both "%s" and "%s" fields.', $key, $newkey));
                 }
 
-                $values[substr($key, 0, -3) . '._id'] = $value;
+                $values[$newkey] = $value;
                 unset($values[$key]);
             }
         }


### PR DESCRIPTION
This was possible after a $newkey assignment was introduced in bd9ef30f98c92b915e9f657504e9cf15e4a2b046

I came across this while reviewing https://github.com/mongodb/laravel-mongodb/pull/3429.

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.
-->

### Checklist

- [ ] Add tests and ensure they pass
