### PR TITLE
PHPORM-305 Deprecate "array" cast storing as JSON-encoded string

### DIFF
--- a/src/Eloquent/DocumentModel.php
+++ b/src/Eloquent/DocumentModel.php
@@ -11,7 +11,6 @@ use DateTimeZone;
 use Illuminate\Contracts\Queue\QueueableCollection;
 use Illuminate\Contracts\Queue\QueueableEntity;
 use Illuminate\Contracts\Support\Arrayable;
-use Illuminate\Database\Eloquent\Casts\Json;
 use Illuminate\Database\Eloquent\Concerns\HasAttributes;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;

--- a/src/Eloquent/DocumentModel.php
+++ b/src/Eloquent/DocumentModel.php
@@ -11,6 +11,7 @@ use DateTimeZone;
 use Illuminate\Contracts\Queue\QueueableCollection;
 use Illuminate\Contracts\Queue\QueueableEntity;
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Database\Eloquent\Casts\Json;
 use Illuminate\Database\Eloquent\Concerns\HasAttributes;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
@@ -267,6 +268,16 @@ trait DocumentModel
         return parent::setAttribute($key, $value);
     }
 
+    /** @inheritdoc */
+    protected function isJsonCastable($key)
+    {
+        if ($this->hasCast($key, ['array'])) {
+            return false;
+        }
+
+        return parent::isJsonCastable($key);
+    }
+
     /**
      * @param mixed $value
      *
@@ -286,6 +297,15 @@ trait DocumentModel
         }
 
         return parent::asDecimal($value, $decimals);
+    }
+
+    public function fromJson($value, $asObject = false)
+    {
+        if (is_array($value)) {
+            return $value;
+        }
+
+        return parent::fromJson($value, $asObject);
     }
 
     /**

--- a/src/Eloquent/DocumentModel.php
+++ b/src/Eloquent/DocumentModel.php
@@ -48,7 +48,10 @@ use function str_contains;
 use function str_starts_with;
 use function strcmp;
 use function strlen;
+use function trigger_error;
 use function var_export;
+
+use const E_USER_DEPRECATED;
 
 /** @mixin Builder */
 trait DocumentModel
