### PR TITLE
PHPORM-458: Support auto-embedding

### DIFF
--- a/src/Schema/Blueprint.php
+++ b/src/Schema/Blueprint.php
@@ -108,6 +108,16 @@ use function key;
  *     indexingMethod?: 'flat'|'hnsw',
  *     hnswOptions?: array{maxEdges?: int, numEdgeCandidates?: int},
  * } | array{
+ *     type: 'autoEmbed',
+ *     modality: 'text',
+ *     path: string,
+ *     model: string,
+ *     numDimensions?: int,
+ *     quantization?: 'float'|'scalar'|'binary'|'binaryNoRescore',
+ *     similarity?: 'euclidean'|'cosine'|'dotProduct',
+ *     indexingMethod?: 'flat'|'hnsw',
+ *     hnswOptions?: array{maxEdges?: int, numEdgeCandidates?: int},
+ * } | array{
  *     type: 'filter',
  *     path: string,
  * }

--- a/tests/PHPStan/SearchIndexTypes.php
+++ b/tests/PHPStan/SearchIndexTypes.php
@@ -229,5 +229,40 @@ final class SearchIndexTypes
                 ['type' => 'filter', 'path' => 'genres'],
             ],
         ]);
+
+        // autoEmbed - minimal definition
+        // Source: https://www.mongodb.com/docs/atlas/atlas-vector-search/vector-search-type/#automated-embedding
+        self::assertVectorSearchIndexDefinition([
+            'fields' => [
+                [
+                    'type' => 'autoEmbed',
+                    'modality' => 'text',
+                    'path' => 'description',
+                    'model' => 'voyage-4',
+                ],
+            ],
+        ]);
+
+        // autoEmbed - with optional tuning parameters
+        // Source: https://www.mongodb.com/docs/atlas/atlas-vector-search/vector-search-type/#automated-embedding
+        self::assertVectorSearchIndexDefinition([
+            'fields' => [
+                [
+                    'type' => 'autoEmbed',
+                    'modality' => 'text',
+                    'path' => 'description',
+                    'model' => 'voyage-4-large',
+                    'numDimensions' => 1024,
+                    'quantization' => 'scalar',
+                    'similarity' => 'dotProduct',
+                    'indexingMethod' => 'hnsw',
+                    'hnswOptions' => [
+                        'maxEdges' => 32,
+                        'numEdgeCandidates' => 200,
+                    ],
+                ],
+                ['type' => 'filter', 'path' => 'genres'],
+            ],
+        ]);
     }
 }


### PR DESCRIPTION
Introduces support for automated embedding. This enables the user to store and update vector embeddings automatically for specified fields, instead of having to manage an embedding pipeline.

See: https://www.mongodb.com/docs/vector-search/crud-embeddings/automated-embedding/

### Checklist

- [x] Add tests and ensure they pass
