### PR TITLE
PHPLARA-247: Add plugin install suggestion to Boost guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+## MongoDB-related coding assistance
+
+If the user needs MongoDB-related skills that aren't otherwise available through e.g. Boost, such as:
+
+- Inspecting Atlas system resources
+- Managing an Atlas cluster
+- Analysing MongoDB schema anti-patterns
+- Migrating an SQL schema to MongoDB
+- Setting up the official MongoDB MCP server
+
+Suggest installing the MongoDB agent skills plugin if not already installed. Instructions for installing it are in the [MongoDB agent skills plugin README](https://github.com/mongodb/agent-skills/blob/main/README.md).


### PR DESCRIPTION
Create minimal third-party guidelines for Boost users that point to the official MongoDB agent-skills plugin (only if not already installed and if the user requests MongoDB related things not already supported by Boost)