### PR TITLE
PHPLARA-81 Add AsBsonDocument and AsBsonArray casts

### DIFF
--- a/src/Eloquent/Casts/AsBsonArray.php
+++ b/src/Eloquent/Casts/AsBsonArray.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Laravel\Eloquent\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\Castable;
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use MongoDB\BSON\Document;
+use MongoDB\Model\BSONArray;
+
+use function is_array;
+
+class AsBsonArray implements Castable, CastsAttributes
+{
+    public static function castUsing(array $arguments): static
+    {
+        return new static();
+    }
+
+    public function get($model, string $key, $value, array $attributes)
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if ($value instanceof BSONArray) {
+            return clone $value;
+        }
+
+        if (! is_array($value)) {
+            return null;
+        }
+
+        return new BSONArray($value);
+    }
+
+    public function set($model, string $key, $value, array $attributes)
+    {
+        if ($value === null) {
+            return [$key => null];
+        }
+
+        if ($value instanceof BSONArray) {
+            return [$key => clone $value];
+        }
+
+        return [$key => new BSONArray((array) $value)];
+    }
+
+    public function compare($model, string $key, $original, $value): bool
+    {
+        return self::normalize($original) === self::normalize($value);
+    }
+
+    private static function normalize($value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if ($value instanceof BSONArray) {
+            $value = $value->getArrayCopy();
+        }
+
+        return (string) Document::fromPHP(['v' => (array) $value]);
+    }
+}

--- a/src/Eloquent/Casts/AsBsonArray.php
+++ b/src/Eloquent/Casts/AsBsonArray.php
@@ -20,19 +20,11 @@ class AsBsonArray implements Castable, CastsAttributes
 
     public function get($model, string $key, $value, array $attributes)
     {
-        if ($value === null) {
-            return null;
-        }
-
         if ($value instanceof BSONArray) {
             return clone $value;
         }
 
-        if (! is_array($value)) {
-            return null;
-        }
-
-        return new BSONArray($value);
+        return is_array($value) ? new BSONArray($value) : null;
     }
 
     public function set($model, string $key, $value, array $attributes)

--- a/src/Eloquent/Casts/AsBsonDocument.php
+++ b/src/Eloquent/Casts/AsBsonDocument.php
@@ -21,10 +21,6 @@ class AsBsonDocument implements Castable, CastsAttributes
 
     public function get($model, string $key, $value, array $attributes)
     {
-        if ($value === null) {
-            return null;
-        }
-
         if ($value instanceof BSONDocument) {
             return clone $value;
         }
@@ -33,11 +29,7 @@ class AsBsonDocument implements Castable, CastsAttributes
             $value = (array) $value;
         }
 
-        if (! is_array($value)) {
-            return null;
-        }
-
-        return new BSONDocument($value);
+        return is_array($value) ? new BSONDocument($value) : null;
     }
 
     public function set($model, string $key, $value, array $attributes)
@@ -48,10 +40,6 @@ class AsBsonDocument implements Castable, CastsAttributes
 
         if ($value instanceof BSONDocument) {
             return [$key => clone $value];
-        }
-
-        if ($value instanceof stdClass) {
-            $value = (array) $value;
         }
 
         return [$key => new BSONDocument((array) $value)];

--- a/src/Eloquent/Casts/AsBsonDocument.php
+++ b/src/Eloquent/Casts/AsBsonDocument.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Laravel\Eloquent\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\Castable;
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use MongoDB\BSON\Document;
+use MongoDB\Model\BSONDocument;
+use stdClass;
+
+use function is_array;
+
+class AsBsonDocument implements Castable, CastsAttributes
+{
+    public static function castUsing(array $arguments): static
+    {
+        return new static();
+    }
+
+    public function get($model, string $key, $value, array $attributes)
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if ($value instanceof BSONDocument) {
+            return clone $value;
+        }
+
+        if ($value instanceof stdClass) {
+            $value = (array) $value;
+        }
+
+        if (! is_array($value)) {
+            return null;
+        }
+
+        return new BSONDocument($value);
+    }
+
+    public function set($model, string $key, $value, array $attributes)
+    {
+        if ($value === null) {
+            return [$key => null];
+        }
+
+        if ($value instanceof BSONDocument) {
+            return [$key => clone $value];
+        }
+
+        if ($value instanceof stdClass) {
+            $value = (array) $value;
+        }
+
+        return [$key => new BSONDocument((array) $value)];
+    }
+
+    public function compare($model, string $key, $original, $value): bool
+    {
+        return self::normalize($original) === self::normalize($value);
+    }
+
+    private static function normalize($value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if ($value instanceof BSONDocument) {
+            $value = $value->getArrayCopy();
+        } elseif ($value instanceof stdClass) {
+            $value = (array) $value;
+        }
+
+        return (string) Document::fromPHP(['v' => $value]);
+    }
+}

