### PR TITLE
Fix test that randomly crashes

### DIFF
--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -458,7 +458,7 @@ class SchemaTest extends TestCase
             $this->assertNotEquals('test_view', $table['name'], 'Standard views should not be included in the result of getTables.');
 
             if ($table['name'] === self::COLL_1) {
-                $this->assertEquals(8192, $table['size']);
+                $this->assertGreaterThanOrEqual(8192, $table['size']);
                 $this->assertEquals($dbName, $table['schema']);
                 $this->assertEquals($dbName . '.' . self::COLL_1, $table['schema_qualified_name']);
                 $found = true;


### PR DESCRIPTION
This test is inconsistently [crashing](https://github.com/mongodb/laravel-mongodb/actions/runs/20030747326/job/57439273219?pr=3463):

```
1) MongoDB\Laravel\Tests\SchemaTest::testGetTables Failed asserting that 40960 matches expected 8192.
```