### PR TITLE
PHPORM-492 Fix PHPDoc return and param types for raw() methods

### DIFF
--- a/src/Eloquent/Builder.php
+++ b/src/Eloquent/Builder.php
@@ -225,7 +225,7 @@ class Builder extends EloquentBuilder
     /**
      * @param (Closure(\MongoDB\Collection):T)|Expression|null $value
      *
-     * @return ($value is Closure ? T|TModel|Collection<int, TModel> : ($value is null ? \MongoDB\Collection : \Illuminate\Database\Query\Expression))
+     * @return ($value is Closure ? (T is CursorInterface ? Collection<int, TModel> : T|TModel|Collection<int, TModel>) : ($value is null ? \MongoDB\Collection : \Illuminate\Contracts\Database\Query\Expression))
      *
      * @template T
      */

--- a/src/Eloquent/Builder.php
+++ b/src/Eloquent/Builder.php
@@ -223,9 +223,9 @@ class Builder extends EloquentBuilder
     }
 
     /**
-     * @param (Closure():T)|Expression|null $value
+     * @param (Closure(\MongoDB\Collection):T)|Expression|null $value
      *
-     * @return ($value is Closure ? T : ($value is null ? Collection : Expression))
+     * @return ($value is Closure ? T|TModel|Collection<int, TModel> : ($value is null ? \MongoDB\Collection : Expression))
      *
      * @template T
      */

--- a/src/Eloquent/Builder.php
+++ b/src/Eloquent/Builder.php
@@ -225,7 +225,7 @@ class Builder extends EloquentBuilder
     /**
      * @param (Closure(\MongoDB\Collection):T)|Expression|null $value
      *
-     * @return ($value is Closure ? T|TModel|Collection<int, TModel> : ($value is null ? \MongoDB\Collection : Expression))
+     * @return ($value is Closure ? T|TModel|Collection<int, TModel> : ($value is null ? \MongoDB\Collection : \Illuminate\Database\Query\Expression))
      *
      * @template T
      */

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -1045,9 +1045,9 @@ class Builder extends BaseBuilder
     }
 
     /**
-     * @param (Closure():T)|Expression|null $value
+     * @param (Closure(\MongoDB\Collection):T)|Expression|null $value
      *
-     * @return ($value is Closure ? T : ($value is null ? Collection : Expression))
+     * @return ($value is Closure ? T : ($value is null ? \MongoDB\Collection : Expression))
      *
      * @template T
      */

--- a/tests/PHPStan/BuilderRawTypes.php
+++ b/tests/PHPStan/BuilderRawTypes.php
@@ -49,7 +49,7 @@ final class BuilderRawTypes
     public static function eloquentBuilderRawClosureFind(EloquentBuilder $builder): void
     {
         assertType(
-            'Illuminate\Database\Eloquent\Collection<int, MongoDB\Laravel\Tests\Models\User>|MongoDB\Driver\CursorInterface|MongoDB\Laravel\Tests\Models\User',
+            'Illuminate\Database\Eloquent\Collection<int, MongoDB\Laravel\Tests\Models\User>',
             $builder->raw(fn (MongoDBCollection $c) => $c->find([])),
         );
     }
@@ -57,7 +57,7 @@ final class BuilderRawTypes
     /** @param EloquentBuilder<User> $builder */
     public static function eloquentBuilderRawExpression(EloquentBuilder $builder): void
     {
-        assertType('Illuminate\Database\Query\Expression', $builder->raw(new Expression('foo')));
+        assertType('Illuminate\Contracts\Database\Query\Expression', $builder->raw(new Expression('foo')));
     }
 
     /** @param EloquentBuilder<User> $builder */

--- a/tests/PHPStan/BuilderRawTypes.php
+++ b/tests/PHPStan/BuilderRawTypes.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Laravel\Tests\PHPStan;
 
