### PR TITLE
PHPORM-477 Opt into Node.js 24 for release workflow jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
     environment: release
     name: "Prepare release"
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     permissions:
       id-token: write
       contents: write
@@ -114,6 +116,8 @@ jobs:
     environment: release
     name: "Publish SSDLC Assets"
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     permissions:
       security-events: read
       id-token: write


### PR DESCRIPTION
Node.js 20 actions are deprecated and will be forced to Node.js 24 by default starting June 2, 2026.

The `prepare-release` and `publish-ssdlc-assets` jobs use composite actions from `mongodb-labs/drivers-github-tools` which internally call Node.js 20 actions (`actions/checkout`, `aws-actions/*`, etc.). Since those are managed upstream and have not been updated yet, this change opts into Node.js 24 proactively by setting `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` on each affected job.

Jira: https://jira.mongodb.org/browse/PHPORM-477
Reference: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/