### PR TITLE
Fix: `increment` & `decrement` on embedded models to delegate to `Model::incrementOrDecrement()`

### DIFF
--- a/src/Eloquent/Builder.php
+++ b/src/Eloquent/Builder.php
@@ -22,6 +22,7 @@ use Override;
 
 use function array_key_exists;
 use function array_map;
+use function array_merge;
 use function array_replace;
 use function collect;
 use function is_array;
@@ -37,6 +38,7 @@ use function value;
 class Builder extends EloquentBuilder
 {
     use QueriesRelationships;
+
     private const DUPLICATE_KEY_ERROR = 11000;
 
     /**

--- a/src/Eloquent/Builder.php
+++ b/src/Eloquent/Builder.php
@@ -36,8 +36,8 @@ use function value;
  */
 class Builder extends EloquentBuilder
 {
-    private const DUPLICATE_KEY_ERROR = 11000;
     use QueriesRelationships;
+    private const DUPLICATE_KEY_ERROR = 11000;
 
     /**
      * The methods that should be returned from query builder.
@@ -198,19 +198,12 @@ class Builder extends EloquentBuilder
     public function increment($column, $amount = 1, array $extra = [])
     {
         // Intercept operations on embedded models and delegate logic
-        // to the parent relation instance.
+        // to the parent relation instance. The value computation, event
+        // firing, and syncOriginalAttribute are handled by
+        // Model::incrementOrDecrement(), so we only need to persist.
         $relation = $this->model->getParentRelation();
         if ($relation) {
-            $value = $this->model->{$column};
-
-            // When doing increment and decrements, Eloquent will automatically
-            // sync the original attributes. We need to change the attribute
-            // temporary in order to trigger an update query.
-            $this->model->{$column} = null;
-
-            $this->model->syncOriginalAttribute($column);
-
-            return $this->model->update([$column => $value]);
+            return $this->update(array_merge([$column => $this->model->{$column}], $extra));
         }
 
         return parent::increment($column, $amount, $extra);
@@ -220,19 +213,12 @@ class Builder extends EloquentBuilder
     public function decrement($column, $amount = 1, array $extra = [])
     {
         // Intercept operations on embedded models and delegate logic
-        // to the parent relation instance.
+        // to the parent relation instance. The value computation, event
+        // firing, and syncOriginalAttribute are handled by
+        // Model::incrementOrDecrement(), so we only need to persist.
         $relation = $this->model->getParentRelation();
         if ($relation) {
-            $value = $this->model->{$column};
-
-            // When doing increment and decrements, Eloquent will automatically
-            // sync the original attributes. We need to change the attribute
-            // temporary in order to trigger an update query.
-            $this->model->{$column} = null;
-
-            $this->model->syncOriginalAttribute($column);
-
-            return $this->model->update([$column => $value]);
+            return $this->update(array_merge([$column => $this->model->{$column}], $extra));
         }
 
         return parent::decrement($column, $amount, $extra);

--- a/src/Eloquent/Builder.php
+++ b/src/Eloquent/Builder.php
@@ -200,9 +200,7 @@ class Builder extends EloquentBuilder
     public function increment($column, $amount = 1, array $extra = [])
     {
         // Intercept operations on embedded models and delegate logic
-        // to the parent relation instance. The value computation, event
-        // firing, and syncOriginalAttribute are handled by
-        // Model::incrementOrDecrement(), so we only need to persist.
+        // to the parent relation instance.
         $relation = $this->model->getParentRelation();
         if ($relation) {
             return $this->update(array_merge([$column => $this->model->{$column}], $extra));
@@ -215,9 +213,7 @@ class Builder extends EloquentBuilder
     public function decrement($column, $amount = 1, array $extra = [])
     {
         // Intercept operations on embedded models and delegate logic
-        // to the parent relation instance. The value computation, event
-        // firing, and syncOriginalAttribute are handled by
-        // Model::incrementOrDecrement(), so we only need to persist.
+        // to the parent relation instance.
         $relation = $this->model->getParentRelation();
         if ($relation) {
             return $this->update(array_merge([$column => $this->model->{$column}], $extra));

--- a/tests/EmbeddedRelationsTest.php
+++ b/tests/EmbeddedRelationsTest.php
@@ -904,6 +904,86 @@ class EmbeddedRelationsTest extends TestCase
         $this->assertEquals(5, $user->addresses()->first()->visited);
     }
 
+    public function testIncrementEmbeddedWithCustomAmount(): void
+    {
+        $user    = User::create(['name' => 'John Doe']);
+        $address = $user->addresses()->create(['city' => 'New York', 'visited' => 5]);
+
+        $address->increment('visited', 3);
+        $this->assertEquals(8, $address->visited);
+        $user = User::where('name', 'John Doe')->first();
+        $this->assertEquals(8, $user->addresses()->first()->visited);
+
+        $address->decrement('visited', 2);
+        $this->assertEquals(6, $address->visited);
+        $user = User::where('name', 'John Doe')->first();
+        $this->assertEquals(6, $user->addresses()->first()->visited);
+    }
+
+    public function testIncrementEmbeddedWithExtra(): void
+    {
+        $user    = User::create(['name' => 'John Doe']);
+        $address = $user->addresses()->create(['city' => 'New York', 'visited' => 5]);
+
+        $address->increment('visited', 1, ['city' => 'Paris']);
+        $this->assertEquals(6, $address->visited);
+        $this->assertEquals('Paris', $address->city);
+        $user = User::where('name', 'John Doe')->first();
+        $this->assertEquals(6, $user->addresses()->first()->visited);
+        $this->assertEquals('Paris', $user->addresses()->first()->city);
+
+        $address->decrement('visited', 1, ['city' => 'London']);
+        $this->assertEquals(5, $address->visited);
+        $this->assertEquals('London', $address->city);
+        $user = User::where('name', 'John Doe')->first();
+        $this->assertEquals(5, $user->addresses()->first()->visited);
+        $this->assertEquals('London', $user->addresses()->first()->city);
+    }
+
+    public function testIncrementEmbeddedFiresEvents(): void
+    {
+        $user    = User::create(['name' => 'John Doe']);
+        $address = $user->addresses()->create(['city' => 'New York', 'visited' => 5]);
+
+        $address->setEventDispatcher($events = Mockery::mock(Dispatcher::class));
+        $events->shouldReceive('dispatch')->with('eloquent.retrieved: ' . $address::class, Mockery::any());
+        $events->shouldReceive('dispatch')
+            ->once()
+            ->with('eloquent.updated: ' . $address::class, $address);
+
+        $events->shouldReceive('until')
+            ->once()
+            ->with('eloquent.updating: ' . $address::class, $address)
+            ->andReturn(true);
+
+        $address->increment('visited');
+
+        $this->assertEquals(6, $address->visited);
+        $address->unsetEventDispatcher();
+    }
+
+    public function testDecrementEmbeddedFiresEvents(): void
+    {
+        $user    = User::create(['name' => 'John Doe']);
+        $address = $user->addresses()->create(['city' => 'New York', 'visited' => 5]);
+
+        $address->setEventDispatcher($events = Mockery::mock(Dispatcher::class));
+        $events->shouldReceive('dispatch')->with('eloquent.retrieved: ' . $address::class, Mockery::any());
+        $events->shouldReceive('dispatch')
+            ->once()
+            ->with('eloquent.updated: ' . $address::class, $address);
+
+        $events->shouldReceive('until')
+            ->once()
+            ->with('eloquent.updating: ' . $address::class, $address)
+            ->andReturn(true);
+
+        $address->decrement('visited');
+
+        $this->assertEquals(4, $address->visited);
+        $address->unsetEventDispatcher();
+    }
+
     public function testPaginateEmbedsMany()
     {
         $user = User::create(['name' => 'John Doe']);


### PR DESCRIPTION
This PR is related to Issue(#3498)

### Why

The previous `Builder::increment()` and `Builder::decrement()` for embedded models manually set the column to `null`, called `syncOriginalAttribute()`, and ignored the `$extra` parameter. This bypassed `Model::incrementOrDecrement()`, which meant:

  - The `updating` / `updated` events were not fired
  - Extra attributes passed to `increment()`/`decrement()` were silently dropped
  - Custom amounts worked only by coincidence (computed by the caller, not the builder)

 So, this PR simplifies the embedded-model path to just persist the already-computed value via `$this->update()`, letting `Model::incrementOrDecrement()` handle value computation, event firing, and `syncOriginalAttribute()`.
 
 ### Changes

1.  **`Builder::increment()`/`decrement()`** — Remove manual attribute manipulation; forward `$extra` to `update()`
2. **Tests** — Add coverage for custom amounts, extra attributes, and `updating`/`updated` event assertions

### Notes
**`Builder`** — Move `use QueriesRelationships` before the constant declaration to follow PHP trait ordering conventions.

### Checklist(Test Results)

- [x] Add tests and ensure they pass
<img width="752" height="816" alt="スクリーンショット 2026-05-10 19 01 31" src="https://github.com/user-attachments/assets/420ebc33-b8c8-4c9f-b5d5-210885da7171" />



Any feedback or suggestions are welcome — feel free to leave a comment. 