### PR TITLE
Remove symfony/polyfill-php86 from require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,8 +63,7 @@
         "phpstan/phpstan": "^1.10|^2.1",
         "phpunit/phpunit": "^10.3|^11.5.3|^12.5.12",
         "rector/rector": "^1.2|^2.3",
-        "spatie/laravel-query-builder": "^5.6|^6",
-        "symfony/polyfill-php86": "^1.37"
+        "spatie/laravel-query-builder": "^5.6|^6"
     },
     "conflict": {
         "illuminate/bus": "< 10.37.2"


### PR DESCRIPTION
## Summary

The `symfony/polyfill-php86` package was masking the absence of `SortDirection` in CI runs against Laravel < 13.8.

Because the polyfill was installed as a direct `require-dev` dependency, `SortDirection` existed in **all** CI environments, including `laravel: 12.*` runs. This prevented detection of bugs in code paths that depend on `SortDirection` being absent - which is exactly what happened with #3519 (the `orderBy(..., 'desc')` path would silently evaluate `SortDirection::Ascending` before reaching the `'desc'` arm).

With this change:

- `laravel: 12.*` CI runs: no `SortDirection` (no polyfill, not a transitive dep of Laravel 12) - the `class_exists()` guard in `BuilderTest` correctly skips enum-specific test cases, and the string-based paths are tested without the enum present.
- `laravel: 13.*` CI runs: polyfill arrives as a transitive dependency of Laravel 13.8+ - `SortDirection` is available and enum-specific test cases execute normally.

Relates to #3519.