### PR TITLE
PHPORM-494 Fix `MongoStore::unserialize()` for empty arrays and objects

### DIFF
--- a/src/Cache/MongoStore.php
+++ b/src/Cache/MongoStore.php
@@ -16,7 +16,6 @@ use function is_float;
 use function is_int;
 use function is_string;
 use function serialize;
-use function str_contains;
 use function unserialize;
 
 final class MongoStore implements LockProvider, Store
@@ -312,7 +311,7 @@ final class MongoStore implements LockProvider, Store
 
     private function unserialize($value): mixed
     {
-        if (! is_string($value) || ! str_contains($value, ';')) {
+        if (! is_string($value)) {
             return $value;
         }
 

--- a/tests/Cache/MongoCacheStoreTest.php
+++ b/tests/Cache/MongoCacheStoreTest.php
@@ -2,15 +2,22 @@
 
 namespace MongoDB\Laravel\Tests\Cache;
 
+use Generator;
 use Illuminate\Cache\Repository;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use MongoDB\BSON\UTCDateTime;
 use MongoDB\Laravel\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use stdClass;
 
 use function assert;
 use function config;
+use function get_debug_type;
+use function is_float;
+use function is_int;
+use function serialize;
 
 /** Tests imported from {@see \Illuminate\Tests\Integration\Database\DatabaseCacheStoreTest} */
 class MongoCacheStoreTest extends TestCase
@@ -257,6 +264,26 @@ class MongoCacheStoreTest extends TestCase
         $this->assertNull($store->get('foo'));
     }
 
+    public static function provideSerializedEdgeCases(): Generator
+    {
+        yield 'empty array' => [[]];
+        yield 'empty object' => [new stdClass()];
+        yield 'null' => [null];
+        yield 'false' => [false];
+    }
+
+    #[DataProvider('provideSerializedEdgeCases')]
+    public function testGetReturnsCachedValueForSerializedEdgeCases(mixed $value): void
+    {
+        $store = $this->getStore();
+
+        $this->assertTrue($store->put('foo', $value, 60));
+
+        $result = $store->get('foo');
+        $this->assertSame(get_debug_type($value), get_debug_type($result));
+        $this->assertEquals($value, $result);
+    }
+
     public function testTTLIndex()
     {
         $store = $this->getStore();
@@ -285,13 +312,13 @@ class MongoCacheStoreTest extends TestCase
         return config('cache.prefix') . $key;
     }
 
-    private function insertToCacheTable(string $key, $value, $ttl = 60)
+    private function insertToCacheTable(string $key, mixed $value, int $ttl = 60): void
     {
         DB::connection('mongodb')
             ->getCollection($this->getCacheCollectionName())
             ->insertOne([
                 '_id' => $this->withCachePrefix($key),
-                'value' => $value,
+                'value' => is_int($value) || is_float($value) ? $value : serialize($value),
                 'expires_at' => new UTCDateTime(Carbon::now()->addSeconds($ttl)),
             ]);
     }


### PR DESCRIPTION
Fix `MongoStore::unserialize()` returning the raw serialized string instead of the value when the cache contains an empty array (`[]`) or an empty object.

## Root Cause

`MongoStore::serialize()` stores integers and floats as native numeric values; all other types go through PHP's `serialize()`. Any string value in the collection is therefore always a PHP-serialized payload.

The `str_contains($value, ';')` guard was meant to detect serialized strings, but PHP serializes empty arrays as `a:0:{}` and empty objects as `O:8:"stdClass":0:{}` — neither contains a semicolon, so unserialization was skipped.

The guard is removed. `insertToCacheTable()` in the test helper is also fixed to serialize values the same way `put()` does, which was the original cause of the workaround.

Fixes https://github.com/mongodb/laravel-mongodb/issues/3515
Jira: https://jira.mongodb.org/browse/PHPORM-494