### PR TITLE
Move field aliasing methods to Grammar class as public overridable API

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -22,6 +22,7 @@ use Throwable;
 use function filter_var;
 use function implode;
 use function is_array;
+use function method_exists;
 use function preg_match;
 use function sprintf;
 use function str_contains;
@@ -371,7 +372,16 @@ class Connection extends BaseConnection
     protected function getDefaultQueryGrammar()
     {
         // Argument added in Laravel 12
-        return new Query\Grammar($this);
+        $grammar = new Query\Grammar($this);
+
+        // Method setConnection() was removed in Laravel 12,
+        // where the connection is passed via the constructor instead.
+        // Keep this for Laravel 11.
+        if (method_exists($grammar, 'setConnection')) {
+            $grammar->setConnection($this);
+        }
+
+        return $grammar;
     }
 
     /** @inheritdoc */
@@ -379,7 +389,16 @@ class Connection extends BaseConnection
     protected function getDefaultSchemaGrammar()
     {
         // Argument added in Laravel 12
-        return new Schema\Grammar($this);
+        $grammar = new Schema\Grammar($this);
+
+        // Method setConnection() was removed in Laravel 12,
+        // where the connection is passed via the constructor instead.
+        // Keep this for Laravel 11.
+        if (method_exists($grammar, 'setConnection')) {
+            $grammar->setConnection($this);
+        }
+
+        return $grammar;
     }
 
     /**

--- a/src/Eloquent/Builder.php
+++ b/src/Eloquent/Builder.php
@@ -253,7 +253,7 @@ class Builder extends EloquentBuilder
         // Convert MongoCursor results to a collection of models.
         if ($results instanceof CursorInterface) {
             $results->setTypeMap(['root' => 'array', 'document' => 'array', 'array' => 'array']);
-            $results = array_map(fn ($document) => $this->query->aliasIdForResult($document), iterator_to_array($results));
+            $results = array_map(fn ($document) => $this->query->getGrammar()->prepareFieldsForResult($document), iterator_to_array($results));
 
             return $this->model->hydrate($results);
         }
@@ -269,7 +269,7 @@ class Builder extends EloquentBuilder
 
         // The result is a single object.
         if (is_array($results) && (array_key_exists('_id', $results) || array_key_exists('id', $results))) {
-            $results = $this->query->aliasIdForResult($results);
+            $results = $this->query->getGrammar()->prepareFieldsForResult($results);
 
             return $this->model->newFromBuilder($results);
         }

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -90,9 +90,9 @@ class Builder extends BaseBuilder
     /**
      * The database collection.
      *
-     * @var Collection
+     * @var \MongoDB\Collection
      */
