### PR TITLE
fix: Sync correct timestamps offset

### DIFF
--- a/src/Queue/MongoQueue.php
+++ b/src/Queue/MongoQueue.php
@@ -78,16 +78,18 @@ class MongoQueue extends DatabaseQueue
      */
     protected function getNextAvailableJobAndReserve($queue)
     {
+        $now = Carbon::now()->getTimestamp();
+
         $job = $this->database->getCollection($this->table)->findOneAndUpdate(
             [
                 'queue' => $this->getQueue($queue),
                 'reserved' => ['$ne' => 1],
-                'available_at' => ['$lte' => Carbon::now()->getTimestamp()],
+                'available_at' => ['$lte' => $now],
             ],
             [
                 '$set' => [
                     'reserved' => 1,
-                    'reserved_at' => Carbon::now()->getTimestamp(),
+                    'reserved_at' => $now,
                 ],
                 '$inc' => ['attempts' => 1],
             ],

--- a/tests/QueueTest.php
+++ b/tests/QueueTest.php
@@ -184,6 +184,24 @@ class QueueTest extends TestCase
         $mock->deleteAndRelease($queue, $job, $delay);
     }
 
+    public function testQueueReservedAtTimestamp(): void
+    {
+        $queue = 'test';
+        Queue::push($queue, ['action' => 'QueueReservedAtTimestamp'], 'test');
+
+        $job = Queue::pop($queue);
+        $this->assertInstanceOf(MongoJob::class, $job);
+
+        $reserved = Queue::getDatabase()
+            ->table(Config::get('queue.connections.database.table'))
+            ->where('id', $job->getJobId())
+            ->first();
+
+        $this->assertSame(Carbon::now()->getTimestamp(), $reserved->reserved_at);
+
+        $job->delete();
+    }
+
     public function testFailedJobLogging()
     {
         Carbon::setTestNow('2019-01-01 00:00:00');


### PR DESCRIPTION
### Summary                                                          
  Refactored `getNextAvailableJobAndReserve` to ensure that the `available_at` filter condition and the `reserved_at` update value share an identical timestamp. Previously, `Carbon::now()->getTimestamp()` was called twice separately, potentially causing slight discrepancies between the two values. 
  
### Changes
  `MongoQueue.php`
  - Captured a single timestamp into a `$now` variable.
  - Updated both the filter query and the $set operation to use $now, ensuring consistent timing within the atomic `findOneAndUpdate` operation. 
  
  
### Before

``` php
            [
                'queue' => $this->getQueue($queue),
                'reserved' => ['$ne' => 1],
                'available_at' => ['$lte' => Carbon::now()->getTimestamp()],
            ],
            [
                '$set' => [
                    'reserved' => 1,
                    'reserved_at' => Carbon::now()->getTimestamp(),
                ],
                '$inc' => ['attempts' => 1],
            ],
            
```

### After

```php
$now = Carbon::now()->getTimestamp();

            [
                'queue' => $this->getQueue($queue),
                'reserved' => ['$ne' => 1],
                'available_at' => ['$lte' => $now],
            ],
            [
                '$set' => [
                    'reserved' => 1,
                    'reserved_at' => $now,
                ],
               '$inc' => ['attempts' => 1],
            ],
```
  
### Checklist
- [x] Add tests and ensure they pass
<img width="730" height="361" alt="スクリーンショット 2026-05-09 12 47 48" src="https://github.com/user-attachments/assets/e1bf09c7-6796-4818-b2da-90224b58a8a8" />



### Note
Closed to #3496
