### PR TITLE
Fix MongoDB presence verification for values containing regex delimiters

### DIFF
--- a/src/Validation/DatabasePresenceVerifier.php
+++ b/src/Validation/DatabasePresenceVerifier.php
@@ -17,7 +17,10 @@ class DatabasePresenceVerifier extends \Illuminate\Validation\DatabasePresenceVe
     #[Override]
     public function getCount($collection, $column, $value, $excludeId = null, $idColumn = null, array $extra = [])
     {
-        $query = $this->table($collection)->where($column, new Regex('^' . preg_quote($value) . '$', '/i'));
+        $quoted = preg_quote((string) $value, '/');
+        $regex = new Regex('^' . $quoted . '$', 'i');
+
+        $query = $this->table($collection)->where($column, $regex);
 
         if ($excludeId !== null && $excludeId !== 'NULL') {
             $query->where($idColumn ?: 'id', '<>', $excludeId);
@@ -40,9 +43,14 @@ class DatabasePresenceVerifier extends \Illuminate\Validation\DatabasePresenceVe
         }
 
         // Generates a regex like '/^(a|b|c)$/i' which can query multiple values
-        $regex = new Regex('^(' . implode('|', array_map(preg_quote(...), $values)) . ')$', 'i');
+        $escapedValues = array_map(
+            static fn ($v) => preg_quote((string) $v, '/'),
+            $values
+        );
 
-        $query = $this->table($collection)->where($column, 'regex', $regex);
+        $regex = new Regex('^(' . implode('|', $escapedValues) . ')$', 'i');
+
+        $query = $this->table($collection)->where($column, $regex);
 
         foreach ($extra as $key => $extraValue) {
             $this->addWhere($query, $key, $extraValue);

--- a/src/Validation/DatabasePresenceVerifier.php
+++ b/src/Validation/DatabasePresenceVerifier.php
@@ -45,7 +45,7 @@ class DatabasePresenceVerifier extends \Illuminate\Validation\DatabasePresenceVe
         // Generates a regex like '/^(a|b|c)$/i' which can query multiple values
         $escapedValues = array_map(
             static fn ($v) => preg_quote((string) $v, '/'),
-            $values
+            $values,
         );
 
         $regex = new Regex('^(' . implode('|', $escapedValues) . ')$', 'i');

--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -131,5 +131,25 @@ class ValidationTest extends TestCase
             ['name' => 'exists:users'],
         );
         $this->assertFalse($validator->fails());
+
+        User::create(['name' => 'Foo/Bar']);
+
+        $validator = Validator::make(
+            ['name' => 'Foo/Bar'],
+            ['name' => 'required|exists:users'],
+        );
+        $this->assertFalse($validator->fails());
+
+        $validator = Validator::make(
+            ['name' => 'foo/bar'], // case-insensitive
+            ['name' => 'required|exists:users'],
+        );
+        $this->assertFalse($validator->fails());
+
+        $validator = Validator::make(
+            ['name' => 'Foo'], // partial should not match
+            ['name' => 'required|exists:users'],
+        );
+        $this->assertTrue($validator->fails());
     }
 }


### PR DESCRIPTION
<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.
-->

### Description

This PR fixes an issue in the MongoDB presence verifier where validation queries could break (or behave unexpectedly) when the input contained regex delimiter characters such as /.

### Motivation

The verifier builds a MongoDB regex from user input to perform a case-insensitive exact match. However, the previous implementation used preg_quote without specifying a delimiter and also mixed regex options in a way that could lead to incorrect patterns. This becomes visible when validating values like Foo/Bar.

###What changed
- Escaped input using preg_quote((string) $value, '/') so / (and other delimiter-related characters) are safely handled.
- Constructed MongoDB\BSON\Regex using the correct options argument ('i') rather than embedding flags in the pattern string.
- Queried using the Regex object directly (where($column, $regex)) instead of passing 'regex' as an operator.
- Applied the same escaping approach for getMultiCount() when building a regex alternation.
- Added a regression test covering Foo/Bar as well as case-insensitive matching and “partial should not match”.

### Why passing the Regex object directly

The MongoDB query builder expects a `MongoDB\BSON\Regex` instance to be provided as the value for a regex comparison.
Using `where($column, 'regex', $regex)` relies on an operator string that may not be interpreted consistently across the MongoDB driver / query builder implementation, whereas passing the Regex object directly (`where($column, $regex)`) is the explicit and supported way to perform regex matching.

### Test plan

./vendor/bin/phpunit

Specifically verified the new cases added in tests/ValidationTest.php (values containing /, case-insensitive exact match, and partial mismatch).

<img width="597" height="220" alt="スクリーンショット 2026-01-14 20 34 21" src="https://github.com/user-attachments/assets/647cdae3-33d6-48d6-b337-874000c988e2" />


### Checklist

- [x] Add tests and ensure they pass
