### PR TITLE
Fix: Recurse into `stdClass` values in `prepareFieldsForQuery`

### DIFF
--- a/src/Query/Grammar.php
+++ b/src/Query/Grammar.php
@@ -88,6 +88,13 @@ class Grammar extends BaseGrammar
                 $value = $this->prepareFieldsForQuery($value, false);
             } elseif ($value instanceof DateTimeInterface) {
                 $value = new UTCDateTime($value);
+            } elseif ($value instanceof stdClass) {
+                $value = $this->prepareFieldsForQuery(
+                    get_object_vars($value),
+                    false,
+                );
+
+                $value = (object) $value;
             }
         }
 

--- a/tests/Query/GrammarTest.php
+++ b/tests/Query/GrammarTest.php
@@ -203,6 +203,63 @@ class GrammarTest extends TestCase
     }
 
     /**
+     * Test that stdClass values are recursed into and processed
+     */
+    public function testPrepareFieldsForQueryProcessesStdClassValues()
+    {
+        $metadata = new stdClass();
+        $metadata->id = '123';
+        $metadata->name = 'test';
+
+        $input = ['metadata' => $metadata];
+        $result = $this->grammar->prepareFieldsForQuery($input);
+
+        $this->assertInstanceOf(stdClass::class, $result['metadata']);
+        $this->assertTrue(property_exists($result['metadata'], '_id'));
+        $this->assertFalse(property_exists($result['metadata'], 'id'));
+        $this->assertEquals('123', $result['metadata']->_id);
+        $this->assertEquals('test', $result['metadata']->name);
+    }
+
+    /**
+     * Test that DateTimeInterface inside stdClass values are converted to UTCDateTime
+     */
+    public function testPrepareFieldsForQueryConvertsDateTimeInsideStdClass()
+    {
+        $metadata = new stdClass();
+        $metadata->created_at = Carbon::parse('2024-01-01 12:00:00');
+        $metadata->label = 'test';
+
+        $input = ['metadata' => $metadata];
+        $result = $this->grammar->prepareFieldsForQuery($input);
+
+        $this->assertInstanceOf(stdClass::class, $result['metadata']);
+        $this->assertInstanceOf(UTCDateTime::class, $result['metadata']->created_at);
+        $this->assertEquals('test', $result['metadata']->label);
+    }
+
+    /**
+     * Test that stdClass values respect renameEmbeddedIdField configuration
+     */
+    public function testPrepareFieldsForQueryProcessesStdClassWithConfigDisabled()
+    {
+        $this->connection->setRenameEmbeddedIdField(false);
+
+        $metadata = new stdClass();
+        $metadata->id = '123';
+        $metadata->name = 'test';
+
+        $input = ['metadata' => $metadata];
+        $result = $this->grammar->prepareFieldsForQuery($input);
+
+        $this->assertInstanceOf(stdClass::class, $result['metadata']);
+        $this->assertTrue(property_exists($result['metadata'], 'id'));
+        $this->assertFalse(property_exists($result['metadata'], '_id'));
+
+        $this->connection->setRenameEmbeddedIdField(true);
+    }
+
+    /**
      * Test that _id is converted to id for root level results
      */
     public function testPrepareFieldsForResultConvertsUnderscoreIdToId()


### PR DESCRIPTION
<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.
-->

## Summary

### Problem
In `Grammar.php`, `prepareFieldsForQuery()` method did not recurse into `stdClass` values. 
This meant that fields inside `stdClass` objects were not processed, causing `DateTimeInterface` values to remain unconverted and `id` fields to not be renamed to `_id`.

### What I did for fixing
Added handling for `stdClass` values in `prepareFieldsForQuery()`. 
When a `stdClass` value is encountered, it is converted to an array, recursively processed, and converted back to `stdClass`.

### Checklist

- [x] Add tests and ensure they pass

### Test Results
<img width="616" height="214" alt="スクリーンショット 2026-06-11 20 16 13" src="https://github.com/user-attachments/assets/7a1afb48-0449-4875-a138-ee90ab9ee125" />

**Notes**
`testPrepareFieldsForQueryProcessesStdClassWithConfigDisabled` test manually resets `renameEmbeddedIdField` to `true` at the end of the test instead of using `tearDown()`.
This is intentional to avoid modifying existing `tearDown()` logic in a separate PR.
If you prefer to consolidate the reset into `tearDown()`, please let me know !