### PR TITLE
PHPLARA-252 Increase Atlas search index readiness timeout to 120s

### DIFF
--- a/.github/workflows/build-ci-atlas.yml
+++ b/.github/workflows/build-ci-atlas.yml
@@ -42,18 +42,19 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Create MongoDB Atlas Local
+        timeout-minutes: 5
         run: |
           docker run --name mongodb -p 27017:27017 --detach mongodb/mongodb-atlas-local:latest
           until docker exec --tty mongodb mongosh --eval "db.runCommand({ ping: 1 })"; do
             sleep 1
           done
-          until docker exec --tty mongodb mongosh --eval "db.createCollection('connection_test') && db.getCollection('connection_test').createSearchIndex({mappings:{dynamic: true}})"; do
+          docker exec --tty mongodb mongosh --eval "db.createCollection('connection_test')"
+          until docker exec --tty mongodb mongosh --eval "db.getCollection('connection_test').createSearchIndex({mappings:{dynamic: true}})"; do
             sleep 1
           done
-
-      - name: Show MongoDB server status
-        run: |
-          docker exec --tty mongodb mongosh --eval "db.runCommand({ serverStatus: 1 })"
+          until docker exec --tty mongodb mongosh --eval "db.runCommand({ serverStatus: 1 })"; do
+            sleep 1
+          done
 
       - name: Setup cache environment
         id: extcache

--- a/tests/AtlasSearchIndexManagement.php
+++ b/tests/AtlasSearchIndexManagement.php
@@ -18,7 +18,7 @@ trait AtlasSearchIndexManagement
      */
     public function waitForSearchIndexesDropped(Collection $collection)
     {
-        $timeout = hrtime()[0] + 30;
+        $timeout = hrtime()[0] + 120;
         // Waits for the search index created in the previous test to be deleted
         while ($collection->listSearchIndexes()->count()) {
             if (hrtime()[0] > $timeout) {
@@ -34,7 +34,7 @@ trait AtlasSearchIndexManagement
      */
     public function waitForSearchIndexesReady(Collection $collection)
     {
-        $timeout = hrtime()[0] + 30;
+        $timeout = hrtime()[0] + 120;
         do {
             if (hrtime()[0] > $timeout) {
                 throw new RuntimeException('Timed out waiting for search indexes to be ready');


### PR DESCRIPTION
On slower Atlas Search deployments (community mongot, cold starts, or auto-embedding indexes), search indexes routinely take more than 30 seconds to become queryable, which makes the `atlas-search` test suite flaky:

```
RuntimeException: Timed out waiting for search indexes to be ready
  at tests/AtlasSearchIndexManagement.php:40
```

- Bump the timeout used by both `waitForSearchIndexesDropped()` and `waitForSearchIndexesReady()` from 30s to 120s, matching what the Doctrine ODM test suite uses (`maxTimeMs: 120_000`) for the same category of test.
- Add a `timeout-minutes: 5` guard on the Atlas Local setup step in the CI workflow, and fold the standalone "Show MongoDB server status" step into the same setup step as a readiness check.

Jira: [PHPLARA-252](https://jira.mongodb.org/browse/PHPLARA-252)