### PR TITLE
Fix overwriting `updated_at` with `$set`

### DIFF
--- a/src/Eloquent/Builder.php
+++ b/src/Eloquent/Builder.php
@@ -310,6 +310,10 @@ class Builder extends EloquentBuilder
         }
 
         $column = $this->model->getUpdatedAtColumn();
+        if (isset($values['$set'][$column])) {
+            return $values;
+        }
+
         $values = array_replace(
             [$column => $this->model->freshTimestampString()],
             $values,

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -169,6 +169,21 @@ class ModelTest extends TestCase
         $this->assertEquals('Hans Thomas', $check->fullname);
     }
 
+    public function testUpdateTroughSetUpdatedAt(): void
+    {
+        $user        = new User();
+        $user->name  = 'John Doe';
+        $user->title = 'admin';
+        $user->age   = 35;
+        $user->save();
+
+        $updatedAt = Carbon::yesterday();
+        User::query()->update(['$set' => ['updated_at' => new UTCDateTime($updatedAt)]]);
+
+        $user->refresh();
+        $this->assertEquals($updatedAt, $user->updated_at);
+    }
+
     public function testUpsert()
     {
         $result = User::upsert([


### PR DESCRIPTION
Hello,

1. Found unexpected behaviour when I'm adding `updated_at`  into `$set`  in Eloquent update. For example:
```php
MyModel::query()
    ->where('foo', 'bar')
    ->update(['$set' => ['...' => '...', 'updated_at' => Carbon::now()->toAtomString()]]);
```
In this case current implementation is overwrite `updated_at`

2. The `$dateFormat`  is ignored when `created_at`  and `updated_at`  are added automatically (when model is saving) and every time set `UTCDateTime`  as format for value in DB. Added check - if `dateFormat` is set in model -> Date::now() is returned from `freshTimestamp`  instead of `UTCDateTime(Date::now())`