### PR TITLE
PHPORM-418 Test with PHP 8.5 and reduce test matrix

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -12,10 +12,14 @@ changelog:
     - title: New Features
       labels:
         - enhancement
+        - feature
     - title: Fixed
       labels:
         - bug
         - fixed
+    - title: Documentation Changes
+      labels:
+        - docs
     - title: Other Changes
       labels:
         - "*"

--- a/.github/workflows/build-ci-atlas.yml
+++ b/.github/workflows/build-ci-atlas.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - "[0-9]+.[0-9x]+"
-      - "feature/*"
   pull_request:
     branches:
       - "[0-9]+.[0-9x]+"
@@ -16,28 +15,34 @@ env:
 
 jobs:
   build:
-    runs-on: "${{ matrix.os }}"
+    runs-on: "ubuntu-latest"
 
     name: "PHP/${{ matrix.php }} Laravel/${{ matrix.laravel }} Driver/${{ matrix.driver }}"
 
     strategy:
       matrix:
-        os:
-          - "ubuntu-latest"
         php:
           - "8.2"
           - "8.3"
           - "8.4"
+          - "8.5"
         laravel:
-          - "11.*"
           - "12.*"
         driver:
-          - 1
+          - 2
         include:
+          # Test Laravel 10
+          - php: "8.1"
+            laravel: "10.*"
+            driver: 1
+          # Test Laravel 11
+          - php: "8.2"
+            laravel: "11.*"
+            driver: 1
+          # Test Driver v1
           - php: "8.4"
             laravel: "12.*"
-            os: "ubuntu-latest"
-            driver: 2
+            driver: 1
 
     steps:
       - uses: "actions/checkout@v5"

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - "[0-9]+.[0-9x]+"
-      - "feature/*"
   pull_request:
     branches:
       - "[0-9]+.[0-9x]+"
@@ -16,53 +15,63 @@ env:
 
 jobs:
   build:
-    runs-on: "${{ matrix.os }}"
+    runs-on: "ubuntu-latest"
 
     name: "PHP/${{ matrix.php }} Laravel/${{ matrix.laravel }} Driver/${{ matrix.driver }} Server/${{ matrix.mongodb }} ${{ matrix.mode }}"
 
     strategy:
       matrix:
-        os:
-          - "ubuntu-latest"
         mongodb:
-          - "4.4"
-          - "5.0"
-          - "6.0"
-          - "7.0"
           - "8.0"
         php:
-          - "8.1"
           - "8.2"
           - "8.3"
           - "8.4"
+          - "8.5"
         laravel:
-          - "10.*"
-          - "11.*"
           - "12.*"
         driver:
           - 2
         include:
+          # Test Lowest dependencies
           - php: "8.1"
             laravel: "10.*"
             mongodb: "5.0"
             mode: "low-deps"
-            os: "ubuntu-latest"
             driver: 1
+          # Test Driver v1
           - php: "8.3"
-            laravel: "11.*"
-            mongodb: "8.0"
-            os: "ubuntu-latest"
+            laravel: "10.*"
+            mongodb: "4.4"
             driver: 1
           - php: "8.4"
             laravel: "12.*"
             mongodb: "8.0"
-            os: "ubuntu-latest"
             driver: 1
-        exclude:
-          - php: "8.1"
+          # Test Laravel 10
+          - php: "8.4"
+            laravel: "10.*"
+            mongodb: "8.0"
+          # Test Laravel 11
+          - php: "8.4"
             laravel: "11.*"
-          - php: "8.1"
+            mongodb: "8.0"
+          # Test all server versions
+          - php: "8.4"
             laravel: "12.*"
+            mongodb: "4.4"
+          - php: "8.4"
+            laravel: "12.*"
+            mongodb: "5.0"
+          - php: "8.4"
+            laravel: "12.*"
+            mongodb: "6.0"
+          - php: "8.4"
+            laravel: "12.*"
+            mongodb: "7.0"
+          - php: "8.4"
+            laravel: "12.*"
+            mongodb: "8.0"
 
     steps:
       - uses: "actions/checkout@v5"

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -49,27 +49,27 @@ jobs:
             mongodb: "8.0"
             driver: 1
           # Test Laravel 10
-          - php: "8.4"
+          - php: "8.5"
             laravel: "10.*"
             mongodb: "8.0"
           # Test Laravel 11
-          - php: "8.4"
+          - php: "8.5"
             laravel: "11.*"
             mongodb: "8.0"
-          # Test all server versions
-          - php: "8.4"
+          # Test all server versions with the lowest PHP and latest Laravel
+          - php: "8.2"
             laravel: "12.*"
             mongodb: "4.4"
-          - php: "8.4"
+          - php: "8.2"
             laravel: "12.*"
             mongodb: "5.0"
-          - php: "8.4"
+          - php: "8.2"
             laravel: "12.*"
             mongodb: "6.0"
-          - php: "8.4"
+          - php: "8.2"
             laravel: "12.*"
             mongodb: "7.0"
-          - php: "8.4"
+          - php: "8.2"
             laravel: "12.*"
             mongodb: "8.0"
 

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - "[0-9]+.[0-9x]+"
-      - "feature/*"
   pull_request:
     branches:
       - "[0-9]+.[0-9x]+"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -9,4 +9,4 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@v6

