### PR TITLE
Update RELEASING.md: remove automated steps, add JIRA version release

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -3,15 +3,6 @@
 The following steps outline the release process for both new minor versions and
 patch versions.
 
-The command examples below assume that the canonical "mongodb" repository has
-the remote name "mongodb". You may need to adjust these commands if you've given
-the remote another name (e.g. "upstream"). The "origin" remote name was not used
-as it likely refers to your personal fork.
-
-It helps to keep your own fork in sync with the "mongodb" repository (i.e. any
-branches and tags on the main repository should also exist in your fork). This
-is left as an exercise to the reader.
-
 ## Ensure PHP version compatibility
 
 Ensure that the test suite completes on supported versions of PHP.
@@ -35,7 +26,7 @@ page.
 
 Releases are done automatically through a GitHub Action. Visit the corresponding
 [Release New Version](https://github.com/mongodb/laravel-mongodb/actions/workflows/release.yml)
-workflow page to trigger a new build. Select the correct branch (e.g. `v4.5`)
+workflow page to trigger a new build. Select the correct branch (e.g. `4.5`)
 and trigger a new run using the "Run workflow" button. In the following prompt,
 enter the version number.
 
@@ -43,44 +34,14 @@ The automation will then create and push the necessary commits and tag, and crea
 a draft release. The release is created in a draft state and can be published
 once the release notes have been updated.
 
-
-## Branch management
-
-# Creating a maintenance branch and updating default branch name
-
-When releasing a new major or minor version (e.g. 4.0.0), the default branch
-should be renamed to the next version (e.g. 4.1). Renaming the default branch
-using GitHub's UI ensures that all open pull request are changed to target the
-new version.
-
-Once the default branch has been renamed, create the maintenance branch for the
-version to be released (e.g. 4.0):
-
-```console
-$ git checkout -b X.Y
-$ git push mongodb X.Y
-```
-
-### After releasing a patch version
-
-If this was a patch release, the maintenance branch must be merged up to the
-default branch (e.g. 4.1):
-
-```console
-$ git checkout 4.1
-$ git pull mongodb 4.1
-$ git merge 4.0 --strategy=ours
-$ git push mongodb
-```
-
-The `--strategy=ours` option ensures that all changes from the merged commits
-will be ignored. This is OK because we previously ensured that the `4.1`
-branch was up-to-date with all code changes in this maintenance branch before
-tagging.
-
-
 ## Publish release notes
 
 Use the generated release note in [this form](https://github.com/mongodb/laravel-mongodb/releases/new).
 
 Release announcements should also be posted in the [MongoDB Product & Driver Announcements: Driver Releases](https://mongodb.com/community/forums/tags/c/announcements/driver-releases/110/php) forum and shared on Twitter.
+
+## Mark JIRA version as released
+
+Mark the version as released from the
+[Manage Versions](https://jira.mongodb.org/plugins/servlet/project-config/PHPORM/versions)
+page.


### PR DESCRIPTION
## Summary

- Remove the preamble about git remote naming conventions (no longer relevant since the process is automated).
- Remove the "Branch management" section: creation of the maintenance branch is handled by `release.yml`, and the merge-up after patch releases is handled by `merge-up.yml`.
- Add a step to mark the Jira version as released after publishing the release notes.