### PR TITLE
PHPORM-479 Fix MongoBatchRepository::rollBack() throwing when no active session

### DIFF
--- a/src/Bus/MongoBatchRepository.php
+++ b/src/Bus/MongoBatchRepository.php
@@ -199,6 +199,10 @@ class MongoBatchRepository extends DatabaseBatchRepository implements PrunableBa
     #[Override]
     public function rollBack(): void
     {
+        if (! $this->connection->getSession()?->isInTransaction()) {
+            return;
+        }
+
         $this->connection->rollBack();
     }
 

--- a/tests/Bus/MongoBatchRepositoryTest.php
+++ b/tests/Bus/MongoBatchRepositoryTest.php
@@ -329,6 +329,20 @@ final class MongoBatchRepositoryTest extends TestCase
         $this->assertInstanceOf(CarbonImmutable::class, $batch->createdAt);
     }
 
+    /** @see https://github.com/mongodb/laravel-mongodb/issues/3488 */
+    public function testRollBackWithoutSessionIsNoOp(): void
+    {
+        $connection = DB::connection('mongodb');
+        $this->assertInstanceOf(Connection::class, $connection);
+        $this->assertNull($connection->getSession());
+
+        $repository = new MongoBatchRepository(new BatchFactory(m::mock(Factory::class)), $connection, 'job_batches');
+
+        // Should not throw even when there is no active MongoDB session or transaction
+        $repository->rollBack();
+        $this->assertNull($connection->getSession());
+    }
+
     /** @see BusBatchTest::createTestBatch() */
     private function createTestBatch(Factory $queue, $allowFailures = false)
     {


### PR DESCRIPTION
## Summary

- `MongoBatchRepository::rollBack()` unconditionally called `$this->connection->rollBack()`, which throws `RuntimeException("There is no active session.")` when no MongoDB transaction/session was ever started
- This happens when batch operations fail (e.g. due to a timeout) and cleanup code triggers rollback — the spurious exception masks the real root cause
- Fix: guard against the no-session / no-active-transaction cases and return early as a no-op

## Test

Added `testRollBackWithoutSessionIsNoOp` to `MongoBatchRepositoryTest` to assert that calling `rollBack()` without an active session does not throw.

Fixes #3488 PHPORM-479