-    protected Collection $collection;
+    protected $collection;
 
     /**
      * The column projections.
@@ -1391,7 +1391,7 @@ class Builder extends BaseBuilder
             $operator = $operator === 'like' ? '=' : 'not';
             // phpcs:ignore Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace
         }
-        
+
         // Manipulate regex operations.
         elseif (in_array($operator, ['regex', 'not regex'])) {
             // Automatically convert regular expression strings to Regex objects.

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -8,14 +8,11 @@ use ArgumentCountError;
 use BadMethodCallException;
 use Carbon\CarbonPeriod;
 use Closure;
-use DateTimeInterface;
-use DateTimeZone;
 use Illuminate\Database\Query\Builder as BaseBuilder;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Date;
 use Illuminate\Support\LazyCollection;
 use InvalidArgumentException;
 use LogicException;
@@ -32,7 +29,6 @@ use MongoDB\Driver\ReadPreference;
 use MongoDB\Laravel\Connection;
 use Override;
 use RuntimeException;
-use stdClass;
 use TypeError;
 
 use function array_fill_keys;
@@ -50,7 +46,6 @@ use function call_user_func;
 use function call_user_func_array;
 use function count;
 use function ctype_xdigit;
-use function date_default_timezone_get;
 use function dd;
 use function dump;
 use function end;
@@ -58,7 +53,6 @@ use function explode;
 use function func_get_args;
 use function func_num_args;
 use function get_debug_type;
-use function get_object_vars;
 use function implode;
 use function in_array;
 use function is_array;
@@ -72,10 +66,8 @@ use function md5;
 use function preg_match;
 use function preg_quote;
 use function preg_replace;
-use function property_exists;
 use function serialize;
 use function sprintf;
-use function str_contains;
 use function str_ends_with;
 use function str_replace;
 use function str_starts_with;
@@ -85,7 +77,10 @@ use function substr;
 use function trait_exists;
 use function var_export;
 
-/** @property Connection $connection */
+/**
+ * @property Connection $connection
+ * @property Grammar    $grammar
+ */
 class Builder extends BaseBuilder
 {
     use BuilderTimeout;
@@ -95,23 +90,23 @@ class Builder extends BaseBuilder
     /**
      * The database collection.
      *
-     * @var \MongoDB\Collection
+     * @var Collection
      */
-    protected $collection;
+    protected Collection $collection;
 
     /**
      * The column projections.
      *
      * @var array
      */
-    public $projections = [];
+    public array $projections = [];
 
     /**
      * The cursor hint value.
      *
      * @var int
      */
-    public $hint;
+    public int $hint;
 
     private ReadPreference $readPreference;
 
@@ -120,7 +115,7 @@ class Builder extends BaseBuilder
      *
      * @var array
      */
-    public $options = [];
+    public array $options = [];
 
     /**
      * All of the available clause operators.
@@ -176,7 +171,7 @@ class Builder extends BaseBuilder
      *
      * @var array
      */
-    protected $conversion = [
+    protected array $conversion = [
         '=' => 'eq',
         '!=' => 'ne',
         '<>' => 'ne',
@@ -302,11 +297,11 @@ class Builder extends BaseBuilder
         }
 
         $wheres = $this->compileWheres();
-        $wheres = $this->aliasIdForQuery($wheres);
+        $wheres = $this->grammar->prepareFieldsForQuery($wheres);
 
         // Use MongoDB's aggregation framework when using grouping or aggregation functions.
         if ($this->groups || $this->aggregate) {
-            $group   = [];
+            $group = [];
             $unwinds = [];
             $set = [];
 
@@ -341,7 +336,7 @@ class Builder extends BaseBuilder
                     $splitColumns = explode('.*.', $column);
                     if (count($splitColumns) === 2) {
                         $unwinds[] = $splitColumns[0];
-                        $column    = implode('.', $splitColumns);
+                        $column = implode('.', $splitColumns);
                     }
 
                     $aggregations = blank($this->aggregate['columns']) ? [] : $this->aggregate['columns'];
@@ -394,7 +389,7 @@ class Builder extends BaseBuilder
 
             // Apply order and limit
             if ($this->orders) {
-                $pipeline[] = ['$sort' => $this->aliasIdForQuery($this->orders)];
+                $pipeline[] = ['$sort' => $this->grammar->prepareFieldsForQuery($this->orders)];
             }
 
             if ($this->offset) {
@@ -435,7 +430,7 @@ class Builder extends BaseBuilder
 
         // Normal query
         // Convert select columns to simple projections.
-        $projection = $this->aliasIdForQuery(array_fill_keys($columns, true));
+        $projection = $this->grammar->prepareFieldsForQuery(array_fill_keys($columns, true));
 
         // Add custom projections.
         if ($this->projections) {
@@ -450,7 +445,7 @@ class Builder extends BaseBuilder
         }
 
         if ($this->orders) {
-            $options['sort'] = $this->aliasIdForQuery($this->orders);
+            $options['sort'] = $this->grammar->prepareFieldsForQuery($this->orders);
         }
 
         if ($this->offset) {
@@ -524,7 +519,7 @@ class Builder extends BaseBuilder
         if ($returnLazy) {
             return LazyCollection::make(function () use ($result) {
                 foreach ($result as $item) {
-                    yield $this->aliasIdForResult($item);
+                    yield $this->grammar->prepareFieldsForResult($item);
                 }
             });
         }
@@ -535,7 +530,7 @@ class Builder extends BaseBuilder
 
         foreach ($result as &$document) {
             if (is_array($document) || is_object($document)) {
-                $document = $this->aliasIdForResult($document);
+                $document = $this->grammar->prepareFieldsForResult($document);
             }
         }
 
@@ -606,8 +601,8 @@ class Builder extends BaseBuilder
         // Once we have executed the query, we will reset the aggregate property so
         // that more select queries can be executed against the database without
         // the aggregate value getting in the way when the grammar builds it.
-        $this->aggregate          = null;
-        $this->columns            = $previousColumns;
+        $this->aggregate = null;
+        $this->columns = $previousColumns;
         $this->bindings['select'] = $previousSelectBindings;
 
         // When the aggregation is per group, we return the results as is.
@@ -765,7 +760,7 @@ class Builder extends BaseBuilder
         }
 
         $values = array_map(
-            $this->aliasIdForQuery(...),
+            $this->grammar->prepareFieldsForQuery(...),
             $values,
         );
 
@@ -782,7 +777,7 @@ class Builder extends BaseBuilder
     {
         $options = $this->inheritConnectionOptions();
 
-        $values = $this->aliasIdForQuery($values);
+        $values = $this->grammar->prepareFieldsForQuery($values);
 
         $result = $this->collection->insertOne($values, $options);
 
@@ -987,8 +982,8 @@ class Builder extends BaseBuilder
             $this->where('_id', '=', $id);
         }
 
-        $wheres  = $this->compileWheres();
-        $wheres  = $this->aliasIdForQuery($wheres);
+        $wheres = $this->compileWheres();
+        $wheres = $this->grammar->prepareFieldsForQuery($wheres);
         $options = $this->inheritConnectionOptions();
 
         /**
@@ -1022,7 +1017,7 @@ class Builder extends BaseBuilder
     public function truncate(): bool
     {
         $options = $this->inheritConnectionOptions();
-        $result  = $this->collection->deleteMany([], $options);
+        $result = $this->collection->deleteMany([], $options);
 
         return $result->isAcknowledged();
     }
@@ -1193,12 +1188,12 @@ class Builder extends BaseBuilder
             $options['multiple'] = true;
         }
 
-        $update = $this->aliasIdForQuery($update);
+        $update = $this->grammar->prepareFieldsForQuery($update);
 
         $options = $this->inheritConnectionOptions($options);
 
         $wheres = $this->compileWheres();
-        $wheres = $this->aliasIdForQuery($wheres);
+        $wheres = $this->grammar->prepareFieldsForQuery($wheres);
         $result = $this->collection->updateMany($wheres, $update, $options);
         if ($result->isAcknowledged()) {
             return $result->getModifiedCount() ?: $result->getUpsertedCount();
@@ -1367,9 +1362,9 @@ class Builder extends BaseBuilder
 
     protected function compileWhereBasic(array $where): array
     {
-        $column   = $where['column'];
+        $column = $where['column'];
         $operator = $where['operator'];
-        $value    = $where['value'];
+        $value = $where['value'];
 
         // Replace like or not like with a Regex instance.
         if (in_array($operator, ['like', 'not like'])) {
@@ -1395,9 +1390,7 @@ class Builder extends BaseBuilder
             // For inverse like operations, we can just use the $not operator with the Regex
             $operator = $operator === 'like' ? '=' : 'not';
             // phpcs:ignore Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace
-        }
-
-        // Manipulate regex operations.
+        } // Manipulate regex operations.
         elseif (in_array($operator, ['regex', 'not regex'])) {
             // Automatically convert regular expression strings to Regex objects.
             if (is_string($value)) {
@@ -1417,7 +1410,7 @@ class Builder extends BaseBuilder
                 $flags = end($e);
                 // Extract the regex string between the delimiters
                 $regstr = substr($value, 1, -1 - strlen($flags));
-                $value  = new Regex($regstr, $flags);
+                $value = new Regex($regstr, $flags);
             }
 
             // For inverse regex operations, we can just use the $not operator with the Regex
@@ -1458,7 +1451,7 @@ class Builder extends BaseBuilder
     protected function compileWhereNull(array $where): array
     {
         $where['operator'] = '=';
-        $where['value']    = null;
+        $where['value'] = null;
 
         return $this->compileWhereBasic($where);
     }
@@ -1466,7 +1459,7 @@ class Builder extends BaseBuilder
     protected function compileWhereNotNull(array $where): array
     {
         $where['operator'] = 'ne';
-        $where['value']    = null;
+        $where['value'] = null;
 
         return $this->compileWhereBasic($where);
     }
@@ -1474,7 +1467,7 @@ class Builder extends BaseBuilder
     protected function compileWhereBetween(array $where): array
     {
         $column = $where['column'];
-        $not    = $where['not'];
+        $not = $where['not'];
         $values = $where['values'];
 
         if ($not) {
@@ -1505,7 +1498,7 @@ class Builder extends BaseBuilder
     protected function compileWhereDate(array $where): array
     {
         $startOfDay = new UTCDateTime(Carbon::parse($where['value'])->startOfDay());
-        $endOfDay   = new UTCDateTime(Carbon::parse($where['value'])->endOfDay());
+        $endOfDay = new UTCDateTime(Carbon::parse($where['value'])->endOfDay());
 
         return match ($where['operator']) {
             'eq', '=' => [
@@ -1868,117 +1861,5 @@ class Builder extends BaseBuilder
     public function orWhereIntegerNotInRaw($column, $values, $boolean = 'and')
     {
         throw new BadMethodCallException('This method is not supported by MongoDB');
-    }
-
-    /**
-     * @internal
-     *
-     * @psalm-param T $values
-     *
-     * @psalm-return T
-     *
-     * @template T of array
-     */
-    public function aliasIdForQuery(array $values, bool $root = true): array
-    {
-        if (array_key_exists('id', $values) && ($root || $this->connection->getRenameEmbeddedIdField())) {
-            if (array_key_exists('_id', $values) && $values['id'] !== $values['_id']) {
-                throw new InvalidArgumentException('Cannot have both "id" and "_id" fields.');
-            }
-
-            $values['_id'] = $values['id'];
-            unset($values['id']);
-        }
-
-        foreach ($values as $key => $value) {
-            if (! is_string($key)) {
-                continue;
-            }
-
-            // "->" arrow notation for subfields is an alias for "." dot notation
-            if (str_contains($key, '->')) {
-                $newKey = str_replace('->', '.', $key);
-                if (array_key_exists($newKey, $values) && $value !== $values[$newKey]) {
-                    throw new InvalidArgumentException(sprintf('Cannot have both "%s" and "%s" fields.', $key, $newKey));
-                }
-
-                $values[$newKey] = $value;
-                unset($values[$key]);
-                $key = $newKey;
-            }
-
-            // ".id" subfield are alias for "._id"
-            if (str_ends_with($key, '.id') && $this->connection->getRenameEmbeddedIdField()) {
-                $newKey = substr($key, 0, -3) . '._id';
-                if (array_key_exists($newKey, $values) && $value !== $values[$newKey]) {
-                    throw new InvalidArgumentException(sprintf('Cannot have both "%s" and "%s" fields.', $key, $newKey));
-                }
-
-                $values[$newKey] = $value;
-                unset($values[$key]);
-            }
-        }
-
-        foreach ($values as &$value) {
-            if (is_array($value)) {
-                $value = $this->aliasIdForQuery($value, false);
-            } elseif ($value instanceof DateTimeInterface) {
-                $value = new UTCDateTime($value);
-            }
-        }
-
-        return $values;
-    }
-
-    /**
-     * @internal
-     *
-     * @psalm-param T $values
-     *
-     * @psalm-return T
-     *
-     * @template T of array|object
-     */
-    public function aliasIdForResult(array|object $values, bool $root = true): array|object
-    {
-        if (is_array($values)) {
-            if (
-                array_key_exists('_id', $values) && ! array_key_exists('id', $values)
-                && ($root || $this->connection->getRenameEmbeddedIdField())
-            ) {
-                $values['id'] = $values['_id'];
-                unset($values['_id']);
-            }
-
-            foreach ($values as $key => $value) {
-                if ($value instanceof UTCDateTime) {
-                    $values[$key] = Date::instance($value->toDateTime())
-                        ->setTimezone(new DateTimeZone(date_default_timezone_get()));
-                } elseif (is_array($value) || is_object($value)) {
-                    $values[$key] = $this->aliasIdForResult($value, false);
-                }
-            }
-        }
-
-        if ($values instanceof stdClass) {
-            if (
-                property_exists($values, '_id') && ! property_exists($values, 'id')
-                && ($root || $this->connection->getRenameEmbeddedIdField())
-            ) {
-                $values->id = $values->_id;
-                unset($values->_id);
-            }
-
-            foreach (get_object_vars($values) as $key => $value) {
-                if ($value instanceof UTCDateTime) {
-                    $values->{$key} = Date::instance($value->toDateTime())
-                        ->setTimezone(new DateTimeZone(date_default_timezone_get()));
-                } elseif (is_array($value) || is_object($value)) {
-                    $values->{$key} = $this->aliasIdForResult($value, false);
-                }
-            }
-        }
-
-        return $values;
     }
 }

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -106,7 +106,7 @@ class Builder extends BaseBuilder
      *
      * @var int
      */
-    public int $hint;
+    public $hint;
 
     private ReadPreference $readPreference;
 

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -1390,7 +1390,9 @@ class Builder extends BaseBuilder
             // For inverse like operations, we can just use the $not operator with the Regex
             $operator = $operator === 'like' ? '=' : 'not';
             // phpcs:ignore Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace
-        } // Manipulate regex operations.
+        }
+        
+        // Manipulate regex operations.
         elseif (in_array($operator, ['regex', 'not regex'])) {
             // Automatically convert regular expression strings to Regex objects.
             if (is_string($value)) {

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -1870,7 +1870,16 @@ class Builder extends BaseBuilder
         throw new BadMethodCallException('This method is not supported by MongoDB');
     }
 
-    private function aliasIdForQuery(array $values, bool $root = true): array
+    /**
+     * @internal
+     *
+     * @psalm-param T $values
+     *
+     * @psalm-return T
+     *
+     * @template T of array
+     */
+    public function aliasIdForQuery(array $values, bool $root = true): array
     {
         if (array_key_exists('id', $values) && ($root || $this->connection->getRenameEmbeddedIdField())) {
             if (array_key_exists('_id', $values) && $values['id'] !== $values['_id']) {
@@ -1888,24 +1897,24 @@ class Builder extends BaseBuilder
 
             // "->" arrow notation for subfields is an alias for "." dot notation
             if (str_contains($key, '->')) {
-                $newkey = str_replace('->', '.', $key);
-                if (array_key_exists($newkey, $values) && $value !== $values[$newkey]) {
-                    throw new InvalidArgumentException(sprintf('Cannot have both "%s" and "%s" fields.', $key, $newkey));
+                $newKey = str_replace('->', '.', $key);
+                if (array_key_exists($newKey, $values) && $value !== $values[$newKey]) {
+                    throw new InvalidArgumentException(sprintf('Cannot have both "%s" and "%s" fields.', $key, $newKey));
                 }
 
-                $values[$newkey] = $value;
+                $values[$newKey] = $value;
                 unset($values[$key]);
-                $key = $newkey;
+                $key = $newKey;
             }
 
             // ".id" subfield are alias for "._id"
             if (str_ends_with($key, '.id') && $this->connection->getRenameEmbeddedIdField()) {
-                $newkey = substr($key, 0, -3) . '._id';
-                if (array_key_exists($newkey, $values) && $value !== $values[$newkey]) {
-                    throw new InvalidArgumentException(sprintf('Cannot have both "%s" and "%s" fields.', $key, $newkey));
+                $newKey = substr($key, 0, -3) . '._id';
+                if (array_key_exists($newKey, $values) && $value !== $values[$newKey]) {
+                    throw new InvalidArgumentException(sprintf('Cannot have both "%s" and "%s" fields.', $key, $newKey));
                 }
 
-                $values[$newkey] = $value;
+                $values[$newKey] = $value;
                 unset($values[$key]);
             }
         }

--- a/src/Query/Grammar.php
+++ b/src/Query/Grammar.php
@@ -34,14 +34,14 @@ class Grammar extends BaseGrammar
      * Prepare fields for the MongoDB query by aliasing "id" to "_id" and handling arrow notation.
      * Users can override this method to customize field aliasing behavior.
      *
-     * @template T of array
-     *
-     * @psalm-param T $values
      * @param array<string, mixed> $values The values to prepare
      * @param bool                 $root   Whether this is the root level (affects embedded id field handling)
+     * @psalm-param T $values
      *
-     * @psalm-return T
      * @return array<string, mixed> The prepared values
+     * @psalm-return T
+     *
+     * @template T of array
      */
     public function prepareFieldsForQuery(array $values, bool $root = true): array
     {
@@ -98,16 +98,16 @@ class Grammar extends BaseGrammar
      * Prepare fields from the MongoDB result by aliasing "_id" to "id".
      * Users can override this method to customize field aliasing behavior.
      *
-     * @template T of array|object
-     *
-     * @psalm-param T                     $values
      * @param array<string, mixed>|object $values The values to prepare
      * @param bool                        $root   Whether this is the root level (affects embedded id field handling)
+     * @psalm-param T                     $values
      *
-     * @psalm-return T
      * @return array<string, mixed>|object The prepared values
+     * @psalm-return T
      *
      * @throws DateInvalidTimeZoneException
+     *
+     * @template T of array|object
      */
     public function prepareFieldsForResult(array|object $values, bool $root = true): array|object
     {

--- a/src/Query/Grammar.php
+++ b/src/Query/Grammar.php
@@ -4,8 +4,151 @@ declare(strict_types=1);
 
 namespace MongoDB\Laravel\Query;
 
+use DateInvalidTimeZoneException;
+use DateTimeInterface;
+use DateTimeZone;
 use Illuminate\Database\Query\Grammars\Grammar as BaseGrammar;
+use Illuminate\Support\Facades\Date;
+use InvalidArgumentException;
+use MongoDB\BSON\UTCDateTime;
+use MongoDB\Laravel\Connection;
+use stdClass;
 
+use function array_key_exists;
+use function date_default_timezone_get;
+use function get_object_vars;
+use function is_array;
+use function is_object;
+use function is_string;
+use function property_exists;
+use function sprintf;
+use function str_contains;
+use function str_ends_with;
+use function str_replace;
+use function substr;
+
+/** @property Connection $connection */
 class Grammar extends BaseGrammar
 {
+    /**
+     * Prepare fields for the MongoDB query by aliasing "id" to "_id" and handling arrow notation.
+     * Users can override this method to customize field aliasing behavior.
+     *
+     * @template T of array
+     *
+     * @psalm-param T $values
+     * @param array<string, mixed> $values The values to prepare
+     * @param bool                 $root   Whether this is the root level (affects embedded id field handling)
+     *
+     * @psalm-return T
+     * @return array<string, mixed> The prepared values
+     */
+    public function prepareFieldsForQuery(array $values, bool $root = true): array
+    {
+        if (array_key_exists('id', $values) && ($root || $this->connection->getRenameEmbeddedIdField())) {
+            if (array_key_exists('_id', $values) && $values['id'] !== $values['_id']) {
+                throw new InvalidArgumentException('Cannot have both "id" and "_id" fields.');
+            }
+
+            $values['_id'] = $values['id'];
+            unset($values['id']);
+        }
+
+        foreach ($values as $key => $value) {
+            if (! is_string($key)) {
+                continue;
+            }
+
+            // "->" arrow notation for subfields is an alias for "." dot notation
+            if (str_contains($key, '->')) {
+                $newKey = str_replace('->', '.', $key);
+                if (array_key_exists($newKey, $values) && $value !== $values[$newKey]) {
+                    throw new InvalidArgumentException(sprintf('Cannot have both "%s" and "%s" fields.', $key, $newKey));
+                }
+
+                $values[$newKey] = $value;
+                unset($values[$key]);
+                $key = $newKey;
+            }
+
+            // ".id" subfield are alias for "._id"
+            if (str_ends_with($key, '.id') && $this->connection->getRenameEmbeddedIdField()) {
+                $newKey = substr($key, 0, -3) . '._id';
+                if (array_key_exists($newKey, $values) && $value !== $values[$newKey]) {
+                    throw new InvalidArgumentException(sprintf('Cannot have both "%s" and "%s" fields.', $key, $newKey));
+                }
+
+                $values[$newKey] = $value;
+                unset($values[$key]);
+            }
+        }
+
+        foreach ($values as &$value) {
+            if (is_array($value)) {
+                $value = $this->prepareFieldsForQuery($value, false);
+            } elseif ($value instanceof DateTimeInterface) {
+                $value = new UTCDateTime($value);
+            }
+        }
+
+        return $values;
+    }
+
+    /**
+     * Prepare fields from the MongoDB result by aliasing "_id" to "id".
+     * Users can override this method to customize field aliasing behavior.
+     *
+     * @template T of array|object
+     *
+     * @psalm-param T                     $values
+     * @param array<string, mixed>|object $values The values to prepare
+     * @param bool                        $root   Whether this is the root level (affects embedded id field handling)
+     *
+     * @psalm-return T
+     * @return array<string, mixed>|object The prepared values
+     *
+     * @throws DateInvalidTimeZoneException
+     */
+    public function prepareFieldsForResult(array|object $values, bool $root = true): array|object
+    {
+        if (is_array($values)) {
+            if (
+                array_key_exists('_id', $values) && ! array_key_exists('id', $values)
+                && ($root || $this->connection->getRenameEmbeddedIdField())
+            ) {
+                $values['id'] = $values['_id'];
+                unset($values['_id']);
+            }
+
+            foreach ($values as $key => $value) {
+                if ($value instanceof UTCDateTime) {
+                    $values[$key] = Date::instance($value->toDateTime())
+                        ->setTimezone(new DateTimeZone(date_default_timezone_get()));
+                } elseif (is_array($value) || is_object($value)) {
+                    $values[$key] = $this->prepareFieldsForResult($value, false);
+                }
+            }
+        }
+
+        if ($values instanceof stdClass) {
+            if (
+                property_exists($values, '_id') && ! property_exists($values, 'id')
+                && ($root || $this->connection->getRenameEmbeddedIdField())
+            ) {
+                $values->id = $values->_id;
+                unset($values->_id);
+            }
+
+            foreach (get_object_vars($values) as $key => $value) {
+                if ($value instanceof UTCDateTime) {
+                    $values->{$key} = Date::instance($value->toDateTime())
+                        ->setTimezone(new DateTimeZone(date_default_timezone_get()));
+                } elseif (is_array($value) || is_object($value)) {
+                    $values->{$key} = $this->prepareFieldsForResult($value, false);
+                }
+            }
+        }
+
+        return $values;
+    }
 }

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -1717,8 +1717,26 @@ class BuilderTest extends TestCase
         $connection->method('getRenameEmbeddedIdField')->willReturn($renameEmbeddedIdField);
         $processor  = $this->createStub(Processor::class);
         $connection->method('getSession')->willReturn(null);
-        $connection->method('getQueryGrammar')->willReturn(new Grammar($connection));
+        $connection->method('getQueryGrammar')->willReturn($this->getMongoGrammar($connection));
 
         return new Builder($connection, null, $processor);
+    }
+
+    /**
+     * Helper method to get a MongoDB grammar instance with the given connection.
+     */
+    protected function getMongoGrammar(Connection $connection): Grammar
+    {
+        // Argument added in Laravel 12
+        $grammar = new Grammar($connection);
+
+        // Method setConnection() was removed in Laravel 12,
+        // where the connection is passed via the constructor instead.
+        // Keep this for Laravel 11.
+        if (method_exists($grammar, 'setConnection')) {
+            $grammar->setConnection($connection);
+        }
+
+        return $grammar;
     }
 }

--- a/tests/Query/GrammarTest.php
+++ b/tests/Query/GrammarTest.php
@@ -13,6 +13,7 @@ use MongoDB\Laravel\Tests\TestCase;
 use stdClass;
 
 use function date_default_timezone_get;
+use function method_exists;
 use function property_exists;
 
 class GrammarTest extends TestCase
@@ -25,7 +26,7 @@ class GrammarTest extends TestCase
         parent::setUp();
 
         $this->connection = $this->getMongoConnection();
-        $this->grammar    = new Grammar($this->connection);
+        $this->grammar    = $this->getMongoGrammar($this->connection);
     }
 
     /**
@@ -416,5 +417,23 @@ class GrammarTest extends TestCase
     protected function getMongoConnection(): Connection
     {
         return $this->app['db']->connection('mongodb');
+    }
+
+    /**
+     * Helper method to get a MongoDB grammar instance with the given connection.
+     */
+    protected function getMongoGrammar(Connection $connection): Grammar
+    {
+        // Argument added in Laravel 12
+        $grammar = new Grammar($connection);
+
+        // Method setConnection() was removed in Laravel 12,
+        // where the connection is passed via the constructor instead.
+        // Keep this for Laravel 11.
+        if (method_exists($grammar, 'setConnection')) {
+            $grammar->setConnection($connection);
+        }
+
+        return $grammar;
     }
 }

--- a/tests/Query/GrammarTest.php
+++ b/tests/Query/GrammarTest.php
@@ -1,0 +1,420 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Laravel\Tests\Query;
+
+use Illuminate\Support\Carbon;
+use InvalidArgumentException;
+use MongoDB\BSON\UTCDateTime;
+use MongoDB\Laravel\Connection;
+use MongoDB\Laravel\Query\Grammar;
+use MongoDB\Laravel\Tests\TestCase;
+use stdClass;
+
+use function date_default_timezone_get;
+use function property_exists;
+
+class GrammarTest extends TestCase
+{
+    private Grammar $grammar;
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->connection = $this->getMongoConnection();
+        $this->grammar    = new Grammar($this->connection);
+    }
+
+    /**
+     * Test that id is converted to _id for root level queries
+     */
+    public function testPrepareFieldsForQueryConvertsIdToUnderscoreId()
+    {
+        $input = ['id' => 123, 'name' => 'John'];
+        $result = $this->grammar->prepareFieldsForQuery($input);
+
+        $this->assertArrayHasKey('_id', $result);
+        $this->assertArrayNotHasKey('id', $result);
+        $this->assertEquals(123, $result['_id']);
+        $this->assertEquals('John', $result['name']);
+    }
+
+    /**
+     * Test that embedded id fields are converted based on configuration
+     */
+    public function testPrepareFieldsForQueryHandlesEmbeddedIdFields()
+    {
+        // With renameEmbeddedIdField enabled (default)
+        $input = ['user' => ['id' => 456, 'name' => 'Jane']];
+        $result = $this->grammar->prepareFieldsForQuery($input);
+
+        $this->assertEquals(['user' => ['_id' => 456, 'name' => 'Jane']], $result);
+    }
+
+    /**
+     * Test that embedded id fields are NOT converted when configuration is disabled
+     */
+    public function testPrepareFieldsForQueryRespectsRenameEmbeddedIdFieldConfiguration()
+    {
+        $this->connection->setRenameEmbeddedIdField(false);
+
+        $input = ['user' => ['id' => 456, 'name' => 'Jane']];
+        $result = $this->grammar->prepareFieldsForQuery($input);
+
+        // Embedded id should NOT be renamed
+        $this->assertEquals(['user' => ['id' => 456, 'name' => 'Jane']], $result);
+
+        // Reset for other tests
+        $this->connection->setRenameEmbeddedIdField(true);
+    }
+
+    /**
+     * Test that arrow notation is converted to dot notation
+     */
+    public function testPrepareFieldsForQueryConvertsArrowNotationToDotNotation()
+    {
+        $input = ['user->name' => 'John', 'user->email' => 'john@example.com'];
+        $result = $this->grammar->prepareFieldsForQuery($input);
+
+        $this->assertArrayHasKey('user.name', $result);
+        $this->assertArrayHasKey('user.email', $result);
+        $this->assertArrayNotHasKey('user->name', $result);
+        $this->assertArrayNotHasKey('user->email', $result);
+        $this->assertEquals('John', $result['user.name']);
+        $this->assertEquals('john@example.com', $result['user.email']);
+    }
+
+    /**
+     * Test that .id subfields are converted to ._id
+     */
+    public function testPrepareFieldsForQueryConvertsSubfieldIdToUnderscoreId()
+    {
+        $input = ['user.id' => 789];
+        $result = $this->grammar->prepareFieldsForQuery($input);
+
+        $this->assertArrayHasKey('user._id', $result);
+        $this->assertArrayNotHasKey('user.id', $result);
+        $this->assertEquals(789, $result['user._id']);
+    }
+
+    /**
+     * Test that .id subfields are NOT converted when configuration is disabled
+     */
+    public function testPrepareFieldsForQueryDoesNotConvertSubfieldIdWhenConfigDisabled()
+    {
+        $this->connection->setRenameEmbeddedIdField(false);
+
+        $input = ['user.id' => 789];
+        $result = $this->grammar->prepareFieldsForQuery($input);
+
+        // Should NOT be converted when renameEmbeddedIdField is false
+        $this->assertArrayHasKey('user.id', $result);
+        $this->assertArrayNotHasKey('user._id', $result);
+        $this->assertEquals(789, $result['user.id']);
+
+        // Reset for other tests
+        $this->connection->setRenameEmbeddedIdField(true);
+    }
+
+    /**
+     * Test that DateTime instances are converted to UTCDateTime
+     */
+    public function testPrepareFieldsForQueryConvertsDateTimeToUTCDateTime()
+    {
+        $date = Carbon::parse('2024-01-01 12:00:00');
+        $input = ['created_at' => $date, 'name' => 'Test'];
+        $result = $this->grammar->prepareFieldsForQuery($input);
+
+        $this->assertInstanceOf(UTCDateTime::class, $result['created_at']);
+        $this->assertEquals('Test', $result['name']);
+    }
+
+    /**
+     * Test that nested arrays are processed recursively
+     */
+    public function testPrepareFieldsForQueryProcessesNestedArrays()
+    {
+        $input = [
+            'id' => 1,
+            'nested' => [
+                'id' => 2,
+                'deep' => ['id' => 3],
+            ],
+        ];
+        $result = $this->grammar->prepareFieldsForQuery($input);
+
+        $this->assertEquals(1, $result['_id']);
+        $this->assertEquals(2, $result['nested']['_id']);
+        $this->assertEquals(3, $result['nested']['deep']['_id']);
+    }
+
+    /**
+     * Test that nested arrays respect renameEmbeddedIdField configuration
+     */
+    public function testPrepareFieldsForQueryProcessesNestedArraysWithConfigDisabled()
+    {
+        $this->connection->setRenameEmbeddedIdField(false);
+
+        $input = [
+            'id' => 1,
+            'nested' => [
+                'id' => 2,
+                'deep' => ['id' => 3],
+            ],
+        ];
+        $result = $this->grammar->prepareFieldsForQuery($input);
+
+        // Root level id should still be converted to _id
+        $this->assertEquals(1, $result['_id']);
+        // But nested id fields should NOT be converted
+        $this->assertEquals(2, $result['nested']['id']);
+        $this->assertEquals(3, $result['nested']['deep']['id']);
+
+        // Reset for other tests
+        $this->connection->setRenameEmbeddedIdField(true);
+    }
+
+    /**
+     * Test that having both id and _id throws an exception
+     */
+    public function testPrepareFieldsForQueryThrowsExceptionWhenBothIdAndUnderscoreIdExist()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot have both "id" and "_id" fields.');
+
+        $input = ['id' => 123, '_id' => 456];
+        $this->grammar->prepareFieldsForQuery($input);
+    }
+
+    /**
+     * Test that having both arrow notation and dot notation throws an exception
+     */
+    public function testPrepareFieldsForQueryThrowsExceptionForConflictingNotations()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot have both "user->name" and "user.name" fields.');
+
+        $input = ['user->name' => 'John', 'user.name' => 'Jane'];
+        $this->grammar->prepareFieldsForQuery($input);
+    }
+
+    /**
+     * Test that _id is converted to id for root level results
+     */
+    public function testPrepareFieldsForResultConvertsUnderscoreIdToId()
+    {
+        $input = ['_id' => 123, 'name' => 'John'];
+        $result = $this->grammar->prepareFieldsForResult($input);
+
+        $this->assertArrayHasKey('id', $result);
+        $this->assertArrayNotHasKey('_id', $result);
+        $this->assertEquals(123, $result['id']);
+        $this->assertEquals('John', $result['name']);
+    }
+
+    /**
+     * Test that embedded _id fields are converted based on configuration
+     */
+    public function testPrepareFieldsForResultHandlesEmbeddedIdFields()
+    {
+        $input = ['user' => ['_id' => 456, 'name' => 'Jane']];
+        $result = $this->grammar->prepareFieldsForResult($input);
+
+        $this->assertEquals(['user' => ['id' => 456, 'name' => 'Jane']], $result);
+    }
+
+    /**
+     * Test that embedded _id fields are NOT converted when configuration is disabled
+     */
+    public function testPrepareFieldsForResultRespectsRenameEmbeddedIdFieldConfiguration()
+    {
+        $this->connection->setRenameEmbeddedIdField(false);
+
+        $input = ['user' => ['_id' => 456, 'name' => 'Jane']];
+        $result = $this->grammar->prepareFieldsForResult($input);
+
+        // Embedded _id should NOT be renamed
+        $this->assertEquals(['user' => ['_id' => 456, 'name' => 'Jane']], $result);
+
+        // Reset for other tests
+        $this->connection->setRenameEmbeddedIdField(true);
+    }
+
+    /**
+     * Test that UTCDateTime instances are converted to Carbon with local timezone
+     */
+    public function testPrepareFieldsForResultConvertsUTCDateTimeToCarbon()
+    {
+        $utcDate = new UTCDateTime(Carbon::parse('2024-01-01 12:00:00', 'UTC'));
+        $input = ['created_at' => $utcDate, 'name' => 'Test'];
+        $result = $this->grammar->prepareFieldsForResult($input);
+
+        $this->assertInstanceOf(Carbon::class, $result['created_at']);
+        $this->assertEquals(date_default_timezone_get(), $result['created_at']->getTimezone()->getName());
+        $this->assertEquals('Test', $result['name']);
+    }
+
+    /**
+     * Test that nested arrays in results are processed recursively
+     */
+    public function testPrepareFieldsForResultProcessesNestedArrays()
+    {
+        $input = [
+            '_id' => 1,
+            'nested' => [
+                '_id' => 2,
+                'deep' => ['_id' => 3],
+            ],
+        ];
+        $result = $this->grammar->prepareFieldsForResult($input);
+
+        $this->assertEquals(1, $result['id']);
+        $this->assertEquals(2, $result['nested']['id']);
+        $this->assertEquals(3, $result['nested']['deep']['id']);
+    }
+
+    /**
+     * Test that nested arrays in results respect renameEmbeddedIdField configuration
+     */
+    public function testPrepareFieldsForResultProcessesNestedArraysWithConfigDisabled()
+    {
+        $this->connection->setRenameEmbeddedIdField(false);
+
+        $input = [
+            '_id' => 1,
+            'nested' => [
+                '_id' => 2,
+                'deep' => ['_id' => 3],
+            ],
+        ];
+        $result = $this->grammar->prepareFieldsForResult($input);
+
+        // Root level _id should still be converted to id
+        $this->assertEquals(1, $result['id']);
+        // But nested _id fields should NOT be converted
+        $this->assertEquals(2, $result['nested']['_id']);
+        $this->assertEquals(3, $result['nested']['deep']['_id']);
+
+        // Reset for other tests
+        $this->connection->setRenameEmbeddedIdField(true);
+    }
+
+    /**
+     * Test that stdClass objects are handled correctly
+     */
+    public function testPrepareFieldsForResultHandlesStdClass()
+    {
+        $input = new stdClass();
+        $input->_id = 123;
+        $input->name = 'John';
+
+        $result = $this->grammar->prepareFieldsForResult($input);
+
+        $this->assertInstanceOf(stdClass::class, $result);
+        $this->assertTrue(property_exists($result, 'id'));
+        $this->assertFalse(property_exists($result, '_id'));
+        $this->assertEquals(123, $result->id);
+        $this->assertEquals('John', $result->name);
+    }
+
+    /**
+     * Test that nested stdClass objects are processed recursively
+     */
+    public function testPrepareFieldsForResultProcessesNestedStdClass()
+    {
+        $nested = new stdClass();
+        $nested->_id = 456;
+        $nested->email = 'john@example.com';
+
+        $input = new stdClass();
+        $input->_id = 123;
+        $input->user = $nested;
+
+        $result = $this->grammar->prepareFieldsForResult($input);
+
+        $this->assertEquals(123, $result->id);
+        $this->assertTrue(property_exists($result->user, 'id'));
+        $this->assertEquals(456, $result->user->id);
+        $this->assertEquals('john@example.com', $result->user->email);
+    }
+
+    /**
+     * Test that nested stdClass objects respect renameEmbeddedIdField configuration
+     */
+    public function testPrepareFieldsForResultProcessesNestedStdClassWithConfigDisabled()
+    {
+        $this->connection->setRenameEmbeddedIdField(false);
+
+        $nested = new stdClass();
+        $nested->_id = 456;
+        $nested->email = 'john@example.com';
+
+        $input = new stdClass();
+        $input->_id = 123;
+        $input->user = $nested;
+
+        $result = $this->grammar->prepareFieldsForResult($input);
+
+        // Root level _id should still be converted to id
+        $this->assertEquals(123, $result->id);
+        // But nested _id should NOT be converted
+        $this->assertTrue(property_exists($result->user, '_id'));
+        $this->assertFalse(property_exists($result->user, 'id'));
+        $this->assertEquals(456, $result->user->_id);
+        $this->assertEquals('john@example.com', $result->user->email);
+
+        // Reset for other tests
+        $this->connection->setRenameEmbeddedIdField(true);
+    }
+
+    /**
+     * Test that mixed nested arrays and objects are handled correctly
+     */
+    public function testPrepareFieldsForResultHandlesMixedNestedStructures()
+    {
+        $object = new stdClass();
+        $object->_id = 789;
+        $object->type = 'nested';
+
+        $input = [
+            '_id' => 123,
+            'nested' => [
+                '_id' => 456,
+                'object' => $object,
+            ],
+        ];
+
+        $result = $this->grammar->prepareFieldsForResult($input);
+
+        $this->assertEquals(123, $result['id']);
+        $this->assertEquals(456, $result['nested']['id']);
+        $this->assertEquals(789, $result['nested']['object']->id);
+        $this->assertEquals('nested', $result['nested']['object']->type);
+    }
+
+    /**
+     * Test that having both id and _id in result does not convert
+     */
+    public function testPrepareFieldsForResultDoesNotConvertWhenIdAlreadyExists()
+    {
+        $input = ['_id' => 123, 'id' => 456, 'name' => 'John'];
+        $result = $this->grammar->prepareFieldsForResult($input);
+
+        // Should keep both as-is when id already exists
+        $this->assertArrayHasKey('_id', $result);
+        $this->assertArrayHasKey('id', $result);
+        $this->assertEquals(123, $result['_id']);
+        $this->assertEquals(456, $result['id']);
+    }
+
+    /**
+     * Helper method to get a MongoDB connection instance
+     */
+    protected function getMongoConnection(): Connection
+    {
+        return $this->app['db']->connection('mongodb');
+    }
+}


### PR DESCRIPTION
"Changed the visibility of aliasIdForQuery from private to public. 
This allows developers to override the method or call it directly to normalize query data (e.g. id => _id) beforehand, resolving limitations like https://github.com/mongodb/laravel-mongodb/issues/3453

### Checklist

- [X] Add tests and ensure they pass
