### PR TITLE
Improve change log categories

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -12,10 +12,14 @@ changelog:
     - title: New Features
       labels:
         - enhancement
+        - feature
     - title: Fixed
       labels:
         - bug
         - fixed
+    - title: Documentation Changes
+      labels:
+        - docs
     - title: Other Changes
       labels:
         - "*"


### PR DESCRIPTION
So that anything labeled `feature` is added to the Features category and docs changes are listed as a separate category
