### PR TITLE
Fix chunked order query bug

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -39,6 +39,7 @@ use function array_fill_keys;
 use function array_filter;
 use function array_is_list;
 use function array_key_exists;
+use function array_keys;
 use function array_map;
 use function array_merge;
 use function array_replace;
@@ -702,6 +703,33 @@ class Builder extends BaseBuilder
         }
 
         return $this;
+    }
+
+    /**
+     * Override Illuminate's removeExistingOrdersFor to support associative order storage used by MongoDB.
+     *
+     * @inheritdoc
+     */
+    #[Override]
+    protected function removeExistingOrdersFor($column): array
+    {
+        $orders = $this->orders ?? [];
+
+        $toUnset = array_filter(
+            array_keys($orders),
+            function ($orderColumn) use ($column) {
+                return $orderColumn === $column
+                    || ($orderColumn === 'id' && $column === '_id')
+                    || ($orderColumn === '_id' && $column === 'id'
+                );
+            },
+        );
+
+        foreach ($toUnset as $column) {
+            unset($orders[$column]);
+        }
+
+        return $orders;
     }
 
     /** @inheritdoc */

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -531,6 +531,36 @@ class BuilderTest extends TestCase
                 ->orderBy('age', 1),
         ];
 
+        yield 'chunked ordering' => [
+            [
+                'find' => [
+                    ['_id' => ['$gt' => 0]],
+                    ['sort' => ['_id' => 1, 'name' => 1], 'limit' => 2],
+                ],
+            ],
+            function (Builder $builder) {
+                $builder->orderBy('_id')->orderBy('name');
+                $builder->forPageAfterId(2);
+
+                return $builder;
+            },
+        ];
+
+        yield 'chunked ordering with id alias' => [
+            [
+                'find' => [
+                    ['_id' => ['$gt' => 0]],
+                    ['sort' => ['_id' => 1, 'name' => 1], 'limit' => 2],
+                ],
+            ],
+            function (Builder $builder) {
+                $builder->orderBy('id')->orderBy('name');
+                $builder->forPageAfterId(2);
+
+                return $builder;
+            },
+        ];
+
         yield 'orderByDesc' => [
             ['find' => [[], ['sort' => ['email' => -1]]]],
             fn (Builder $builder) => $builder->orderByDesc('email'),


### PR DESCRIPTION
Fix https://github.com/mongodb/laravel-mongodb/issues/3474

Illuminate's query builder ordering was conflicting with our own, resulting in incorrect ordering for chunked queries.

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.
-->

### Checklist

- [x] Add tests and ensure they pass