--- a/src/Eloquent/DocumentModel.php
+++ b/src/Eloquent/DocumentModel.php
@@ -400,6 +400,10 @@ trait DocumentModel
                 $this->castAttribute($key, $original);
         }
 
+        if ($this->isClassComparable($key)) {
+            return $this->compareClassCastableAttribute($key, $original, $attribute);
+        }
+
         if ($this->isClassCastable($key)) {
             return ! is_object($attribute) ? $attribute === $original : $attribute == $original;
         }

--- a/tests/Casts/AsBsonDocumentArrayTest.php
+++ b/tests/Casts/AsBsonDocumentArrayTest.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Laravel\Tests\Casts;
+
+use Illuminate\Support\Facades\DB;
+use MongoDB\Laravel\Tests\Models\BsonCasting;
+use MongoDB\Laravel\Tests\TestCase;
+use MongoDB\Model\BSONArray;
+use MongoDB\Model\BSONDocument;
+use stdClass;
+
+use function assert;
+
+/**
+ * Mirrors Laravel's Illuminate\Tests\Integration\Database\DatabaseCustomCastsTest
+ * for the MongoDB-native AsBsonDocument / AsBsonArray casts.
+ *
+ * @see https://jira.mongodb.org/browse/PHPLARA-81
+ */
+class AsBsonDocumentArrayTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        BsonCasting::truncate();
+    }
+
+    public function testCustomCasting(): void
+    {
+        $model = new BsonCasting();
+        $model->specs = ['name' => 'Taylor'];
+        $model->variants = [['name' => 'Taylor']];
+        $model->save();
+
+        $model = $model->fresh();
+
+        self::assertInstanceOf(BSONDocument::class, $model->specs);
+        self::assertInstanceOf(BSONArray::class, $model->variants);
+        self::assertSame(['name' => 'Taylor'], $model->specs->getArrayCopy());
+        self::assertSame([['name' => 'Taylor']], $model->variants->getArrayCopy());
+
+        $model->specs['age'] = 34;
+        $model->specs['meta']['title'] = 'Developer';
+        $model->variants[] = ['name' => 'Otwell'];
+
+        $model->save();
+        $model = $model->fresh();
+
+        self::assertSame(
+            ['name' => 'Taylor', 'age' => 34, 'meta' => ['title' => 'Developer']],
+            $model->specs->getArrayCopy(),
+        );
+        self::assertSame(
+            [['name' => 'Taylor'], ['name' => 'Otwell']],
+            $model->variants->getArrayCopy(),
+        );
+    }
+
+    public function testCustomCastingUsingCreate(): void
+    {
+        $model = BsonCasting::create([
+            'specs' => ['name' => 'Taylor'],
+            'variants' => [['name' => 'Taylor']],
+        ]);
+
+        $model = $model->fresh();
+
+        self::assertSame(['name' => 'Taylor'], $model->specs->getArrayCopy());
+        self::assertSame([['name' => 'Taylor']], $model->variants->getArrayCopy());
+    }
+
+    public function testCustomCastingNullableValues(): void
+    {
+        $model = new BsonCasting();
+        $model->specs = null;
+        $model->variants = null;
+        $model->save();
+
+        $model = $model->fresh();
+
+        self::assertNull($model->specs);
+        self::assertNull($model->variants);
+
+        $model->specs = ['name' => 'John'];
+        $model->specs['name'] = 'Taylor';
+        $model->specs['meta']['title'] = 'Developer';
+
+        $model->variants = [];
+        $model->variants[] = ['name' => 'Taylor'];
+
+        $model->save();
+        $model = $model->fresh();
+
+        self::assertSame(
+            ['name' => 'Taylor', 'meta' => ['title' => 'Developer']],
+            $model->specs->getArrayCopy(),
+        );
+        self::assertSame([['name' => 'Taylor']], $model->variants->getArrayCopy());
+    }
+
+    public function testDirtyOnAsBsonDocument(): void
+    {
+        $model = new BsonCasting();
+        $model->setRawAttributes(['specs' => ['bar' => 'foo']]);
+        $model->syncOriginal();
+
+        self::assertInstanceOf(BSONDocument::class, $model->specs);
+        self::assertFalse($model->isDirty('specs'));
+
+        $model->specs = ['bar' => 'foo'];
+        self::assertFalse($model->isDirty('specs'));
+
+        $model->specs = ['baz' => 'foo'];
+        self::assertTrue($model->isDirty('specs'));
+    }
+
+    public function testDirtyOnAsBsonArray(): void
+    {
+        $model = new BsonCasting();
+        $model->setRawAttributes(['variants' => [['bar' => 'foo']]]);
+        $model->syncOriginal();
+
+        self::assertInstanceOf(BSONArray::class, $model->variants);
+        self::assertFalse($model->isDirty('variants'));
+
+        $model->variants = [['bar' => 'foo']];
+        self::assertFalse($model->isDirty('variants'));
+
+        $model->variants = [['baz' => 'foo']];
+        self::assertTrue($model->isDirty('variants'));
+    }
+
+    public function testStorageIsNativeBsonNotJsonString(): void
+    {
+        $model = BsonCasting::create([
+            'specs' => ['storage' => ['primary' => '512GB SSD']],
+            'variants' => [['color' => 'Blue']],
+        ]);
+
+        $raw = DB::connection()->table($model->getTable())->find($model->_id);
+        assert($raw instanceof stdClass);
+
+        self::assertIsArray($raw->specs);
+        self::assertIsArray($raw->variants);
+        self::assertSame('512GB SSD', $raw->specs['storage']['primary']);
+        self::assertSame('Blue', $raw->variants[0]['color']);
+    }
+}

