### PR TITLE
Add 'alias_id' config option to disable top-level _id/id aliasing

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -57,6 +57,9 @@ class Connection extends BaseConnection
     /** @var bool Whether to rename the rename "id" into "_id" for embedded documents. */
     private bool $renameEmbeddedIdField;
 
+    /** @var bool Whether to alias "id" to "_id" at the top level for queries and results. */
+    private bool $aliasId;
+
     /**
      * Create a new database connection instance.
      */
@@ -86,6 +89,7 @@ class Connection extends BaseConnection
         $this->useDefaultQueryGrammar();
 
         $this->renameEmbeddedIdField = $config['rename_embedded_id_field'] ?? true;
+        $this->aliasId = $config['alias_id'] ?? true;
     }
 
     /**
@@ -421,6 +425,18 @@ class Connection extends BaseConnection
     public function getRenameEmbeddedIdField(): bool
     {
         return $this->renameEmbeddedIdField;
+    }
+
+    /** Set whether to alias "id" to "_id" at the top level for queries and results. */
+    public function setAliasId(bool $alias): void
+    {
+        $this->aliasId = $alias;
+    }
+
+    /** Get whether to alias "id" to "_id" at the top level for queries and results. */
+    public function getAliasId(): bool
+    {
+        return $this->aliasId;
     }
 
     /**

--- a/src/Eloquent/DocumentModel.php
+++ b/src/Eloquent/DocumentModel.php
@@ -101,26 +101,38 @@ trait DocumentModel
 
     /**
      * Get the primary key for the model.
-     * When alias_id is disabled, always use '_id' as the primary key
-     * to prevent MongoDB's _id from overwriting a custom 'id' field.
+     *
+     * When alias_id is disabled and the model uses Eloquent's default 'id' key,
+     * returns '_id' to prevent MongoDB's _id from overwriting a custom 'id' field.
+     * Models with a custom primary key are always respected regardless of alias_id.
+     *
+     * @return string
      */
     public function getKeyName()
     {
-        return $this->getConnection()->getAliasId()
-            ? parent::getKeyName()
-            : '_id';
+        if (! $this->getConnection()->getAliasId() && parent::getKeyName() === 'id') {
+            return '_id';
+        }
+
+        return parent::getKeyName();
     }
 
     /**
      * Get the value of the model's primary key.
-     * When alias_id is disabled, return the raw '_id' attribute directly
-     * to bypass the getIdAttribute accessor.
+     *
+     * When alias_id is disabled and the model uses Eloquent's default 'id' key,
+     * returns the raw '_id' attribute directly to bypass the getIdAttribute accessor.
+     * Models with a custom primary key are always respected regardless of alias_id.
+     *
+     * @return mixed
      */
     public function getKey()
     {
-        return $this->getConnection()->getAliasId()
-            ? parent::getKey()
-            : $this->attributes['_id'] ?? null;
+        if (! $this->getConnection()->getAliasId() && parent::getKeyName() === 'id') {
+            return $this->attributes['_id'] ?? null;
+        }
+
+        return parent::getKey();
     }
 
     /** @inheritdoc */

--- a/src/Eloquent/DocumentModel.php
+++ b/src/Eloquent/DocumentModel.php
@@ -77,6 +77,12 @@ trait DocumentModel
      */
     public function getIdAttribute($value = null)
     {
+        // When alias_id is disabled, return the actual 'id' attribute without
+        // falling back to '_id', so that custom 'id' fields are preserved.
+        if (! $this->getConnection()->getAliasId()) {
+            return $value ?? $this->attributes['id'] ?? null;
+        }
+
         // If we don't have a value for 'id', we will use the MongoDB '_id' value.
         // This allows us to work with models in a more sql-like way.
         $value ??= $this->attributes['id'] ?? $this->attributes['_id'] ?? null;
@@ -91,6 +97,30 @@ trait DocumentModel
         }
 
         return $value;
+    }
+
+    /**
+     * Get the primary key for the model.
+     * When alias_id is disabled, always use '_id' as the primary key
+     * to prevent MongoDB's _id from overwriting a custom 'id' field.
+     */
+    public function getKeyName()
+    {
+        return $this->getConnection()->getAliasId()
+            ? parent::getKeyName()
+            : '_id';
+    }
+
+    /**
+     * Get the value of the model's primary key.
+     * When alias_id is disabled, return the raw '_id' attribute directly
+     * to bypass the getIdAttribute accessor.
+     */
+    public function getKey()
+    {
+        return $this->getConnection()->getAliasId()
+            ? parent::getKey()
+            : $this->attributes['_id'] ?? null;
     }
 
     /** @inheritdoc */

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -1286,7 +1286,7 @@ class Builder extends BaseBuilder
                 $where['column'] = (string) $where['column'];
 
                 // Compatibility with Eloquent queries that uses "id" instead of MongoDB's _id