+use Illuminate\Database\Query\Expression;
 use MongoDB\Collection as MongoDBCollection;
 use MongoDB\Laravel\Eloquent\Builder as EloquentBuilder;
 use MongoDB\Laravel\Query\Builder as QueryBuilder;
@@ -33,6 +34,11 @@ final class BuilderRawTypes
         assertType('array|object|null', $queryBuilder->raw(fn (MongoDBCollection $c) => $c->findOne([])));
     }
 
+    public static function queryBuilderRawExpression(QueryBuilder $queryBuilder): void
+    {
+        assertType('Illuminate\Database\Query\Expression', $queryBuilder->raw(new Expression('foo')));
+    }
+
     /** @param EloquentBuilder<User> $builder */
     public static function eloquentBuilderRawNull(EloquentBuilder $builder): void
     {
@@ -46,6 +52,12 @@ final class BuilderRawTypes
             'Illuminate\Database\Eloquent\Collection<int, MongoDB\Laravel\Tests\Models\User>|MongoDB\Driver\CursorInterface|MongoDB\Laravel\Tests\Models\User',
             $builder->raw(fn (MongoDBCollection $c) => $c->find([])),
         );
+    }
+
+    /** @param EloquentBuilder<User> $builder */
+    public static function eloquentBuilderRawExpression(EloquentBuilder $builder): void
+    {
+        assertType('Illuminate\Database\Query\Expression', $builder->raw(new Expression('foo')));
     }
 
     /** @param EloquentBuilder<User> $builder */

--- a/tests/PHPStan/BuilderRawTypes.php
+++ b/tests/PHPStan/BuilderRawTypes.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Laravel\Tests\PHPStan;
+
+use MongoDB\Collection as MongoDBCollection;
+use MongoDB\Driver\CursorInterface;
+use MongoDB\Laravel\Eloquent\Builder as EloquentBuilder;
+use MongoDB\Laravel\Query\Builder as QueryBuilder;
+use MongoDB\Laravel\Tests\Models\User;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * PHPStan type-level tests for Builder::raw() return and param types.
+ * These functions are never executed at runtime — they exist to let PHPStan
+ * validate that the @param and @return types on raw() match the declared signatures.
+ */
+final class BuilderRawTypes
+{
+    public static function queryBuilderRawNull(QueryBuilder $queryBuilder): void
+    {
+        assertType('MongoDB\Collection', $queryBuilder->raw());
+    }
+
+    public static function queryBuilderRawClosureReceivesMongoCollection(QueryBuilder $queryBuilder): void
+    {
+        $queryBuilder->raw(function (MongoDBCollection $collection): CursorInterface {
+            return $collection->find([]);
+        });
+    }
+
+    public static function queryBuilderRawClosureFind(QueryBuilder $queryBuilder): void
+    {
+        assertType('MongoDB\Driver\CursorInterface', $queryBuilder->raw(fn (MongoDBCollection $c) => $c->find([])));
+    }
+
+    public static function queryBuilderRawClosureFindOne(QueryBuilder $queryBuilder): void
+    {
+        assertType('array|object|null', $queryBuilder->raw(fn (MongoDBCollection $c) => $c->findOne([])));
+    }
+
+    /** @param EloquentBuilder<User> $builder */
+    public static function eloquentBuilderRawNull(EloquentBuilder $builder): void
+    {
+        assertType('MongoDB\Collection', $builder->raw());
+    }
+
+    /** @param EloquentBuilder<User> $builder */
+    public static function eloquentBuilderRawClosureReceivesMongoCollection(EloquentBuilder $builder): void
+    {
+        $builder->raw(function (MongoDBCollection $collection): CursorInterface {
+            return $collection->find([]);
+        });
+    }
+
+    /** @param EloquentBuilder<User> $builder */
+    public static function eloquentBuilderRawClosureFind(EloquentBuilder $builder): void
+    {
+        assertType(
+            'Illuminate\Database\Eloquent\Collection<int, MongoDB\Laravel\Tests\Models\User>|MongoDB\Driver\CursorInterface|MongoDB\Laravel\Tests\Models\User',
+            $builder->raw(fn (MongoDBCollection $c) => $c->find([])),
+        );
+    }
+
+    /** @param EloquentBuilder<User> $builder */
+    public static function eloquentBuilderRawClosureFindOne(EloquentBuilder $builder): void
+    {
+        // PHPStan simplifies User|Collection<int, User>|array|object|null to array|object|null
+        // because object is a supertype of User and Collection.
+        assertType(
+            'array|object|null',
+            $builder->raw(fn (MongoDBCollection $c) => $c->findOne([])),
+        );
+    }
+}

