### PR TITLE
Fix: Sync cancellation timestamps

### DIFF
--- a/src/Bus/MongoBatchRepository.php
+++ b/src/Bus/MongoBatchRepository.php
@@ -170,12 +170,14 @@ class MongoBatchRepository extends DatabaseBatchRepository implements PrunableBa
     public function cancel(string $batchId): void
     {
         $batchId = new ObjectId($batchId);
+
+        $now = $this->getUTCDateTime();
         $this->collection->updateOne(
             ['_id' => $batchId],
             [
                 '$set' => [
-                    'cancelled_at' => $this->getUTCDateTime(),
-                    'finished_at' => $this->getUTCDateTime(),
+                    'cancelled_at' => $now,
+                    'finished_at' => $now,
                 ],
             ],
         );

--- a/tests/Bus/MongoBatchRepositoryTest.php
+++ b/tests/Bus/MongoBatchRepositoryTest.php
@@ -13,6 +13,7 @@ use Illuminate\Queue\CallQueuedClosure;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Tests\Bus\BusBatchTest;
 use Mockery as m;
+use MongoDB\BSON\ObjectId;
 use MongoDB\Laravel\Bus\MongoBatchRepository;
 use MongoDB\Laravel\Connection;
 use MongoDB\Laravel\Tests\Bus\Fixtures\ChainHeadJob;
@@ -341,6 +342,34 @@ final class MongoBatchRepositoryTest extends TestCase
         // Should not throw even when there is no active MongoDB session or transaction
         $repository->rollBack();
         $this->assertNull($connection->getSession());
+    }
+
+    /** @see MongoBatchRepository::cancel() */
+    public function testCancelSetsSameTimestampForCancelledAtAndFinishedAt(): void
+    {
+        $queue = m::mock(Factory::class);
+        $batch = $this->createTestBatch($queue);
+
+        $batch->cancel();
+
+        $connection = DB::connection('mongodb');
+        $raw = $connection->getCollection('job_batches')->findOne(
+            ['_id' => new ObjectId((string) $batch->id)],
+            ['typeMap' => ['root' => 'array', 'document' => 'array', 'array' => 'array']],
+        );
+
+        $this->assertNotNull($raw['cancelled_at']);
+        $this->assertNotNull($raw['finished_at']);
+
+        // Convert BSON UTCDateTime to milliseconds string for reliable comparison
+        $cancelledAtMs = (string) $raw['cancelled_at'];
+        $finishedAtMs = (string) $raw['finished_at'];
+
+        $this->assertEquals(
+            $cancelledAtMs,
+            $finishedAtMs,
+            'The cancelled_at and finished_at timestamps should be identical.',
+        );
     }
 
     /** @see BusBatchTest::createTestBatch() */


### PR DESCRIPTION
### Summary
Refactored the cancel method to ensure that cancelled_at and finished_at share an identical timestamp. Previously, these fields were populated by separate method calls, potentially causing millisecond-level discrepancies.

### Changes
MongoBatchRepository.php
Captured a single UTC datetime instance into a $now variable.

Updated the $set operation to use $now for both fields, ensuring atomic consistency within the database update.

MongoBatchRepositoryTest.php
Added testCancelSetsSameTimestampForCheckedAtAndFinishedAt to verify the fix.

The test ensures that both fields are not only present but are also strictly identical at the BSON timestamp level.

### Technical Note
By unifying the timestamp, we eliminate non-deterministic behavior in the repository layer. This is particularly important for audit logs and state-machine transitions where "cancelled" and "finished" are considered to have occurred as part of the same logical event.

### Checklist

- [x] Add tests and ensure they pass

### Test Results
<img width="606" height="191" alt="スクリーンショット 2026-04-14 22 45 30" src="https://github.com/user-attachments/assets/45399de7-cccc-48fd-98bc-3297c44477a0" />

