### PR TITLE
feat(scout): support sorting by relevance score (`_score`) in ScoutEngine

### DIFF
--- a/src/Scout/ScoutEngine.php
+++ b/src/Scout/ScoutEngine.php
@@ -260,10 +260,15 @@ final class ScoutEngine extends Engine
             $compound['mustNot'][] = ['in' => ['path' => $field, 'value' => $value]];
         }
 
-        // Sort by field value only if specified
+        // Sort by field value only if specified.
+        // '_score' maps to Atlas Search's relevance score via $meta: searchScore (always descending).
         $sort = [];
         foreach ($builder->orders as $order) {
-            $sort[$order['column']] = $order['direction'] === 'asc' ? 1 : -1;
+            if ($order['column'] === '_score') {
+                $sort['score'] = ['$meta' => 'searchScore'];
+            } else {
+                $sort[$order['column']] = $order['direction'] === 'asc' ? 1 : -1;
+            }
         }
 
         $pipeline = [

--- a/src/Scout/ScoutEngine.php
+++ b/src/Scout/ScoutEngine.php
@@ -270,6 +270,10 @@ final class ScoutEngine extends Engine
         $sort = [];
         foreach ($builder->orders as $order) {
             if ($order['column'] === '_score') {
+                if ($order['direction'] === 'asc') {
+                    throw new InvalidArgumentException("Cannot sort by '_score' in ascending order; Atlas Search relevance score always sorts descending.");
+                }
+
                 $sort['score'] = ['$meta' => 'searchScore'];
             } else {
                 $sort[$order['column']] = $order['direction'] === 'asc' ? 1 : -1;

--- a/src/Scout/ScoutEngine.php
+++ b/src/Scout/ScoutEngine.php
@@ -198,6 +198,18 @@ final class ScoutEngine extends Engine
      */
     private function performSearch(Builder $builder, ?int $offset = null): array
     {
+        // Validate sort before any I/O so unit tests can assert on these exceptions without a real collection.
+        $columns = array_column($builder->orders, 'column');
+        if (in_array('_score', $columns, true) && in_array('score', $columns, true)) {
+            throw new InvalidArgumentException("Cannot sort by a field named 'score' together with Atlas Search's '_score' relevance sort.");
+        }
+
+        foreach ($builder->orders as $order) {
+            if ($order['column'] === '_score' && $order['direction'] === 'asc') {
+                throw new InvalidArgumentException("Cannot sort by '_score' in ascending order; Atlas Search relevance score always sorts descending.");
+            }
+        }
+
         $collection = $this->getSearchableCollection($builder->model);
 
         if ($builder->callback) {
@@ -262,18 +274,9 @@ final class ScoutEngine extends Engine
 
         // Sort by field value only if specified.
         // '_score' maps to Atlas Search's relevance score via $meta: searchScore (always descending).
-        $columns = array_column($builder->orders, 'column');
-        if (in_array('_score', $columns, true) && in_array('score', $columns, true)) {
-            throw new InvalidArgumentException("Cannot sort by a field named 'score' together with Atlas Search's '_score' relevance sort.");
-        }
-
         $sort = [];
         foreach ($builder->orders as $order) {
             if ($order['column'] === '_score') {
-                if ($order['direction'] === 'asc') {
-                    throw new InvalidArgumentException("Cannot sort by '_score' in ascending order; Atlas Search relevance score always sorts descending.");
-                }
-
                 $sort['score'] = ['$meta' => 'searchScore'];
             } else {
                 $sort[$order['column']] = $order['direction'] === 'asc' ? 1 : -1;

--- a/src/Scout/ScoutEngine.php
+++ b/src/Scout/ScoutEngine.php
@@ -262,6 +262,11 @@ final class ScoutEngine extends Engine
 
         // Sort by field value only if specified.
         // '_score' maps to Atlas Search's relevance score via $meta: searchScore (always descending).
+        $columns = array_column($builder->orders, 'column');
+        if (in_array('_score', $columns, true) && in_array('score', $columns, true)) {
+            throw new InvalidArgumentException("Cannot sort by a field named 'score' together with Atlas Search's '_score' relevance sort.");
+        }
+
         $sort = [];
         foreach ($builder->orders as $order) {
             if ($order['column'] === '_score') {

--- a/tests/Scout/ScoutEngineTest.php
+++ b/tests/Scout/ScoutEngineTest.php
@@ -404,6 +404,44 @@ class ScoutEngineTest extends TestCase
                 ],
             ]),
         ];
+
+        yield 'ordered by score' => [
+            function () {
+                $builder = new Builder(new SearchableModel(), 'lar');
+                $builder->orderBy('_score', 'desc');
+
+                return $builder;
+            },
+            array_replace_recursive($defaultPipeline, [
+                [
+                    '$search' => [
+                        'sort' => [
+                            'score' => ['$meta' => 'searchScore'],
+                        ],
+                    ],
+                ],
+            ]),
+        ];
+
+        yield 'ordered by score and field' => [
+            function () {
+                $builder = new Builder(new SearchableModel(), 'lar');
+                $builder->orderBy('_score', 'desc');
+                $builder->orderBy('name', 'asc');
+
+                return $builder;
+            },
+            array_replace_recursive($defaultPipeline, [
+                [
+                    '$search' => [
+                        'sort' => [
+                            'score' => ['$meta' => 'searchScore'],
+                            'name' => 1,
+                        ],
+                    ],
+                ],
+            ]),
+        ];
     }
 
     public function testPaginate()

--- a/tests/Scout/ScoutEngineTest.php
+++ b/tests/Scout/ScoutEngineTest.php
@@ -158,6 +158,20 @@ class ScoutEngineTest extends TestCase
         $engine->search($builder);
     }
 
+    public function testSearchRejectsAscendingScoreSort(): void
+    {
+        $database = $this->createMock(Database::class);
+        $builder = new Builder(new SearchableModel(), 'lar');
+        $builder->orderBy('_score', 'asc');
+
+        $engine = new ScoutEngine($database, softDelete: false);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Cannot sort by '_score' in ascending order; Atlas Search relevance score always sorts descending.");
+
+        $engine->search($builder);
+    }
+
     public static function provideSearchPipelines(): iterable
     {
         $defaultPipeline = [

--- a/tests/Scout/ScoutEngineTest.php
+++ b/tests/Scout/ScoutEngineTest.php
@@ -8,6 +8,7 @@ use DateTimeImmutable;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Support\Collection as LaravelCollection;
 use Illuminate\Support\LazyCollection;
+use InvalidArgumentException;
 use Laravel\Scout\Builder;
 use Laravel\Scout\Jobs\RemoveFromSearch;
 use LogicException;
@@ -140,6 +141,21 @@ class ScoutEngineTest extends TestCase
         $engine = new ScoutEngine($database, softDelete: false);
         $result = $engine->search($builder());
         $this->assertEquals($data, $result);
+    }
+
+    public function testSearchRejectsScoreFieldWithScoreSort(): void
+    {
+        $database = $this->createMock(Database::class);
+        $builder = new Builder(new SearchableModel(), 'lar');
+        $builder->orderBy('_score', 'desc');
+        $builder->orderBy('score', 'asc');
+
+        $engine = new ScoutEngine($database, softDelete: false);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Cannot sort by a field named 'score' together with Atlas Search's '_score' relevance sort.");
+
+        $engine->search($builder);
     }
 
     public static function provideSearchPipelines(): iterable

--- a/tests/Scout/ScoutIntegrationTest.php
+++ b/tests/Scout/ScoutIntegrationTest.php
@@ -15,6 +15,7 @@ use Override;
 use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\Attributes\Group;
 
+use function array_column;
 use function array_merge;
 use function count;
 use function env;
@@ -262,6 +263,67 @@ class ScoutIntegrationTest extends TestCase
             43 => 'Dana Larson Sr.',
             44 => 'Amos Larson Sr.',
         ], $page2->pluck('name', 'id')->all());
+    }
+
+    #[Depends('testItCanCreateTheCollection')]
+    public function testItCanSortByRelevanceScore()
+    {
+        $results = ScoutUser::search('lar')->orderBy('_score', 'desc')->take(10)->keys()->all();
+
+        // Reference: same pipeline with $meta:searchScore sort applied directly, bypassing ScoutEngine
+        $reference = DB::connection('mongodb')
+            ->getCollection('prefix_scout_users')
+            ->aggregate([
+                [
+                    '$search' => [
+                        'index' => 'scout',
+                        'compound' => [
+                            'should' => [
+                                ['text' => ['query' => 'lar', 'path' => ['wildcard' => '*'], 'fuzzy' => ['maxEdits' => 2], 'score' => ['boost' => ['value' => 5]]]],
+                                ['wildcard' => ['query' => 'lar*', 'path' => ['wildcard' => '*'], 'allowAnalyzedField' => true]],
+                            ],
+                            'minimumShouldMatch' => 1,
+                        ],
+                        'count' => ['type' => 'lowerBound'],
+                        'sort' => ['score' => ['$meta' => 'searchScore']],
+                    ],
+                ],
+                ['$project' => ['id' => 1, '_id' => 0]],
+                ['$limit' => 10],
+            ]);
+
+        $referenceIds = array_column(iterator_to_array($reference), 'id');
+        self::assertSame($referenceIds, $results);
+    }
+
+    #[Depends('testItCanCreateTheCollection')]
+    public function testItCanSortByRelevanceScoreAndField()
+    {
+        $results = ScoutUser::search('lar')->orderBy('_score', 'desc')->orderBy('id', 'asc')->take(10)->keys()->all();
+
+        $reference = DB::connection('mongodb')
+            ->getCollection('prefix_scout_users')
+            ->aggregate([
+                [
+                    '$search' => [
+                        'index' => 'scout',
+                        'compound' => [
+                            'should' => [
+                                ['text' => ['query' => 'lar', 'path' => ['wildcard' => '*'], 'fuzzy' => ['maxEdits' => 2], 'score' => ['boost' => ['value' => 5]]]],
+                                ['wildcard' => ['query' => 'lar*', 'path' => ['wildcard' => '*'], 'allowAnalyzedField' => true]],
+                            ],
+                            'minimumShouldMatch' => 1,
+                        ],
+                        'count' => ['type' => 'lowerBound'],
+                        'sort' => ['score' => ['$meta' => 'searchScore'], 'id' => 1],
+                    ],
+                ],
+                ['$project' => ['id' => 1, '_id' => 0]],
+                ['$limit' => 10],
+            ]);
+
+        $referenceIds = array_column(iterator_to_array($reference), 'id');
+        self::assertSame($referenceIds, $results);
     }
 
     public function testItCannotIndexInTheSameNamespace()


### PR DESCRIPTION
## Summary

Adds support for `orderBy('_score', 'desc')` in the MongoDB Laravel Scout engine, mapping it to Atlas Search's relevance score sort (`$meta: searchScore`) instead of treating it as a regular field sort.

### Current Problem

Previously, `$sort[$order['column']] = $order['direction'] === 'asc' ? 1 : -1;` treated every order column the same way, including `_score`.
Atlas Search does not support sorting by a numeric `1`/`-1` direction on `_score` — relevance score sorting requires the dedicated `$meta: searchScore` syntax.
As a result, `orderBy('_score', 'desc')` would silently produce an invalid sort and not work correctly against Atlas Search.

### What I have changed

- In `performSearch()`, the sort-building loop now branches on the order column:
  - If the column is `_score`, it maps to `'score' => ['$meta' => 'searchScore']`.
  - Otherwise, it falls back to the existing `1`/`-1` direction sort.
- `orderBy('_score', 'asc')` throws an `InvalidArgumentException` because `$meta: searchScore` does not support ascending direction — only descending is valid in Atlas Search.
- Sorting by `_score` together with a field named `score` throws an `InvalidArgumentException` because both map to the same key in the Atlas Search sort stage.
- Added unit test coverages:
  - `ordered by score`: verifies `_score` alone maps to the relevance sort.
  - `ordered by score and field`: verifies `_score` and a regular field can be combined in the same sort.
  - `testSearchRejectsAscendingScoreSort`: verifies that `orderBy('_score', 'asc')` throws.
  - `testSearchRejectsScoreFieldWithScoreSort`: verifies the `score` field name collision throws.
- Added Atlas Search integration tests comparing the Scout result order against a reference raw aggregation pipeline using `$meta: searchScore` directly.

### Test Results
<img width="757" height="200" alt="screenshot 2026-06-20 17 58 05" src="https://github.com/user-attachments/assets/3340feb3-131c-456e-b787-d74e92730b94" />

### Checklist

- [x] Add tests and ensure they pass