### PR TITLE
PHPORM-491 Support \SortDirection enum in Query\Builder::orderBy()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,8 @@
         "doctrine/coding-standard": "^12.0",
         "spatie/laravel-query-builder": "^5.6|^6",
         "phpstan/phpstan": "^1.10|^2.1",
-        "rector/rector": "^1.2|^2.3"
+        "rector/rector": "^1.2|^2.3",
+        "symfony/polyfill-php86": "^1.37"
     },
     "conflict": {
         "illuminate/bus": "< 10.37.2"

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -29,6 +29,7 @@ use MongoDB\Driver\ReadPreference;
 use MongoDB\Laravel\Connection;
 use Override;
 use RuntimeException;
+use SortDirection;
 use TypeError;
 
 use function array_fill_keys;
@@ -656,14 +657,19 @@ class Builder extends BaseBuilder
     }
 
     /**
-     * @param int|string|array $direction
+     * @param SortDirection|int|string|array $direction
      *
      * @inheritdoc
      */
     #[Override]
     public function orderBy($column, $direction = 'asc')
     {
-        if (is_string($direction)) {
+        // Laravel 13.8+ passes the global \SortDirection enum (PHP 8.6+ /
+        // symfony/polyfill-php86) as the default direction. See
+        // laravel/framework#59865.
+        if ($direction instanceof SortDirection) {
+            $direction = $direction === SortDirection::Ascending ? 1 : -1;
+        } elseif (is_string($direction)) {
             $direction = match ($direction) {
                 'asc', 'ASC' => 1,
                 'desc', 'DESC' => -1,

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -664,16 +664,11 @@ class Builder extends BaseBuilder
     #[Override]
     public function orderBy($column, $direction = 'asc')
     {
-        // Laravel 13.8+ passes the global \SortDirection enum (PHP 8.6+ /
-        // symfony/polyfill-php86) as the default direction. See
-        // laravel/framework#59865.
-        if ($direction instanceof SortDirection) {
-            $direction = $direction === SortDirection::Ascending ? 1 : -1;
-        } elseif (is_string($direction)) {
+        if (is_string($direction) || $direction instanceof SortDirection) {
             $direction = match ($direction) {
-                'asc', 'ASC' => 1,
-                'desc', 'DESC' => -1,
-                default => throw new InvalidArgumentException('Order direction must be "asc" or "desc".'),
+                'asc', 'ASC', SortDirection::Ascending => 1,
+                'desc', 'DESC', SortDirection::Descending => -1,
+                default => throw new InvalidArgumentException('Order direction must be "asc", "desc" or a case from the SortDirection enum.'),
             };
         }
 

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -24,7 +24,6 @@ use PHPUnit\Framework\TestCase;
 use SortDirection;
 use stdClass;
 
-use function class_exists;
 use function collect;
 use function method_exists;
 use function now;
@@ -568,22 +567,20 @@ class BuilderTest extends TestCase
             fn (Builder $builder) => $builder->orderByDesc('email'),
         ];
 
-        if (class_exists(SortDirection::class)) {
-            yield 'orderBy SortDirection::Ascending' => [
-                ['find' => [[], ['sort' => ['email' => 1]]]],
-                fn (Builder $builder) => $builder->orderBy('email', SortDirection::Ascending),
-            ];
+        yield 'orderBy SortDirection::Ascending' => [
+            ['find' => [[], ['sort' => ['email' => 1]]]],
+            fn (Builder $builder) => $builder->orderBy('email', SortDirection::Ascending),
+        ];
 
-            yield 'orderBy SortDirection::Descending' => [
-                ['find' => [[], ['sort' => ['email' => -1]]]],
-                fn (Builder $builder) => $builder->orderBy('email', SortDirection::Descending),
-            ];
+        yield 'orderBy SortDirection::Descending' => [
+            ['find' => [[], ['sort' => ['email' => -1]]]],
+            fn (Builder $builder) => $builder->orderBy('email', SortDirection::Descending),
+        ];
 
-            yield 'orderBy SortDirection on natural' => [
-                ['find' => [[], ['sort' => ['$natural' => -1]]]],
-                fn (Builder $builder) => $builder->orderBy('natural', SortDirection::Descending),
-            ];
-        }
+        yield 'orderBy SortDirection on natural' => [
+            ['find' => [[], ['sort' => ['$natural' => -1]]]],
+            fn (Builder $builder) => $builder->orderBy('natural', SortDirection::Descending),
+        ];
 
         /** @see DatabaseQueryBuilderTest::testReorder() */
         yield 'reorder reset' => [
@@ -1506,7 +1503,7 @@ class BuilderTest extends TestCase
     {
         yield 'orderBy invalid direction' => [
             InvalidArgumentException::class,
-            'Order direction must be "asc" or "desc"',
+            'Order direction must be "asc", "desc" or a case from the SortDirection enum.',
             fn (Builder $builder) => $builder->orderBy('_id', 'dasc'),
         ];
 

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -21,8 +21,10 @@ use MongoDB\Laravel\Query\Grammar;
 use MongoDB\Laravel\Query\Processor;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use SortDirection;
 use stdClass;
 
+use function class_exists;
 use function collect;
 use function method_exists;
 use function now;
@@ -565,6 +567,23 @@ class BuilderTest extends TestCase
             ['find' => [[], ['sort' => ['email' => -1]]]],
             fn (Builder $builder) => $builder->orderByDesc('email'),
         ];
+
+        if (class_exists(SortDirection::class)) {
+            yield 'orderBy SortDirection::Ascending' => [
+                ['find' => [[], ['sort' => ['email' => 1]]]],
+                fn (Builder $builder) => $builder->orderBy('email', SortDirection::Ascending),
+            ];
+
+            yield 'orderBy SortDirection::Descending' => [
+                ['find' => [[], ['sort' => ['email' => -1]]]],
+                fn (Builder $builder) => $builder->orderBy('email', SortDirection::Descending),
+            ];
+
+            yield 'orderBy SortDirection on natural' => [
+                ['find' => [[], ['sort' => ['$natural' => -1]]]],
+                fn (Builder $builder) => $builder->orderBy('natural', SortDirection::Descending),
+            ];
+        }
 
         /** @see DatabaseQueryBuilderTest::testReorder() */
         yield 'reorder reset' => [


### PR DESCRIPTION
Laravel 13.8 introduced the global `\SortDirection` enum (PHP 8.6+, backported via `symfony/polyfill-php86`) and uses it as the default direction in `Illuminate\Database\Query\Builder::orderBy()` and internal helpers (`latest()`, `oldest()`, `orderByDesc()`, `forPageAfterId()`, etc.). See laravel/framework#59865.

The MongoDB override only normalized `'asc'`/`'desc'` strings, so a `SortDirection` instance fell through and was stored verbatim in `$this->orders`, leading to:

  Non-backed enum SortDirection cannot be serialized for field path "_id"

Translate `\SortDirection::Ascending` to `1` and `\SortDirection::Descending` to `-1` before storing the order. The `instanceof` check is safe on Laravel < 13.8 where the class is absent (PHP returns `false` without autoloading or erroring), so existing string handling is preserved.

Tests are added in `tests/Query/BuilderTest.php` and only emitted by the data provider when `\SortDirection` exists in the runtime.

Refs: #3506