### PR TITLE
Fix MongoStore increment behavior for expired cache entries

### DIFF
--- a/src/Cache/MongoStore.php
+++ b/src/Cache/MongoStore.php
@@ -179,25 +179,23 @@ final class MongoStore implements LockProvider, Store
     #[Override]
     public function increment($key, $value = 1): int|float|false
     {
+        $now = $this->getUTCDateTime();
+
         $result = $this->collection->findOneAndUpdate(
             [
                 '_id' => $this->prefix . $key,
+                'expires_at' => ['$gt' => $now],
             ],
             [
                 '$inc' => ['value' => $value],
             ],
             [
+                'projection' => ['value' => 1, 'expires_at' => 1],
                 'returnDocument' => FindOneAndUpdate::RETURN_DOCUMENT_AFTER,
             ],
         );
 
         if (! $result) {
-            return false;
-        }
-
-        if ($result['expires_at'] <= $this->getUTCDateTime()) {
-            $this->forgetIfExpired($key);
-
             return false;
         }
 

--- a/src/Cache/MongoStore.php
+++ b/src/Cache/MongoStore.php
@@ -190,7 +190,7 @@ final class MongoStore implements LockProvider, Store
                 '$inc' => ['value' => $value],
             ],
             [
-                'projection' => ['value' => 1, 'expires_at' => 1],
+                'projection' => ['value' => 1],
                 'returnDocument' => FindOneAndUpdate::RETURN_DOCUMENT_AFTER,
             ],
         );

--- a/tests/Cache/MongoCacheStoreTest.php
+++ b/tests/Cache/MongoCacheStoreTest.php
@@ -199,6 +199,14 @@ class MongoCacheStoreTest extends TestCase
 
         $this->insertToCacheTable('foo', 10, -5);
         $this->assertFalse($store->increment('foo', 5));
+
+        $doc = DB::connection('mongodb')
+            ->getCollection($this->getCacheCollectionName())
+            ->findOne(
+                ['_id' => $this->withCachePrefix('foo')],
+                ['projection' => ['value' => 1]]
+            );
+        $this->assertSame(10, $doc['value']);
     }
 
     public function testTouchReturnsFalseWhenKeyDoesNotExist()

--- a/tests/Cache/MongoCacheStoreTest.php
+++ b/tests/Cache/MongoCacheStoreTest.php
@@ -207,6 +207,17 @@ class MongoCacheStoreTest extends TestCase
                 ['projection' => ['value' => 1]],
             );
         $this->assertSame(10, $doc['value']);
+
+        // decrement on an expired entry must also return false and leave the value unchanged
+        $this->assertFalse($store->decrement('foo', 5));
+
+        $doc = DB::connection('mongodb')
+            ->getCollection($this->getCacheCollectionName())
+            ->findOne(
+                ['_id' => $this->withCachePrefix('foo')],
+                ['projection' => ['value' => 1]],
+            );
+        $this->assertSame(10, $doc['value']);
     }
 
     public function testTouchReturnsFalseWhenKeyDoesNotExist()

--- a/tests/Cache/MongoCacheStoreTest.php
+++ b/tests/Cache/MongoCacheStoreTest.php
@@ -204,7 +204,7 @@ class MongoCacheStoreTest extends TestCase
             ->getCollection($this->getCacheCollectionName())
             ->findOne(
                 ['_id' => $this->withCachePrefix('foo')],
-                ['projection' => ['value' => 1]]
+                ['projection' => ['value' => 1]],
             );
         $this->assertSame(10, $doc['value']);
     }


### PR DESCRIPTION
<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.
-->

### Description

This PR fixes the behavior of `MongoStore::increment()` so that expired cache entries are no longer incremented.

### what has changed

- Before changed
    - Increment the value first
    - Then check whether the cache entry was expired
    - Potentially delete the entry afterward

This caused expired cache values to be modified briefly, which is inconsistent with Laravel’s cache semantics.

- The method now:
    - Filters out expired entries at the query level using expires_at > now
    - Returns false when the cache entry is missing or expired
    - Avoids modifying expired values entirely

### Test Results
<img width="796" height="450" alt="スクリーンショット 2025-12-15 10 39 13" src="https://github.com/user-attachments/assets/ad773931-b06c-495d-8626-2373904a9c0d" />

- A regression test was added to proved that
    - `increment()` returns `false` for expired cache entries
    - The stored value remains unchanged when the cache is already expired

### Checklist

- [x] Add tests and ensure they pass
