### PR TITLE
fix: `MongoLock` lottery never pruned expired locks

### DIFF
--- a/src/Cache/MongoLock.php
+++ b/src/Cache/MongoLock.php
@@ -81,7 +81,7 @@ final class MongoLock extends Lock
             ],
         );
 
-        if ($this->lottery[0] <= 0 && random_int(1, $this->lottery[1]) <= $this->lottery[0]) {
+        if ($this->lottery[0] > 0 && random_int(1, $this->lottery[1]) <= $this->lottery[0]) {
             $this->collection->deleteMany(['expires_at' => ['$lte' => $this->getUTCDateTime()]]);
         }
 

--- a/tests/Cache/MongoLockTest.php
+++ b/tests/Cache/MongoLockTest.php
@@ -39,6 +39,32 @@ class MongoLockTest extends TestCase
         );
     }
 
+    public function testLotteryPrunesExpiredLocks(): void
+    {
+        $collection = $this->createMock(Collection::class);
+        $collection->expects($this->once())
+            ->method('findOneAndUpdate')
+            ->willReturn(['owner' => 'test-owner']);
+        $collection->expects($this->once())
+            ->method('deleteMany');
+
+        $lock = new MongoLock($collection, 'foo', 10, 'test-owner', lottery: [1, 1]);
+        $lock->acquire();
+    }
+
+    public function testDisabledLotteryDoesNotPruneExpiredLocks(): void
+    {
+        $collection = $this->createMock(Collection::class);
+        $collection->expects($this->once())
+            ->method('findOneAndUpdate')
+            ->willReturn(['owner' => 'test-owner']);
+        $collection->expects($this->never())
+            ->method('deleteMany');
+
+        $lock = new MongoLock($collection, 'foo', 10, 'test-owner', lottery: [0, 0]);
+        $lock->acquire();
+    }
+
     public function testLockCanBeAcquired()
     {
         $lock = $this->getCache()->lock('foo');


### PR DESCRIPTION
<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.
-->

## Summary

### Content
The lottery condition in `MongoLock::acquire()` was logically inverted, because of expired lock pruning to never execute.

### Current the problems

**First Problem**
The original condition `$this->lottery[0] <= 0` is `true` only when the lottery is disabled (chance = 0). 
Combined with `random_int(1, total) <= 0`, which can never be true since `random_int` returns a minimum of 1, the pruning block was unreachable under all circumstances.

**Second Problem**
Because of  a `ValueError` from `random_int(1, 0)` due to PHP requiring min ≤ max. 
The fix short-circuits before calling `random_int` in this case.

### What I have changed
- Fix lottery condition from `<= 0` to `> 0` so pruning executes with the correct probability.
- Add unit tests to verify pruning runs when lottery hits (`[1, 1]`) and does not run when lottery is disabled (`[0, 0]`).

### Test Results
<img width="744" height="220" alt="スクリーンショット 2026-06-20 14 32 40" src="https://github.com/user-attachments/assets/a1e12d19-ad25-4d7c-bcbf-b9125f68a4b4" />


### Checklist

- [ ] Add tests and ensure they pass
