### PR TITLE
PHPORM-486: Explicitly do not support base vector search methods

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -703,8 +703,7 @@ class Builder extends BaseBuilder
             function ($orderColumn) use ($column) {
                 return $orderColumn === $column
                     || ($orderColumn === 'id' && $column === '_id')
-                    || ($orderColumn === '_id' && $column === 'id'
-                );
+                    || ($orderColumn === '_id' && $column === 'id');
             },
         );
 
@@ -1870,5 +1869,60 @@ class Builder extends BaseBuilder
     public function orWhereIntegerNotInRaw($column, $values, $boolean = 'and')
     {
         throw new BadMethodCallException('This method is not supported by MongoDB');
+    }
+
+    /**
+     * Base method from Laravel >= 13.0
+     * ToDo: mark as `#[Override]` when we drop support for Laravel < 13.0
+     *
+     * @internal This method is not supported by MongoDB. Use vectorSearch() instead.
+     */
+    public function whereVectorSimilarTo($column, $vector, $minSimilarity = 0.6, $order = true)
+    {
+        throw new BadMethodCallException('This method is not supported by MongoDB. Use vectorSearch() instead.');
+    }
+
+    /**
+     * Base method from Laravel >= 13.0
+     * ToDo: mark as `#[Override]` when we drop support for Laravel < 13.0
+     *
+     * @internal This method is not supported by MongoDB. Use vectorSearch() with the $filter parameter instead.
+     */
+    public function whereVectorDistanceLessThan($column, $vector, $maxDistance, $boolean = 'and')
+    {
+        throw new BadMethodCallException('This method is not supported by MongoDB. Use vectorSearch() with the $filter parameter instead.');
+    }
+
+    /**
+     * Base method from Laravel >= 13.0
+     * ToDo: mark as `#[Override]` when we drop support for Laravel < 13.0
+     *
+     * @internal This method is not supported by MongoDB. Use vectorSearch() with the $filter parameter instead.
+     */
+    public function orWhereVectorDistanceLessThan($column, $vector, $maxDistance)
+    {
+        throw new BadMethodCallException('This method is not supported by MongoDB. Use vectorSearch() with the $filter parameter instead.');
+    }
+
+    /**
+     * Base method from Laravel >= 13.0
+     * ToDo: mark as `#[Override]` when we drop support for Laravel < 13.0
+     *
+     * @internal This method is not supported by MongoDB. Use vectorSearch() instead, which returns vectorSearchScore in the result.
+     */
+    public function selectVectorDistance($column, $vector, $as = null)
+    {
+        throw new BadMethodCallException('This method is not supported by MongoDB. Use vectorSearch() instead, which returns vectorSearchScore in the result.');
+    }
+
+    /**
+     * Base method from Laravel >= 13.0
+     * ToDo: mark as `#[Override]` when we drop support for Laravel < 13.0
+     *
+     * @internal This method is not supported by MongoDB. Use vectorSearch() instead, which returns results ordered by vector score.
+     */
+    public function orderByVectorDistance($column, $vector = [])
+    {
+        throw new BadMethodCallException('This method is not supported by MongoDB. Use vectorSearch() instead, which returns results ordered by vector score.');
     }
 }

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -1646,6 +1646,12 @@ class BuilderTest extends TestCase
 
         /** @see DatabaseQueryBuilderTest::testOrWhereIntegerNotInRaw */
         yield 'orWhereIntegerNotInRaw' => [fn (Builder $builder) => $builder->orWhereIntegerNotInRaw('id', ['1a', 2])];
+
+        yield 'whereVectorSimilarTo' => [fn (Builder $builder) => $builder->whereVectorSimilarTo('embedding', [0.1, 0.2])];
+        yield 'whereVectorDistanceLessThan' => [fn (Builder $builder) => $builder->whereVectorDistanceLessThan('embedding', [0.1, 0.2], 0.5)];
+        yield 'orWhereVectorDistanceLessThan' => [fn (Builder $builder) => $builder->orWhereVectorDistanceLessThan('embedding', [0.1, 0.2], 0.5)];
+        yield 'selectVectorDistance' => [fn (Builder $builder) => $builder->selectVectorDistance('embedding', [0.1, 0.2])];
+        yield 'orderByVectorDistance' => [fn (Builder $builder) => $builder->orderByVectorDistance('embedding', [0.1, 0.2])];
     }
 
     #[DataProvider('provideDisableRenameEmbeddedIdField')]


### PR DESCRIPTION
As the existing `vectorSearch` method already supports all their usage and the arguments for the base methods don't correspond with MongoDB vector search usage


### Checklist

- [x] Add tests and ensure they pass
