### PR TITLE
fix: count() after groupBy() returns integer instead of Collection

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -560,6 +560,27 @@ class Builder extends BaseBuilder
         return md5(serialize(array_values($key)));
     }
 
+    /** @inheritdoc */
+    #[Override]
+    public function count($columns = '*')
+    {
+        if ($this->groups) {
+            $without = ['columns', 'orders', 'limit', 'offset'];
+
+            $mql = $this->cloneWithout($without)
+                ->cloneWithoutBindings(['select', 'order'])
+                ->toMql();
+
+            $mql['aggregate'][0][] = ['$count' => 'aggregate'];
+
+            $result = $this->collection->aggregate($mql['aggregate'][0], $mql['aggregate'][1])->toArray();
+
+            return isset($result[0]) ? (int) ((array) $result[0])['aggregate'] : 0;
+        }
+
+        return parent::count($columns);
+    }
+
     /** @return ($function is null ? AggregationBuilder : mixed) */
     #[Override]
     public function aggregate($function = null, $columns = ['*'])

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -771,6 +771,27 @@ class QueryBuilderTest extends TestCase
         $this->assertEquals([(object) ['role' => 'admin', 'aggregate' => 1.5], (object) ['role' => 'user', 'aggregate' => 4]], $results->toArray());
     }
 
+    public function testCountWithGroupBy(): void
+    {
+        DB::table('users')->insert([
+            ['name' => 'John Doe', 'role' => 'admin'],
+            ['name' => 'Jane Doe', 'role' => 'admin'],
+            ['name' => 'Robert Roe', 'role' => 'user'],
+        ]);
+
+        $count = DB::table('users')->groupBy('role')->count();
+        $this->assertIsInt($count);
+        $this->assertEquals(2, $count);
+
+        $count = DB::table('users')->where('role', 'admin')->groupBy('role')->count();
+        $this->assertIsInt($count);
+        $this->assertEquals(1, $count);
+
+        $count = DB::table('users')->where('role', 'nonexistent')->groupBy('role')->count();
+        $this->assertIsInt($count);
+        $this->assertSame(0, $count);
+    }
+
     public function testAggregateByGroupException(): void
     {
         $this->expectException(InvalidArgumentException::class);


### PR DESCRIPTION
## Summary

- Fixes #3512
- Overrides `count()` in `Query\Builder` to handle `groupBy()` correctly
- When groups are present, runs a `$match` + `$group` + `$count` aggregation pipeline to return the number of distinct groups as an integer
- Mirrors the pattern already used in `runPaginationCountQuery()`

## Problem

`->groupBy('status')->count()` triggered a PHP warning and returned `1`:

```
WARNING Object of class Illuminate\Support\Collection could not be converted to int
```

The root cause: `aggregate()` returns a `Collection` when `$this->groups` is set, but `count()` casts the return value to `(int)`.

## Note on SQL behavior

For reference, Eloquent SQL generates `SELECT count(*) as aggregate FROM ... GROUP BY status`, which returns one row per group. Laravel takes `$results[0]['aggregate']`, i.e. the count of the **first (arbitrary) group** — not the number of groups, and not the total count.

Our implementation returns the **number of distinct groups**, which is consistent with `runPaginationCountQuery()` behavior and more predictable than the SQL equivalent.

## Test plan

- [x] `testCountWithGroupBy` covers the fix (multiple groups, filtered result, no match)
- [x] `testAggregateGroupBy` confirms `aggregateByGroup('count')` still returns per-group Collection unchanged