-                if ($where['column'] === 'id') {
+                if ($where['column'] === 'id' && $this->connection->getAliasId()) {
                     $where['column'] = '_id';
                 }
 
@@ -1863,7 +1863,9 @@ class Builder extends BaseBuilder
 
     private function aliasIdForQuery(array $values, bool $root = true): array
     {
-        if (array_key_exists('id', $values) && ($root || $this->connection->getRenameEmbeddedIdField())) {
+        $shouldAliasRoot = $root && $this->connection->getAliasId();
+        $shouldAliasEmbedded = ! $root && $this->connection->getRenameEmbeddedIdField();
+        if (array_key_exists('id', $values) && ($shouldAliasRoot || $shouldAliasEmbedded)) {
             if (array_key_exists('_id', $values) && $values['id'] !== $values['_id']) {
                 throw new InvalidArgumentException('Cannot have both "id" and "_id" fields.');
             }
@@ -1924,9 +1926,11 @@ class Builder extends BaseBuilder
     public function aliasIdForResult(array|object $values, bool $root = true): array|object
     {
         if (is_array($values)) {
+            $shouldAliasRoot = $root && $this->connection->getAliasId();
+            $shouldAliasEmbedded = ! $root && $this->connection->getRenameEmbeddedIdField();
             if (
                 array_key_exists('_id', $values) && ! array_key_exists('id', $values)
-                && ($root || $this->connection->getRenameEmbeddedIdField())
+                && ($shouldAliasRoot || $shouldAliasEmbedded)
             ) {
                 $values['id'] = $values['_id'];
                 unset($values['_id']);
@@ -1943,9 +1947,11 @@ class Builder extends BaseBuilder
         }
 
         if ($values instanceof stdClass) {
+            $shouldAliasRoot = $root && $this->connection->getAliasId();
+            $shouldAliasEmbedded = ! $root && $this->connection->getRenameEmbeddedIdField();
             if (
                 property_exists($values, '_id') && ! property_exists($values, 'id')
-                && ($root || $this->connection->getRenameEmbeddedIdField())
+                && ($shouldAliasRoot || $shouldAliasEmbedded)
             ) {
                 $values->id = $values->_id;
                 unset($values->_id);

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -1681,10 +1681,11 @@ class BuilderTest extends TestCase
         ];
     }
 
-    private function getBuilder(bool $renameEmbeddedIdField = true): Builder
+    private function getBuilder(bool $renameEmbeddedIdField = true, bool $aliasId = true): Builder
     {
         $connection = $this->createStub(Connection::class);
         $connection->method('getRenameEmbeddedIdField')->willReturn($renameEmbeddedIdField);
+        $connection->method('getAliasId')->willReturn($aliasId);
         $processor  = $this->createStub(Processor::class);
         $connection->method('getSession')->willReturn(null);
         $connection->method('getQueryGrammar')->willReturn(new Grammar($connection));


### PR DESCRIPTION
## Summary

Adds a new `alias_id` connection config option (default: `true`) that allows disabling the automatic top-level `_id` ↔ `id` aliasing introduced in v5.0.

- When `alias_id` is `false`, root-level `id` is treated as a regular field and not converted to/from `_id`
- When `alias_id` is `true` (default), behavior is identical to current — zero breaking changes
- When disabling `alias_id`, also set `rename_embedded_id_field` to `false` to prevent compound query operators (`$and`/`$or`) from incorrectly aliasing root-level `id` fields in nested where clauses

## Problem

Applications upgrading from v4 to v5 that have documents with a **business `id` field** (e.g., external API IDs, legacy system identifiers) alongside MongoDB's `_id` experience data corruption because the aliasing overwrites the custom `id` field with `_id`.

The existing `rename_embedded_id_field` config (v5.3+) only controls embedded document aliasing. There is currently no way to disable top-level aliasing, which has been reported in:
- #3392 — Requesting reconsideration with this minimal, backward-compatible implementation
- Community forum: https://www.mongodb.com/community/forums/t/issue-with-id-to-id-conversion-when-upgrading-to-laravel-mongodb-v5-laravel-12-support/321882
- Community forum: https://www.mongodb.com/community/forums/t/id-vs-id-with-laravel-mongodb-v5/316408

## Changes

| File | Change |
|---|---|
| `src/Connection.php` | New `aliasId` property, getter/setter, config init (`'alias_id' => true`) |
| `src/Query/Builder.php` | `compileWheres()`: gate `id` → `_id` column rename on `getAliasId()` |
| `src/Query/Builder.php` | `aliasIdForQuery()`: separate root aliasing (`alias_id`) from embedded aliasing (`rename_embedded_id_field`) |
| `src/Query/Builder.php` | `aliasIdForResult()`: same separation for result processing |
| `src/Eloquent/DocumentModel.php` | `getIdAttribute()`: return actual `id` attribute without `_id` fallback when disabled |
| `src/Eloquent/DocumentModel.php` | `getKeyName()`: return `_id` as primary key when disabled |
| `src/Eloquent/DocumentModel.php` | `getKey()`: return raw `_id` attribute directly, bypassing accessor |

## Config usage

```php
// config/database.php
'mongodb' => [
    'driver' => 'mongodb',
    'dsn' => env('MONGODB_URI'),
    'database' => env('MONGODB_DATABASE'),
    'alias_id' => false,
    'rename_embedded_id_field' => false,
],
```

Or at runtime:
```php
DB::connection('mongodb')->setAliasId(false);
DB::connection('mongodb')->setRenameEmbeddedIdField(false);
```

### Why both config keys?

The `aliasIdForQuery()` method recurses into nested arrays with `root=false`. Compound query operators like `$and`/`$or` (automatically added by SoftDeletes or multiple `where()` clauses) create nested array structures that are incorrectly treated as embedded documents during recursion. Setting `rename_embedded_id_field` to `false` prevents this from converting root-level `id` to `_id` inside these query structures.

## Test plan
- [x] All existing tests pass unchanged (default `alias_id => true`)
- [x] Verified with integration tests: model lifecycle (create, refresh, query, update), query builder insert, raw MongoDB document verification, soft deletes with compound where clauses