--- a/.github/workflows/merge-up.yml
+++ b/.github/workflows/merge-up.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - "[0-9]+.[0-9x]+"
-      - "feature/*"
 
 env:
   GH_TOKEN: ${{ secrets.MERGE_UP_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
         run: echo '🎬 Release process for version ${{ inputs.version }} started by @${{ github.triggering_actor }}' >> $GITHUB_STEP_SUMMARY
 
       - name: "Generate token and checkout repository"
-        uses: mongodb-labs/drivers-github-tools/secure-checkout@v2
+        uses: mongodb-labs/drivers-github-tools/secure-checkout@v3
         with:
           app_id: ${{ vars.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -71,7 +71,7 @@ jobs:
       #
 
       - name: "Set up drivers-github-tools"
-        uses: mongodb-labs/drivers-github-tools/setup@v2
+        uses: mongodb-labs/drivers-github-tools/setup@v3
         with:
           aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
           aws_region_name: ${{ vars.AWS_REGION_NAME }}
@@ -82,7 +82,7 @@ jobs:
         run: echo "RELEASE_URL=$(gh release create ${{ inputs.version }} --target ${{ github.ref_name }} --title "${{ inputs.version }}" --generate-notes --draft)" >> "$GITHUB_ENV"
 
       - name: "Create release tag"
-        uses: mongodb-labs/drivers-github-tools/tag-version@v2
+        uses: mongodb-labs/drivers-github-tools/tag-version@v3
         with:
           version: ${{ inputs.version }}
           tag_message_template: 'Release ${VERSION}'
@@ -121,7 +121,7 @@ jobs:
 
     steps:
       - name: "Generate token and checkout repository"
-        uses: mongodb-labs/drivers-github-tools/secure-checkout@v2
+        uses: mongodb-labs/drivers-github-tools/secure-checkout@v3
         with:
           app_id: ${{ vars.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -129,14 +129,14 @@ jobs:
 
       # Sets the S3_ASSETS environment variable used later
       - name: "Set up drivers-github-tools"
-        uses: mongodb-labs/drivers-github-tools/setup@v2
+        uses: mongodb-labs/drivers-github-tools/setup@v3
         with:
           aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
           aws_region_name: ${{ vars.AWS_REGION_NAME }}
           aws_secret_id: ${{ secrets.AWS_SECRET_ID }}
 
       - name: "Generate SSDLC Reports"
-        uses: mongodb-labs/drivers-github-tools/full-report@v2
+        uses: mongodb-labs/drivers-github-tools/full-report@v3
         with:
           product_name: "MongoDB Laravel Integration"
           release_version: ${{ inputs.version }}
@@ -147,7 +147,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload S3 assets
-        uses: mongodb-labs/drivers-github-tools/upload-s3-assets@v2
+        uses: mongodb-labs/drivers-github-tools/upload-s3-assets@v3
         with:
           version: ${{ inputs.version }}
           product_name: laravel-mongodb

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -89,13 +89,13 @@ jobs:
 
       - name: "Upload SARIF report"
         if: ${{ github.event_name != 'workflow_dispatch' }}
-        uses: "github/codeql-action/upload-sarif@v3"
+        uses: "github/codeql-action/upload-sarif@v4"
         with:
           sarif_file: phpstan.sarif
 
       - name: "Upload SARIF report"
         if: ${{ github.event_name == 'workflow_dispatch' }}
-        uses: "github/codeql-action/upload-sarif@v3"
+        uses: "github/codeql-action/upload-sarif@v4"
         with:
           sarif_file: phpstan.sarif
           ref: ${{ inputs.ref }}

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - "[0-9]+.[0-9x]+"
-      - "feature/*"
   pull_request:
     branches:
       - "[0-9]+.[0-9x]+"
@@ -17,7 +16,7 @@ on:
         required: true
 
 env:
-  PHP_VERSION: "8.2"
+  PHP_VERSION: "8.5"
   DRIVER_VERSION: "stable"
   MONGODB_EXT_V1: mongodb-1.21.0
   MONGODB_EXT_V2: mongodb-mongodb/mongo-php-driver@v2.x
@@ -34,9 +33,12 @@ jobs:
           - '8.2'
           - '8.3'
           - '8.4'
+          - '8.5'
         driver:
-          - 1
           - 2
+        include:
+          - php: "8.4"
+            driver: 1
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,7 @@
         "illuminate/database": "^10.30|^11|^12",
         "illuminate/events": "^10.0|^11|^12",
         "illuminate/support": "^10.0|^11|^12",
-        "mongodb/mongodb": "^1.21|^2",
-        "symfony/http-foundation": "^6.4|^7"
+        "mongodb/mongodb": "^1.21|^2"
     },
     "require-dev": {
         "laravel/scout": "^10.3",

--- a/src/Session/MongoDbSessionHandler.php
+++ b/src/Session/MongoDbSessionHandler.php
@@ -1,14 +1,5 @@
 <?php
 
-/*
- * This file is part of the Symfony package.
- *
- * (c) Fabien Potencier <fabien@symfony.com>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace MongoDB\Laravel\Session;
 
 use Illuminate\Session\DatabaseSessionHandler;


### PR DESCRIPTION
Fix PHPORM-418

- Add PHP 8.5 to the tests
- Reduce test matrix for less resource consumption while keeping a coverage for every MongoDB  server, driver, PHP and Laravel versions.
- Don't run tests in duplicate for `feature/*` branches, they must be used to PR version branches.