### PR TITLE
Remove explicit dependency to symfony/http-kernel as it's not used directly

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,7 @@
         "illuminate/database": "^10.30|^11|^12",
         "illuminate/events": "^10.0|^11|^12",
         "illuminate/support": "^10.0|^11|^12",
-        "mongodb/mongodb": "^1.21|^2",
-        "symfony/http-foundation": "^6.4|^7"
+        "mongodb/mongodb": "^1.21|^2"
     },
     "require-dev": {
         "laravel/scout": "^10.3",

--- a/src/Session/MongoDbSessionHandler.php
+++ b/src/Session/MongoDbSessionHandler.php
@@ -1,14 +1,5 @@
 <?php
 
-/*
- * This file is part of the Symfony package.
- *
- * (c) Fabien Potencier <fabien@symfony.com>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace MongoDB\Laravel\Session;
 
 use Illuminate\Session\DatabaseSessionHandler;


### PR DESCRIPTION
Missing from #3348