--- a/tests/Casts/AsBsonDocumentArrayTest.php
+++ b/tests/Casts/AsBsonDocumentArrayTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace MongoDB\Laravel\Tests\Casts;
 
 use Illuminate\Support\Facades\DB;
+use MongoDB\Laravel\Eloquent\Casts\AsBsonArray;
+use MongoDB\Laravel\Eloquent\Casts\AsBsonDocument;
 use MongoDB\Laravel\Tests\Models\BsonCasting;
 use MongoDB\Laravel\Tests\TestCase;
 use MongoDB\Model\BSONArray;
@@ -147,5 +149,61 @@ class AsBsonDocumentArrayTest extends TestCase
         self::assertIsArray($raw->variants);
         self::assertSame('512GB SSD', $raw->specs['storage']['primary']);
         self::assertSame('Blue', $raw->variants[0]['color']);
+    }
+
+    public function testGetReturnsNullForNonArrayValue(): void
+    {
+        $model = new BsonCasting();
+
+        self::assertNull((new AsBsonArray())->get($model, 'variants', null, []));
+        self::assertNull((new AsBsonArray())->get($model, 'variants', 'scalar', []));
+        self::assertNull((new AsBsonArray())->get($model, 'variants', 42, []));
+
+        self::assertNull((new AsBsonDocument())->get($model, 'specs', null, []));
+        self::assertNull((new AsBsonDocument())->get($model, 'specs', 'scalar', []));
+        self::assertNull((new AsBsonDocument())->get($model, 'specs', 42, []));
+    }
+
+    public function testGetConvertsStdClassToBsonDocument(): void
+    {
+        $result = (new AsBsonDocument())->get(new BsonCasting(), 'specs', (object) ['name' => 'Taylor'], []);
+
+        self::assertInstanceOf(BSONDocument::class, $result);
+        self::assertSame(['name' => 'Taylor'], $result->getArrayCopy());
+    }
+
+    public function testGetClonesExistingBsonContainer(): void
+    {
+        $model = new BsonCasting();
+
+        $document = new BSONDocument(['name' => 'Taylor']);
+        $castDocument = (new AsBsonDocument())->get($model, 'specs', $document, []);
+        self::assertInstanceOf(BSONDocument::class, $castDocument);
+        self::assertNotSame($document, $castDocument);
+        self::assertSame(['name' => 'Taylor'], $castDocument->getArrayCopy());
+
+        $array = new BSONArray([['name' => 'Taylor']]);
+        $castArray = (new AsBsonArray())->get($model, 'variants', $array, []);
+        self::assertInstanceOf(BSONArray::class, $castArray);
+        self::assertNotSame($array, $castArray);
+        self::assertSame([['name' => 'Taylor']], $castArray->getArrayCopy());
+    }
+
+    /**
+     * Mirrors the leniency of Laravel's AsArrayObject / AsCollection: set() never
+     * throws on non-array input, it coerces via (array) instead.
+     */
+    public function testSetCoercesNonArrayValueWithoutThrowing(): void
+    {
+        $model = new BsonCasting();
+
+        $variants = (new AsBsonArray())->set($model, 'variants', 'foo', []);
+        self::assertEquals(new BSONArray(['foo']), $variants['variants']);
+
+        $specs = (new AsBsonDocument())->set($model, 'specs', (object) ['name' => 'Taylor'], []);
+        self::assertEquals(new BSONDocument(['name' => 'Taylor']), $specs['specs']);
+
+        self::assertSame(['variants' => null], (new AsBsonArray())->set($model, 'variants', null, []));
+        self::assertSame(['specs' => null], (new AsBsonDocument())->set($model, 'specs', null, []));
     }
 }

