### PR TITLE
ScoutEngine: correct `delete()` TypeError message to reference EloquentCollection

### DIFF
--- a/src/Scout/ScoutEngine.php
+++ b/src/Scout/ScoutEngine.php
@@ -151,7 +151,7 @@ final class ScoutEngine extends Engine
     #[Override]
     public function delete($models): void
     {
-        assert($models instanceof EloquentCollection, new TypeError(sprintf('Argument #1 ($models) must be of type %s, %s given', Collection::class, get_debug_type($models))));
+        assert($models instanceof EloquentCollection, new TypeError(sprintf('Argument #1 ($models) must be of type %s, %s given', EloquentCollection::class, get_debug_type($models))));
 
         if ($models->isEmpty()) {
             return;

--- a/tests/Scout/ScoutEngineTest.php
+++ b/tests/Scout/ScoutEngineTest.php
@@ -21,6 +21,7 @@ use MongoDB\Laravel\Tests\Scout\Models\ScoutUser;
 use MongoDB\Laravel\Tests\Scout\Models\SearchableModel;
 use MongoDB\Laravel\Tests\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
+use TypeError;
 
 use function array_replace_recursive;
 use function count;
@@ -669,5 +670,18 @@ class ScoutEngineTest extends TestCase
 
         $engine = new ScoutEngine($database, softDelete: false);
         $engine->delete($job->models);
+    }
+
+    public function testDeleteRejectsNonEloquentCollection(): void
+    {
+        $database = $this->createMock(Database::class);
+        $engine = new ScoutEngine($database, softDelete: false);
+
+        $this->expectException(TypeError::class);
+        $this->expectExceptionMessage(
+            'Argument #1 ($models) must be of type Illuminate\Database\Eloquent\Collection',
+        );
+
+        $engine->delete(LaravelCollection::make([1, 2, 3]));
     }
 }


### PR DESCRIPTION
### Context
The ScoutEngine::delete() method requires an Illuminate\Database\Eloquent\Collection (alias EloquentCollection). However, the thrown TypeError message incorrectly states the expected type as Illuminate\Support\Collection, which misleads during debugging.

### Problem

Current message (incorrect):
Argument #1 ($models) must be of type Illuminate\Support\Collection

This contradicts the actual method contract and the behaviour of update(), which already reports EloquentCollection correctly.

### Change

Update the thrown TypeError message in ScoutEngine::delete() to name Illuminate\Database\Eloquent\Collection (EloquentCollection) as the expected type.

### Tests

Adjust/confirm the expectation in testDeleteRejectsNonEloquentCollection() to assert the corrected message:
Argument #1 ($models) must be of type Illuminate\Database\Eloquent\Collection.
<img width="589" height="591" alt="スクリーンショット 2025-10-30 17 00 07" src="https://github.com/user-attachments/assets/a43c183a-3229-4525-95b0-0a70ee503ab0" />


### Checklist

- [x] Add tests and ensure they pass