@@ -271,7 +274,14 @@ trait DocumentModel
     protected function isJsonCastable($key)
     {
         if ($this->hasCast($key, ['array'])) {
-            return false;
+            trigger_error(
+                sprintf(
+                    'The "array" cast on attribute "%s" of model "%s" stores values as a JSON-encoded string in MongoDB, which is not the native format. Use the "json" cast to keep this behavior explicitly, or remove the cast to store a native BSON array.',
+                    $key,
+                    static::class,
+                ),
+                E_USER_DEPRECATED,
+            );
         }
 
         return parent::isJsonCastable($key);

--- a/src/Eloquent/DocumentModel.php
+++ b/src/Eloquent/DocumentModel.php
@@ -276,7 +276,7 @@ trait DocumentModel
         if ($this->hasCast($key, ['array'])) {
             trigger_error(
                 sprintf(
-                    'The "array" cast on attribute "%s" of model "%s" stores values as a JSON-encoded string in MongoDB, which is not the native format. Use the "json" cast to keep this behavior explicitly, or remove the cast to store a native BSON array.',
+                    'The "array" cast on attribute "%s" of model "%s" stores values as a JSON-encoded string in MongoDB, which is not the native format. Remove the cast to store native BSON arrays. If you must keep JSON string storage, use the "json" cast explicitly.',
                     $key,
                     static::class,
                 ),
@@ -311,7 +311,7 @@ trait DocumentModel
     public function fromJson($value, $asObject = false)
     {
         if (is_array($value)) {
-            return $value;
+            return $asObject ? (object) $value : $value;
         }
 
         return parent::fromJson($value, $asObject);

--- a/tests/Casts/ArrayTest.php
+++ b/tests/Casts/ArrayTest.php
@@ -8,6 +8,13 @@ use Illuminate\Support\Facades\DB;
 use MongoDB\BSON\ObjectId;
 use MongoDB\Laravel\Tests\Models\Casting;
 use MongoDB\Laravel\Tests\TestCase;
+use stdClass;
+
+use function assert;
+use function restore_error_handler;
+use function set_error_handler;
+
+use const E_USER_DEPRECATED;
 
 class ArrayTest extends TestCase
 {
@@ -18,44 +25,58 @@ class ArrayTest extends TestCase
         Casting::truncate();
     }
 
-    public function testArray(): void
+    public function testArrayCastTriggersDeprecation(): void
     {
-        /** @var Casting $model */
-        $model = Casting::query()->create(['arrayValue' => ["Dreamin' 'bout the spot that right now, I'm actually in", 'g-eazy' => 'Still']]);
+        $deprecations = [];
+        set_error_handler(static function (int $errno, string $errstr) use (&$deprecations): bool {
+            if ($errno === E_USER_DEPRECATED) {
+                $deprecations[] = $errstr;
+            }
 
+            return true;
+        });
+
+        $model = Casting::query()->create(['arrayValue' => ['key' => 'value']]);
+        assert($model instanceof Casting);
+
+        restore_error_handler();
+
+        self::assertNotEmpty($deprecations);
+        self::assertStringContainsString('Use the "json" cast to keep this behavior explicitly, or remove the cast to store a native BSON array.', $deprecations[0]);
         self::assertIsArray($model->arrayValue);
-        self::assertIsArray(
-            DB::connection()
-              ->table((new Casting())->getTable())
-              ->where('id', $model->id)
-              ->first()->arrayValue,
-        );
-        self::assertEquals(["Dreamin' 'bout the spot that right now, I'm actually in", 'g-eazy' => 'Still'], $model->arrayValue);
-
-        $model->update(['arrayValue' => ['What if I just said, f*ck it, never followed my dreams?']]);
-
-        self::assertIsArray($model->arrayValue);
-        self::assertIsArray(
-            DB::connection()
-              ->table((new Casting())->getTable())
-              ->where('id', $model->id)
-              ->first()->arrayValue,
-        );
-        self::assertEquals(['What if I just said, f*ck it, never followed my dreams?'], $model->arrayValue);
+        self::assertSame(['key' => 'value'], $model->arrayValue);
     }
 
-    public function testArrayLegacyJsonStringIsStillReadable(): void
+    public function testJsonStringIsNotDecodedWithoutCast(): void
     {
-        // Simulate data previously saved with the old behavior (JSON-encoded string).
+        // Document stored with the old behavior (JSON-encoded string via "array" cast).
         $id = new ObjectId();
-        $table = (new Casting())->getTable();
-        DB::connection()->table($table)->insert([
+        DB::connection()->table((new Casting())->getTable())->insert([
             '_id' => $id,
-            'arrayValue' => '{"key":"value","nested":{"a":1}}',
+            'arrayValue' => '{"key":"value"}',
         ]);
 
-        /** @var Casting $model */
+        // Without a cast, the raw JSON string is returned as-is — not decoded.
+        // Users must migrate their data before removing the "array" cast.
+        $raw = DB::connection()->table((new Casting())->getTable())->find($id);
+        assert($raw instanceof stdClass);
+
+        self::assertIsString($raw->arrayValue);
+        self::assertSame('{"key":"value"}', $raw->arrayValue);
+    }
+
+    public function testArrayCastStillReadableAsBsonNativeArray(): void
+    {
+        // A value stored as a native BSON array (e.g. by another system or after a future migration)
+        // must remain readable via the "array" cast.
+        $id = new ObjectId();
+        DB::connection()->table((new Casting())->getTable())->insert([
+            '_id' => $id,
+            'arrayValue' => ['key' => 'value', 'nested' => ['a' => 1]],
+        ]);
+
         $model = Casting::query()->find($id);
+        assert($model instanceof Casting);
 
         self::assertIsArray($model->arrayValue);
         self::assertSame(['key' => 'value', 'nested' => ['a' => 1]], $model->arrayValue);

--- a/tests/Casts/ArrayTest.php
+++ b/tests/Casts/ArrayTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Laravel\Tests\Casts;
+
+use Illuminate\Support\Facades\DB;
+use MongoDB\Laravel\Tests\Models\Casting;
+use MongoDB\Laravel\Tests\TestCase;
+
+class ArrayTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Casting::truncate();
+    }
+
+    public function testArray(): void
+    {
+        $model = Casting::query()->create(['arrayValue' => ["Dreamin' 'bout the spot that right now, I'm actually in", 'g-eazy' => 'Still']]);
+
+        self::assertIsArray($model->arrayValue);
+        self::assertIsArray(
+            DB::connection()
+              ->table((new Casting())->getTable())
+              ->where('id', $model->id)
+              ->first()->arrayValue
+        );
+        self::assertEquals(["Dreamin' 'bout the spot that right now, I'm actually in", 'g-eazy' => 'Still'], $model->arrayValue);
+
+        $model->update(['arrayValue' => ['What if I just said, f*ck it, never followed my dreams?']]);
+
+        self::assertIsArray($model->arrayValue);
+        self::assertIsArray(
+            DB::connection()
+              ->table((new Casting())->getTable())
+              ->where('id', $model->id)
+              ->first()->arrayValue
+        );
+        self::assertEquals(['What if I just said, f*ck it, never followed my dreams?'], $model->arrayValue);
+    }
+}

--- a/tests/Casts/ArrayTest.php
+++ b/tests/Casts/ArrayTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MongoDB\Laravel\Tests\Casts;
 
 use Illuminate\Support\Facades\DB;
+use MongoDB\BSON\ObjectId;
 use MongoDB\Laravel\Tests\Models\Casting;
 use MongoDB\Laravel\Tests\TestCase;
 
@@ -19,6 +20,7 @@ class ArrayTest extends TestCase
 
     public function testArray(): void
     {
+        /** @var Casting $model */
         $model = Casting::query()->create(['arrayValue' => ["Dreamin' 'bout the spot that right now, I'm actually in", 'g-eazy' => 'Still']]);
 
         self::assertIsArray($model->arrayValue);
@@ -40,5 +42,22 @@ class ArrayTest extends TestCase
               ->first()->arrayValue,
         );
         self::assertEquals(['What if I just said, f*ck it, never followed my dreams?'], $model->arrayValue);
+    }
+
+    public function testArrayLegacyJsonStringIsStillReadable(): void
+    {
+        // Simulate data previously saved with the old behavior (JSON-encoded string).
+        $id = new ObjectId();
+        $table = (new Casting())->getTable();
+        DB::connection()->table($table)->insert([
+            '_id' => $id,
+            'arrayValue' => '{"key":"value","nested":{"a":1}}',
+        ]);
+
+        /** @var Casting $model */
+        $model = Casting::query()->find($id);
+
+        self::assertIsArray($model->arrayValue);
+        self::assertSame(['key' => 'value', 'nested' => ['a' => 1]], $model->arrayValue);
     }
 }

--- a/tests/Casts/ArrayTest.php
+++ b/tests/Casts/ArrayTest.php
@@ -31,18 +31,22 @@ class ArrayTest extends TestCase
         set_error_handler(static function (int $errno, string $errstr) use (&$deprecations): bool {
             if ($errno === E_USER_DEPRECATED) {
                 $deprecations[] = $errstr;
+
+                return true;
             }
 
-            return true;
+            return false;
         });
 
-        $model = Casting::query()->create(['arrayValue' => ['key' => 'value']]);
-        assert($model instanceof Casting);
-
-        restore_error_handler();
+        try {
+            $model = Casting::query()->create(['arrayValue' => ['key' => 'value']]);
+            assert($model instanceof Casting);
+        } finally {
+            restore_error_handler();
+        }
 
         self::assertNotEmpty($deprecations);
-        self::assertStringContainsString('Use the "json" cast to keep this behavior explicitly, or remove the cast to store a native BSON array.', $deprecations[0]);
+        self::assertStringContainsString('Remove the cast to store native BSON arrays.', $deprecations[0]);
         self::assertIsArray($model->arrayValue);
         self::assertSame(['key' => 'value'], $model->arrayValue);
     }
@@ -80,5 +84,21 @@ class ArrayTest extends TestCase
 
         self::assertIsArray($model->arrayValue);
         self::assertSame(['key' => 'value', 'nested' => ['a' => 1]], $model->arrayValue);
+    }
+
+    public function testObjectCastWithNativeBsonDocumentReturnsObject(): void
+    {
+        // A native BSON document read via an "object" cast must come back as an object, not an array.
+        $id = new ObjectId();
+        DB::connection()->table((new Casting())->getTable())->insert([
+            '_id' => $id,
+            'objectValue' => ['key' => 'value'],
+        ]);
+
+        $model = Casting::query()->find($id);
+        assert($model instanceof Casting);
+
+        self::assertIsObject($model->objectValue);
+        self::assertSame('value', $model->objectValue->key);
     }
 }

