### PR TITLE
PHPORM-495 Fix sort direction enum use

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -664,10 +664,16 @@ class Builder extends BaseBuilder
     #[Override]
     public function orderBy($column, $direction = 'asc')
     {
-        if (is_string($direction) || $direction instanceof SortDirection) {
+        if ($direction instanceof SortDirection) {
             $direction = match ($direction) {
-                'asc', 'ASC', SortDirection::Ascending => 1,
-                'desc', 'DESC', SortDirection::Descending => -1,
+                SortDirection::Ascending => 1,
+                SortDirection::Descending => -1,
+                default => throw new InvalidArgumentException('Unexpected SortDirection enum case.'),
+            };
+        } elseif (is_string($direction)) {
+            $direction = match ($direction) {
+                'asc', 'ASC' => 1,
+                'desc', 'DESC' => -1,
                 default => throw new InvalidArgumentException('Order direction must be "asc", "desc" or a case from the SortDirection enum.'),
             };
         }

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -24,6 +24,7 @@ use PHPUnit\Framework\TestCase;
 use SortDirection;
 use stdClass;
 
+use function class_exists;
 use function collect;
 use function method_exists;
 use function now;
@@ -567,20 +568,22 @@ class BuilderTest extends TestCase
             fn (Builder $builder) => $builder->orderByDesc('email'),
         ];
 
-        yield 'orderBy SortDirection::Ascending' => [
-            ['find' => [[], ['sort' => ['email' => 1]]]],
-            fn (Builder $builder) => $builder->orderBy('email', SortDirection::Ascending),
-        ];
+        if (class_exists(SortDirection::class)) {
+            yield 'orderBy SortDirection::Ascending' => [
+                ['find' => [[], ['sort' => ['email' => 1]]]],
+                fn (Builder $builder) => $builder->orderBy('email', SortDirection::Ascending),
+            ];
 
-        yield 'orderBy SortDirection::Descending' => [
-            ['find' => [[], ['sort' => ['email' => -1]]]],
-            fn (Builder $builder) => $builder->orderBy('email', SortDirection::Descending),
-        ];
+            yield 'orderBy SortDirection::Descending' => [
+                ['find' => [[], ['sort' => ['email' => -1]]]],
+                fn (Builder $builder) => $builder->orderBy('email', SortDirection::Descending),
+            ];
 
-        yield 'orderBy SortDirection on natural' => [
-            ['find' => [[], ['sort' => ['$natural' => -1]]]],
-            fn (Builder $builder) => $builder->orderBy('natural', SortDirection::Descending),
-        ];
+            yield 'orderBy SortDirection on natural' => [
+                ['find' => [[], ['sort' => ['$natural' => -1]]]],
+                fn (Builder $builder) => $builder->orderBy('natural', SortDirection::Descending),
+            ];
+        }
 
         /** @see DatabaseQueryBuilderTest::testReorder() */
         yield 'reorder reset' => [


### PR DESCRIPTION
Fixes #3518
Fixes PHPORM-495

On PHP < 8.6 and Laravel < 13.8, the `SortDirection` enum does not exist. Since the `match` statement actually uses the enum, this causes errors on previous versions. This PR splits the `if` block into two parts to only use the enum if it actually exists. There's also a separate fix for the tests on Laravel versions without the enum.