--- a/tests/Models/BsonCasting.php
+++ b/tests/Models/BsonCasting.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Laravel\Tests\Models;
+
+use MongoDB\Laravel\Eloquent\Casts\AsBsonArray;
+use MongoDB\Laravel\Eloquent\Casts\AsBsonDocument;
+use MongoDB\Laravel\Eloquent\Model;
+use MongoDB\Model\BSONArray;
+use MongoDB\Model\BSONDocument;
+
+/**
+ * @property BSONDocument $specs
+ * @property BSONArray    $variants
+ */
+class BsonCasting extends Model
+{
+    protected $connection = 'mongodb';
+    protected $table = 'phplara81_bson_casts';
+    protected $fillable = ['specs', 'variants'];
+
+    protected $casts = [
+        'specs' => AsBsonDocument::class,
+        'variants' => AsBsonArray::class,
+    ];
+}


### PR DESCRIPTION
Introduces two Eloquent casts that store attributes as **native BSON** documents and arrays instead of JSON-encoded strings.

- `MongoDB\Laravel\Eloquent\Casts\AsBsonDocument` returns a `MongoDB\Model\BSONDocument` on read.
- `MongoDB\Laravel\Eloquent\Casts\AsBsonArray` returns a `MongoDB\Model\BSONArray` on read.

```php
use MongoDB\Laravel\Eloquent\Casts\AsBsonArray;
use MongoDB\Laravel\Eloquent\Casts\AsBsonDocument;

class Product extends Model
{
    protected \$casts = [
        'specs' => AsBsonDocument::class,
        'variants' => AsBsonArray::class,
    ];
}

\$product->specs['storage']['primary'] = '1TB SSD';   // nested mutation
\$product->variants[] = ['color' => 'Red'];           // append
\$product->save();
```

## Benefits

Same ergonomics as [Laravel's `AsArrayObject` / `AsCollection`](https://laravel-news.com/as-arrayobject-and-as-collection-custom-casts):
- Mutation of nested paths without full reassignment (`\$model->specs['a']['b'] = 'x'`), thanks to `ArrayObject` reference semantics.
- Automatic dirty tracking on nested mutations.
- Property-style access (`\$doc->foo`) in addition to array-style.

Plus **MongoDB-specific advantages that JSON string storage cannot deliver**:
- Fields are queryable and indexable by nested path (`specs.storage.primary`).
- Partial updates via `\$set`, `\$push`, `\$inc`, etc. work naturally.
- Aggregation pipelines can project, filter, and group on nested fields.
- Storage size is smaller than an escaped JSON string.
- No JSON encode/decode overhead on every read/write.

## Why not `Illuminate\Database\Eloquent\Casts\AsArrayObject` and `AsCollection`?

**Avoid these casts on MongoDB models.** Their `castUsing()` returns an anonymous class that calls `Json::encode(\$value)` in `set()` and `Json::decode(\$attributes[\$key])` in `get()`. Values are stored as JSON strings in MongoDB, not as BSON documents. This defeats every native MongoDB capability listed above: no indexing on nested fields, no `\$set` on `specs.storage.primary`, no aggregations on inner values, and larger on-disk size.

Because the encoding is hardcoded inside anonymous classes returned by `castUsing()`, there is no clean override point for a MongoDB-friendly variant. New casts are required.

The same issue affects `AsEnumArrayObject`, `AsEnumCollection`, `AsEncryptedArrayObject`, `AsEncryptedCollection`. Follow-ups may add BSON-native equivalents.

## Dirty tracking

`AsBsonDocument` and `AsBsonArray` implement `compare(\$model, \$key, \$original, \$value)` that normalizes both operands via `MongoDB\BSON\Document::fromPHP()` and compares the serialized BSON bytes. This means:
- Reassigning an equivalent-but-different container (e.g. array vs `BSONDocument` with the same content) is not dirty.
- Round-trip BSON types are compared correctly.

`DocumentModel::originalIsEquivalent()` now consults `isClassComparable()` before the loose-equality fallback, so casts opting in to `compare()` get honored.

## Related

Complementary to #3501, which generalizes BSON-aware comparison across all attribute types.