--- a/tests/Casts/ArrayTest.php
+++ b/tests/Casts/ArrayTest.php
@@ -26,7 +26,7 @@ class ArrayTest extends TestCase
             DB::connection()
               ->table((new Casting())->getTable())
               ->where('id', $model->id)
-              ->first()->arrayValue
+              ->first()->arrayValue,
         );
         self::assertEquals(["Dreamin' 'bout the spot that right now, I'm actually in", 'g-eazy' => 'Still'], $model->arrayValue);
 
@@ -37,7 +37,7 @@ class ArrayTest extends TestCase
             DB::connection()
               ->table((new Casting())->getTable())
               ->where('id', $model->id)
-              ->first()->arrayValue
+              ->first()->arrayValue,
         );
         self::assertEquals(['What if I just said, f*ck it, never followed my dreams?'], $model->arrayValue);
     }

--- a/tests/Models/Casting.php
+++ b/tests/Models/Casting.php
@@ -7,6 +7,10 @@ namespace MongoDB\Laravel\Tests\Models;
 use MongoDB\Laravel\Eloquent\Casts\BinaryUuid;
 use MongoDB\Laravel\Eloquent\Model;
 
+/**
+ * @property mixed $id
+ * @property array $arrayValue
+ */
 class Casting extends Model
 {
     protected $connection = 'mongodb';

--- a/tests/Models/Casting.php
+++ b/tests/Models/Casting.php
@@ -36,6 +36,7 @@ class Casting extends Model
         'encryptedArray',
         'encryptedObject',
         'encryptedCollection',
+        'arrayValue',
     ];
 
     protected $casts = [
@@ -60,5 +61,6 @@ class Casting extends Model
         'encryptedArray' => 'encrypted:array',
         'encryptedObject' => 'encrypted:object',
         'encryptedCollection' => 'encrypted:collection',
+        'arrayValue' => 'array',
     ];
 }

--- a/tests/Models/Casting.php
+++ b/tests/Models/Casting.php
@@ -10,6 +10,7 @@ use MongoDB\Laravel\Eloquent\Model;
 /**
  * @property mixed $id
  * @property array $arrayValue
+ * @property object $objectValue
  */
 class Casting extends Model
 {


### PR DESCRIPTION
Fix #3306 [PHPORM-305](https://jira.mongodb.org/browse/PHPORM-305)

The `array` cast stores values as JSON-encoded strings in MongoDB via `isJsonCastable`, which is inconsistent with the native BSON format.

This PR emits a deprecation notice when an `array` cast is used to write a value, giving users a migration path before the behavior changes in the next major version.

**Recommended migration:** remove the `array` cast. Without a cast, MongoDB stores and reads arrays as native BSON arrays.

**Alternative (keep JSON string storage):** switch to the `json` cast explicitly.

The `fromJson` override also ensures that values already stored as native BSON arrays are read back correctly through an `array` cast, for forward compatibility.