### PR TITLE
PHPLARA-73 Make id/_id column aliasing overridable via Grammar

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -36,6 +36,7 @@ use function array_fill_keys;
 use function array_filter;
 use function array_is_list;
 use function array_key_exists;
+use function array_key_first;
 use function array_keys;
 use function array_map;
 use function array_merge;
@@ -1293,10 +1294,11 @@ class Builder extends BaseBuilder
             if (isset($where['column'])) {
                 $where['column'] = (string) $where['column'];
 
-                // Compatibility with Eloquent queries that uses "id" instead of MongoDB's _id
-                if ($where['column'] === 'id') {
-                    $where['column'] = '_id';
-                }
+                // Compatibility with Eloquent queries that use "id" instead of MongoDB's _id.
+                // Delegates to Grammar::prepareFieldsForQuery so the aliasing is overridable.
+                $where['column'] = (string) array_key_first(
+                    $this->grammar->prepareFieldsForQuery([$where['column'] => null]),
+                );
 
                 // Convert id's.
                 if ($where['column'] === '_id' || str_ends_with($where['column'], '._id')) {

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -1736,6 +1736,29 @@ class BuilderTest extends TestCase
         ];
     }
 
+    public function testCustomGrammarDisablesIdAliasing()
+    {
+        $connection = $this->createStub(Connection::class);
+        $connection->method('getRenameEmbeddedIdField')->willReturn(true);
+        $connection->method('getSession')->willReturn(null);
+        $grammar = new class ($connection) extends Grammar {
+            public function prepareFieldsForQuery(array $values, bool $root = true): array
+            {
+                return $values;
+            }
+        };
+        $connection->method('getQueryGrammar')->willReturn($grammar);
+
+        $builder = new Builder($connection, null, $this->createStub(Processor::class));
+
+        $mql = $builder->where('id', '=', 'abc123')->toMql();
+
+        $this->assertEquals(
+            ['find' => [['id' => 'abc123'], ['typeMap' => ['root' => 'object', 'document' => 'array']]]],
+            $mql,
+        );
+    }
+
     private function getBuilder(bool $renameEmbeddedIdField = true): Builder
     {
         $connection = $this->createStub(Connection::class);


### PR DESCRIPTION
The top-level `id` to `_id` column rename in `Builder::compileWheres()` was hardcoded, which caused data corruption for users whose MongoDB documents have a business `id` field alongside `_id` (see #3392).

This delegates the aliasing to `Grammar::prepareFieldsForQuery()`, which is already the public overridable API (introduced in #3476). Users who need to disable the aliasing can now extend the Grammar class, consistent with Laravel's query builder architecture.

The `alias_id` connection config option (proposed in #3472) is not the right approach because `compileWheres()` runs before `Grammar::prepareFieldsForQuery()` at other call sites, so the Grammar hook would have received a payload where `id` had already been replaced by `_id`.

Ticket: https://jira.mongodb.org/browse/PHPLARA-73