--- a/tests/PHPStan/BuilderRawTypes.php
+++ b/tests/PHPStan/BuilderRawTypes.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace MongoDB\Laravel\Tests\PHPStan;
 
 use MongoDB\Collection as MongoDBCollection;
-use MongoDB\Driver\CursorInterface;
 use MongoDB\Laravel\Eloquent\Builder as EloquentBuilder;
 use MongoDB\Laravel\Query\Builder as QueryBuilder;
 use MongoDB\Laravel\Tests\Models\User;
@@ -24,13 +23,6 @@ final class BuilderRawTypes
         assertType('MongoDB\Collection', $queryBuilder->raw());
     }
 
-    public static function queryBuilderRawClosureReceivesMongoCollection(QueryBuilder $queryBuilder): void
-    {
-        $queryBuilder->raw(function (MongoDBCollection $collection): CursorInterface {
-            return $collection->find([]);
-        });
-    }
-
     public static function queryBuilderRawClosureFind(QueryBuilder $queryBuilder): void
     {
         assertType('MongoDB\Driver\CursorInterface', $queryBuilder->raw(fn (MongoDBCollection $c) => $c->find([])));
@@ -45,14 +37,6 @@ final class BuilderRawTypes
     public static function eloquentBuilderRawNull(EloquentBuilder $builder): void
     {
         assertType('MongoDB\Collection', $builder->raw());
-    }
-
-    /** @param EloquentBuilder<User> $builder */
-    public static function eloquentBuilderRawClosureReceivesMongoCollection(EloquentBuilder $builder): void
-    {
-        $builder->raw(function (MongoDBCollection $collection): CursorInterface {
-            return $collection->find([]);
-        });
     }
 
     /** @param EloquentBuilder<User> $builder */


### PR DESCRIPTION
Fixes https://jira.mongodb.org/browse/PHPORM-492

## Summary

The `@param` and `@return` PHPDoc types on `raw()` had several issues.

**`@param` — Closure argument type:**
Both `Query\Builder::raw()` and `Eloquent\Builder::raw()` declared the Closure as `Closure():T` (no arguments), but the Closure actually receives a `\MongoDB\Collection` instance at runtime.

**`@return` — null case:**
Both builders declared returning `Collection` (either `Illuminate\Support\Collection` or `Illuminate\Database\Eloquent\Collection`) when `$value` is `null`. The method actually returns the raw `\MongoDB\Collection` object.

**`@return` — Expression case (`Eloquent\Builder` only):**
`Expression` in `Eloquent\Builder` resolves to `MongoDB\Builder\Expression` (the local import), but the method delegates to `Query\Builder::raw()` which returns an `Illuminate\Contracts\Database\Query\Expression`.

**`@return` — Closure case (`Eloquent\Builder` only):**
The return type was declared as `T` (the Closure's return type), but `Eloquent\Builder::raw()` post-processes the result:
- If `T` is a `CursorInterface`, it is always hydrated into `Collection<int, TModel>` — the cursor is never returned.
- If the result is a document (object/array with `_id` or `id`), it is converted to a `TModel` instance.

A nested conditional type fixes the `CursorInterface` case:
```
T is CursorInterface ? Collection<int, TModel> : T|TModel|Collection<int, TModel>
```

**PHPStan type tests** are added in `tests/PHPStan/BuilderRawTypes.php` to validate all cases.