### PR TITLE
Fix Builder methods declaration for compatibility with Laravel 12.51

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -48,6 +48,7 @@
 
     <rule ref="PSR1.Classes.ClassDeclaration.MultipleClasses">
         <exclude-pattern>tests/Ticket/*.php</exclude-pattern>
+        <exclude-pattern>src/Query/BuilderTimeout.php</exclude-pattern>
     </rule>
 
     <rule ref="SlevomatCodingStandard.Commenting.DocCommentSpacing.IncorrectAnnotationsGroup">

--- a/src/Eloquent/Builder.php
+++ b/src/Eloquent/Builder.php
@@ -28,6 +28,7 @@ use function is_array;
 use function is_object;
 use function iterator_to_array;
 use function property_exists;
+use function value;
 
 /**
  * @method \MongoDB\Laravel\Query\Builder toBase()
@@ -277,7 +278,7 @@ class Builder extends EloquentBuilder
     }
 
     #[Override]
-    public function firstOrCreate(array $attributes = [], array $values = [])
+    public function firstOrCreate(array $attributes = [], Closure|array $values = [])
     {
         $instance = (clone $this)->where($attributes)->first();
         if ($instance !== null) {
@@ -286,14 +287,14 @@ class Builder extends EloquentBuilder
 
         // createOrFirst is not supported in transaction.
         if ($this->getConnection()->getSession()?->isInTransaction()) {
-            return $this->create(array_replace($attributes, $values));
+            return $this->create(array_replace($attributes, value($values)));
         }
 
         return $this->createOrFirst($attributes, $values);
     }
 
     #[Override]
-    public function createOrFirst(array $attributes = [], array $values = [])
+    public function createOrFirst(array $attributes = [], Closure|array $values = [])
     {
         // The duplicate key error would abort the transaction. Using the regular firstOrCreate in that case.
         if ($this->getConnection()->getSession()?->isInTransaction()) {
@@ -301,7 +302,7 @@ class Builder extends EloquentBuilder
         }
 
         try {
-            return $this->create(array_replace($attributes, $values));
+            return $this->create(array_replace($attributes, value($values)));
         } catch (BulkWriteException $e) {
             if ($e->getCode() === self::DUPLICATE_KEY_ERROR) {
                 return $this->where($attributes)->first() ?? throw $e;

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -87,6 +87,8 @@ use function var_export;
 /** @property Connection $connection */
 class Builder extends BaseBuilder
 {
+    use BuilderTimeout;
+
     private const REGEX_DELIMITERS = ['/', '#', '~'];
 
     /**
@@ -102,13 +104,6 @@ class Builder extends BaseBuilder
      * @var array
      */
     public $projections = [];
-
-    /**
-     * The maximum amount of seconds to allow the query to run.
-     *
-     * @var int|float
-     */
-    public $timeout;
 
     /**
      * The cursor hint value.
@@ -210,20 +205,6 @@ class Builder extends BaseBuilder
     public function project($columns)
     {
         $this->projections = is_array($columns) ? $columns : func_get_args();
-
-        return $this;
-    }
-
-    /**
-     * The maximum amount of seconds to allow the query to run.
-     *
-     * @param  int|float $seconds
-     *
-     * @return $this
-     */
-    public function timeout($seconds)
-    {
-        $this->timeout = $seconds;
 
         return $this;
     }

--- a/src/Query/BuilderTimeout.php
+++ b/src/Query/BuilderTimeout.php
@@ -33,7 +33,7 @@ if (method_exists(Builder::class, 'timeout')) {
         /**
          * The maximum amount of seconds to allow the query to run.
          *
-         * @param  int|float $seconds
+         * @param  int|null $seconds
          *
          * @return $this
          */

--- a/src/Query/BuilderTimeout.php
+++ b/src/Query/BuilderTimeout.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Laravel\Query;
+
+use Illuminate\Database\Query\Builder;
+
+use function method_exists;
+
+/**
+ * The method {@see \Illuminate\Database\Query\Builder::timeout()} was added in
+ * Laravel 12.51.0. This trait removes the method if it already exists
+ * as it's identical to the one added in Laravel 12.51, and adds it if it doesn't
+ * exist to provide support for older Laravel versions.
+ */
+if (method_exists(Builder::class, 'timeout')) {
+    /** @internal For Laravel 12.51+ */
+    trait BuilderTimeout
+    {
+    }
+} else {
+    /** @internal For older Laravel versions */
+    trait BuilderTimeout
+    {
+        /**
+         * The maximum amount of seconds to allow the query to run.
+         *
+         * @var int|float
+         */
+        public $timeout;
+
+        /**
+         * The maximum amount of seconds to allow the query to run.
+         *
+         * @param  int|float $seconds
+         *
+         * @return $this
+         */
+        public function timeout($seconds): static
+        {
+            $this->timeout = $seconds;
+
+            return $this;
+        }
+    }
+}

--- a/src/Query/BuilderTimeout.php
+++ b/src/Query/BuilderTimeout.php
@@ -10,9 +10,9 @@ use function method_exists;
 
 /**
  * The method {@see \Illuminate\Database\Query\Builder::timeout()} was added in
- * Laravel 12.51.0. This trait removes the method if it already exists
- * as it's identical to the one added in Laravel 12.51, and adds it if it doesn't
- * exist to provide support for older Laravel versions.
+ * Laravel 12.51.0. On Laravel 12.51.0 and later, this trait is empty because the
+ * framework already provides the method. On older Laravel versions, this trait
+ * defines the timeout API to provide backwards compatibility.
  */
 if (method_exists(Builder::class, 'timeout')) {
     /** @internal For Laravel 12.51+ */

--- a/src/Query/BuilderTimeout.php
+++ b/src/Query/BuilderTimeout.php
@@ -37,7 +37,7 @@ if (method_exists(Builder::class, 'timeout')) {
          *
          * @return $this
          */
-        public function timeout($seconds): static
+        public function timeout($seconds)
         {
             $this->timeout = $seconds;
 

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -1129,6 +1129,25 @@ class ModelTest extends TestCase
         $this->assertEquals($user->id, $check->id);
     }
 
+    public function testFirstOrCreateWithValues(): void
+    {
+        $name = 'Jane Poe';
+
+        $user = User::where('name', $name)->first();
+        $this->assertNull($user);
+
+        $user = User::firstOrCreate(['name' => $name], static fn () => ['age' => 30]);
+        $this->assertInstanceOf(User::class, $user);
+        $this->assertTrue(Model::isDocumentModel($user));
+        $this->assertTrue($user->exists);
+        $this->assertEquals($name, $user->name);
+
+        $check = User::where('name', $name)->first();
+        $this->assertInstanceOf(User::class, $check);
+        $this->assertEquals($user->id, $check->id);
+        $this->assertSame(30, $check->age);
+    }
+
     public function testEnumCast(): void
     {
         $name = 'John Member';
@@ -1213,7 +1232,7 @@ class ModelTest extends TestCase
         $events = [];
         $user3 = User::createOrFirst(
             ['email' => 'jane.doe@example.com'],
-            ['name' => 'Jane Doe', 'birthday' => new DateTime('1987-05-28')],
+            static fn () => ['name' => 'Jane Doe', 'birthday' => new DateTime('1987-05-28')],
         );
 
         $this->assertNotEquals($user3->id, $user1->id);

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -1438,8 +1438,8 @@ class BuilderTest extends TestCase
         ];
 
         yield 'timeout' => [
-            ['find' => [[], ['maxTimeMS' => 2345]]],
-            fn (Builder $builder) => $builder->timeout(2.3456),
+            ['find' => [[], ['maxTimeMS' => 2000]]],
+            fn (Builder $builder) => $builder->timeout(2),
         ];
     }
 


### PR DESCRIPTION
Fix https://github.com/mongodb/laravel-mongodb/issues/3478
Fix https://github.com/mongodb/laravel-mongodb/issues/3477

1. Declare `Query\Builder::timeout()` conditionally if not declared in Laravel.
   https://github.com/laravel/framework/pull/58644
2. Support value-closure as 2nd argument of `createOrFirst` and `firstOrCreate`.
   https://github.com/laravel/framework/pull/58639

