### PR TITLE
PHPLARA-251: Create database query tool for Boost

### DIFF
--- a/resources/boost/guidelines/core.blade.php
+++ b/resources/boost/guidelines/core.blade.php
@@ -8,6 +8,7 @@ Before running any Boost database tool, check whether the target connection uses
 
 If it does, you MUST use a MongoDB Laravel equivalent tool instead, if available:
 
-| Boost tool        | MongoDB Laravel tool |
-|-------------------|----------------------|
-| `database-schema` | `database-info`      |
+| Boost tool        | MongoDB Laravel tool      |
+|-------------------|---------------------------|
+| `database-schema` | `database-info`           |
+| `database-query`  | `database-query-mongodb`  |

--- a/src/MongoDBServiceProvider.php
+++ b/src/MongoDBServiceProvider.php
@@ -26,6 +26,7 @@ use MongoDB\Laravel\Queue\MongoConnector;
 use MongoDB\Laravel\Scout\ScoutEngine;
 use MongoDB\Laravel\Session\MongoDbSessionHandler;
 use MongoDB\Laravel\Tools\DatabaseInfo;
+use MongoDB\Laravel\Tools\DatabaseQuery;
 use Override;
 use RuntimeException;
 
@@ -170,7 +171,7 @@ class MongoDBServiceProvider extends ServiceProvider
 
         config()->set('boost.mcp.tools.include', array_merge(
             config('boost.mcp.tools.include', []),
-            [DatabaseInfo::class],
+            [DatabaseInfo::class, DatabaseQuery::class],
         ));
     }
 

--- a/src/Tools/DatabaseQuery.php
+++ b/src/Tools/DatabaseQuery.php
@@ -1,0 +1,219 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Laravel\Tools;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\JsonSchema\Types\Type;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+use MongoDB\Laravel\Connection;
+use Throwable;
+
+use function array_key_first;
+use function array_merge;
+use function array_walk;
+use function count;
+use function implode;
+use function in_array;
+use function is_array;
+use function sprintf;
+use function str_replace;
+
+/**
+ * MongoDB equivalent of Boost's DatabaseQuery tool.
+ *
+ * Runs read-only MQL commands against a MongoDB connection. Boost's own
+ * DatabaseQuery tool only understands SQL and will not run against a
+ * "mongodb" driver connection.
+ */
+#[IsReadOnly]
+class DatabaseQuery extends Tool
+{
+    // BSON objects are capped at 100 nesting levels:
+    // https://www.mongodb.com/docs/manual/reference/limits/#mongodb-limit-Nested-Depth-for-BSON-Documents
+    private const MAX_NESTING_LEVEL = 100;
+
+    // Aggregation pipelines are capped at 1000 stages
+    // https://www.mongodb.com/docs/manual/core/aggregation-pipeline-limits/#number-of-stages-restrictions
+    private const MAX_STAGES_PER_PIPELINE = 1000;
+
+    /**
+     * The tool's name.
+     *
+     * Set explicitly so it does not collide with Boost's own `database-query` tool.
+     */
+    protected string $name = 'database-query-mongodb';
+
+    /**
+     * The tool's description.
+     */
+    protected string $description = 'Execute a read-only MQL command against a MongoDB connection. Pass a "command" argument (an MQL command document, e.g. {"find": "users", "filter": {"active": true}}) — never SQL. Only read commands are allowed (aggregate, count, distinct, find). Only use this tool with a connection you already know uses the "mongodb" driver.';
+
+    /**
+     * Get the tool's input schema.
+     *
+     * @return array<string, Type>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'command' => $schema->object()
+                ->description('The MQL command to execute. Only read commands are allowed (i.e. aggregate, count, distinct, find).')
+                ->required(),
+            'connection' => $schema->string()
+                ->description('Name of the MongoDB database connection to query. Must be a connection that uses the "mongodb" driver.')
+                ->required(),
+        ];
+    }
+
+    /**
+     * Handle the tool request.
+     */
+    public function handle(Request $request): Response
+    {
+        $connectionName = (string) $request->get('connection');
+        $connection = DB::connection($connectionName);
+
+        if (! $connection instanceof Connection) {
+            return Response::error(sprintf('The [%s] connection is not a MongoDB connection.', $connectionName));
+        }
+
+        try {
+            return Response::json($this->handleMql($request->array('command'), $connection));
+        } catch (InvalidArgumentException $exception) {
+            return Response::error($exception->getMessage());
+        } catch (Throwable $exception) {
+            return Response::error('Query failed: ' . $exception->getMessage());
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $command
+     *
+     * @return array<int, mixed>
+     *
+     * @throws InvalidArgumentException
+     */
+    private function handleMql(array $command, Connection $connection): array
+    {
+        if ($command === []) {
+            throw new InvalidArgumentException('Please pass a valid MongoDB command');
+        }
+
+        // Allowed CRUD commands (https://www.mongodb.com/docs/manual/reference/mql/crud-commands/)
+        $allowList = ['aggregate', 'count', 'distinct', 'find'];
+        $operation = array_key_first($command);
+
+        if (! in_array($operation, $allowList, true)) {
+            throw new InvalidArgumentException(sprintf('Only read commands are allowed (%s).', implode(', ', $allowList)));
+        }
+
+        if ($operation === 'aggregate') {
+            // Check nested write ops recursively with conservative allow list
+            $this->ensureNoNestedWriteInAggregation($command['pipeline'] ?? []);
+        }
+
+        return $connection->getDatabase()->command($command)->toArray();
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $pipeline
+     *
+     * @throws InvalidArgumentException
+     */
+    private function ensureNoNestedWriteInAggregation(array $pipeline, int $level = 1): void
+    {
+        if ($level > self::MAX_NESTING_LEVEL) {
+            throw new InvalidArgumentException(sprintf('Aggregation nesting exceeds the maximum of %d levels.', self::MAX_NESTING_LEVEL));
+        }
+
+        if (count($pipeline) > self::MAX_STAGES_PER_PIPELINE) {
+            throw new InvalidArgumentException(sprintf('A pipeline exceeds the maximum of %d stages.', self::MAX_STAGES_PER_PIPELINE));
+        }
+
+        // These aggregation stages may contain nested aggregation pipelines
+        // and must be checked for write ops recursively.
+        $supportsNestedWrites = ['facet', 'lookup', 'unionWith'];
+
+        // Every known read-only aggregation stage. Kept as an allow list (rather than
+        // denying $merge/$out) so that write stages added in the future are rejected by
+        // default. See https://www.mongodb.com/docs/manual/reference/mql/aggregation-stages
+        $allowList = array_merge($supportsNestedWrites, [
+            'addFields',
+            'bucket',
+            'bucketAuto',
+            'changeStream',
+            'changeStreamSplitLargeEvent',
+            'collStats',
+            'count',
+            'currentOp',
+            'densify',
+            'documents',
+            'fill',
+            'geoNear',
+            'graphLookup',
+            'group',
+            'indexStats',
+            'limit',
+            'listLocalSessions',
+            'listSampledQueries',
+            'listSearchIndexes',
+            'listSessions',
+            'match',
+            'planCacheStats',
+            'project',
+            'redact',
+            'replaceRoot',
+            'replaceWith',
+            'sample',
+            'search',
+            'searchMeta',
+            'set',
+            'setWindowFields',
+            'shardedDataDistribution',
+            'skip',
+            'sort',
+            'sortByCount',
+            'unwind',
+            'unset',
+            'vectorSearch',
+        ]);
+
+        // A pipeline is a list of single-key stage documents, e.g. [['$match' => [...]], ...].
+        foreach ($pipeline as $stage) {
+            $operator = array_key_first($stage);
+            $stageName = str_replace('$', '', (string) $operator);
+            $stageBody = $stage[$operator];
+
+            if (! in_array($stageName, $allowList, true)) {
+                throw new InvalidArgumentException(sprintf('Only read aggregation stages are allowed. Found: %s', $stageName));
+            }
+
+            if (! in_array($stageName, $supportsNestedWrites, true)) {
+                continue;
+            }
+
+            switch ($stageName) {
+                case 'facet':
+                    array_walk($stageBody, fn ($pipeline) => $this->ensureNoNestedWriteInAggregation($pipeline, $level + 1));
+
+                    break;
+
+                case 'lookup':
+                case 'unionWith':
+                    // Both stages take an optional single sub-pipeline; unionWith may also be a plain collection name.
+                    if (is_array($stageBody) && isset($stageBody['pipeline'])) {
+                        $this->ensureNoNestedWriteInAggregation($stageBody['pipeline'], $level + 1);
+                    }
+
+                    break;
+            }
+        }
+    }
+}

--- a/tests/Tools/DatabaseQueryTest.php
+++ b/tests/Tools/DatabaseQueryTest.php
@@ -1,0 +1,315 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Laravel\Tests\Tools;
+
+use Illuminate\Database\ConnectionInterface;
+use Illuminate\Support\Facades\DB;
+use Iterator;
+use Mockery;
+use MongoDB\BSON\Int64;
+use MongoDB\Database;
+use MongoDB\Driver\CursorInterface;
+use MongoDB\Driver\Server;
+use MongoDB\Laravel\Connection;
+use MongoDB\Laravel\Tests\TestCase;
+use MongoDB\Laravel\Tools\DatabaseQuery;
+use PHPUnit\Framework\Attributes\DataProvider;
+use RuntimeException;
+
+use function current;
+use function key;
+use function next;
+use function reset;
+use function sprintf;
+
+class DatabaseQueryTest extends TestCase
+{
+    use InteractsWithTools;
+
+    public function testRunsSuccessfulFindCommand(): void
+    {
+        $this->fakeMongoConnection([['_id' => 1, 'name' => 'Taylor']]);
+
+        $rows = $this->toolJson(new DatabaseQuery(), [
+            'connection' => 'mongodb',
+            'command' => ['find' => 'examples', 'filter' => ['name' => 'Taylor']],
+        ]);
+
+        $this->assertCount(1, $rows);
+        $this->assertSame('Taylor', $rows[0]['name']);
+    }
+
+    /** @param list<array<string, mixed>> $pipeline */
+    #[DataProvider('readOnlyAggregations')]
+    public function testRunsReadOnlyAggregation(array $pipeline): void
+    {
+        $this->fakeMongoConnection([['count' => 1]]);
+
+        $response = $this->runTool(new DatabaseQuery(), [
+            'connection' => 'mongodb',
+            'command' => ['aggregate' => 'examples', 'pipeline' => $pipeline],
+        ]);
+
+        $this->assertToolHasNoError($response);
+    }
+
+    public static function readOnlyAggregations(): array
+    {
+        return [
+            'flat stages' => [
+                [
+                    ['$match' => ['name' => 'Taylor']],
+                    ['$sort' => ['name' => 1]],
+                ],
+            ],
+            'nested read-only lookup' => [
+                [
+                    ['$lookup' => ['from' => 'others', 'pipeline' => [['$match' => ['ok' => true]]]]],
+                ],
+            ],
+            'nested read-only unionWith' => [
+                [
+                    ['$unionWith' => ['coll' => 'others', 'pipeline' => [['$match' => ['ok' => true]]]]],
+                ],
+            ],
+            'nested read-only facet' => [
+                [
+                    [
+                        '$facet' => [
+                            'a' => [['$match' => ['ok' => true]]],
+                            'b' => [['$count' => 'total']],
+                        ],
+                    ],
+                ],
+            ],
+            'deeply nested read-only pipelines' => [
+                [
+                    [
+                        '$lookup' => [
+                            'from' => 'others',
+                            'pipeline' => [
+                                ['$unionWith' => ['coll' => 'more', 'pipeline' => [['$match' => ['ok' => true]]]]],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public function testErrorsWhenConnectionIsNotMongoDB(): void
+    {
+        DB::shouldReceive('connection')->andReturn(Mockery::mock(ConnectionInterface::class));
+
+        $response = $this->runTool(new DatabaseQuery(), [
+            'connection' => 'sqlite',
+            'command' => ['find' => 'examples'],
+        ]);
+
+        $this->assertToolHasError($response);
+        $this->assertToolTextContains($response, 'The [sqlite] connection is not a MongoDB connection.');
+    }
+
+    public function testRejectsEmptyCommand(): void
+    {
+        $this->fakeMongoConnection();
+
+        $response = $this->runTool(new DatabaseQuery(), [
+            'connection' => 'mongodb',
+            'command' => [],
+        ]);
+
+        $this->assertToolHasError($response);
+        $this->assertToolTextContains($response, 'Please pass a valid MongoDB command');
+    }
+
+    public function testRejectsWriteCommand(): void
+    {
+        $this->fakeMongoConnection();
+
+        $response = $this->runTool(new DatabaseQuery(), [
+            'connection' => 'mongodb',
+            'command' => ['insert' => 'examples', 'documents' => [['name' => 'Otwell']]],
+        ]);
+
+        $this->assertToolHasError($response);
+        $this->assertToolTextContains($response, 'Only read commands are allowed (aggregate, count, distinct, find).');
+    }
+
+    /** @param list<array<string, mixed>> $pipeline */
+    #[DataProvider('writeStagesNestedInAggregations')]
+    public function testRejectsWriteStageNestedInAggregation(array $pipeline, string $writeStage): void
+    {
+        $this->fakeMongoConnection();
+
+        $response = $this->runTool(new DatabaseQuery(), [
+            'connection' => 'mongodb',
+            'command' => ['aggregate' => 'examples', 'pipeline' => $pipeline],
+        ]);
+
+        $this->assertToolHasError($response);
+        $this->assertToolTextContains($response, sprintf('Only read aggregation stages are allowed. Found: %s', $writeStage));
+    }
+
+    public static function writeStagesNestedInAggregations(): array
+    {
+        return [
+            'write nested in lookup' => [
+                [
+                    [
+                        '$lookup' => [
+                            'from' => 'others',
+                            'pipeline' => [
+                                ['$match' => ['name' => 'Taylor']],
+                                ['$merge' => 'evil'],
+                            ],
+                        ],
+                    ],
+                ],
+                'merge',
+            ],
+            'write nested in unionWith' => [
+                [
+                    [
+                        '$unionWith' => [
+                            'coll' => 'others',
+                            'pipeline' => [
+                                ['$out' => 'evil'],
+                            ],
+                        ],
+                    ],
+                ],
+                'out',
+            ],
+            'write nested in facet' => [
+                [
+                    [
+                        '$facet' => [
+                            'a' => [['$match' => ['ok' => true]]],
+                            'b' => [['$merge' => 'evil']],
+                        ],
+                    ],
+                ],
+                'merge',
+            ],
+            'write nested three levels deep' => [
+                [
+                    [
+                        '$lookup' => [
+                            'from' => 'a',
+                            'pipeline' => [
+                                [
+                                    '$unionWith' => [
+                                        'coll' => 'b',
+                                        'pipeline' => [
+                                            ['$out' => 'evil'],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                'out',
+            ],
+        ];
+    }
+
+    public function testReportsFailureWhenTheDriverThrows(): void
+    {
+        $database = Mockery::mock(Database::class);
+        $database->shouldReceive('command')->andThrow(new RuntimeException('Simulated DB failure'));
+
+        $connection = Mockery::mock(Connection::class);
+        $connection->shouldReceive('getDatabase')->andReturn($database);
+
+        DB::shouldReceive('connection')->andReturn($connection);
+
+        $response = $this->runTool(new DatabaseQuery(), [
+            'connection' => 'mongodb',
+            'command' => ['find' => 'examples'],
+        ]);
+
+        $this->assertToolHasError($response);
+        $this->assertToolTextContains($response, 'Query failed: Simulated DB failure');
+    }
+
+    /**
+     * Bind a fully mocked MongoDB connection so the tool never touches a real server.
+     *
+     * @param list<array<string, mixed>> $documents
+     */
+    private function fakeMongoConnection(array $documents = []): void
+    {
+        // Database::command() is typed to return a CursorInterface (Mockery enforces the return type),
+        // so the double implements it. Iterator is listed explicitly because in ext-mongodb 1.x
+        // CursorInterface only extends Traversable (in 2.x it extends Iterator); without it the class is
+        // not a valid Traversable and PHP fatals at declaration time.
+        $cursor = new class ($documents) implements CursorInterface, Iterator {
+            /** @param list<array<string, mixed>> $documents */
+            public function __construct(private array $documents)
+            {
+            }
+
+            /** @return list<array<string, mixed>> */
+            public function toArray(): array
+            {
+                return $this->documents;
+            }
+
+            public function current(): array|object|null
+            {
+                return current($this->documents) ?: null;
+            }
+
+            public function key(): ?int
+            {
+                return key($this->documents);
+            }
+
+            public function next(): void
+            {
+                next($this->documents);
+            }
+
+            public function valid(): bool
+            {
+                return key($this->documents) !== null;
+            }
+
+            public function rewind(): void
+            {
+                reset($this->documents);
+            }
+
+            public function getId(): Int64
+            {
+                throw new RuntimeException('unused in tests');
+            }
+
+            public function getServer(): Server
+            {
+                throw new RuntimeException('unused in tests');
+            }
+
+            public function isDead(): bool
+            {
+                return true;
+            }
+
+            public function setTypeMap(array $typemap): void
+            {
+            }
+        };
+
+        $database = Mockery::mock(Database::class);
+        $database->shouldReceive('command')->andReturn($cursor);
+
+        $connection = Mockery::mock(Connection::class);
+        $connection->shouldReceive('getDatabase')->andReturn($database);
+
+        DB::shouldReceive('connection')->andReturn($connection);
+    }
+}

--- a/tests/Tools/ToolsIntegrationTest.php
+++ b/tests/Tools/ToolsIntegrationTest.php
@@ -11,6 +11,7 @@ use Laravel\Boost\Mcp\ToolRegistry;
 use Laravel\Mcp\Server\Tool;
 use MongoDB\Laravel\Tests\TestCase;
 use MongoDB\Laravel\Tools\DatabaseInfo;
+use MongoDB\Laravel\Tools\DatabaseQuery;
 
 use function array_merge;
 
@@ -45,5 +46,6 @@ class ToolsIntegrationTest extends TestCase
     private function tools(): Generator
     {
         yield [new DatabaseInfo(), ['connection' => 'mongodb']];
+        yield [new DatabaseQuery(), ['connection' => 'mongodb', 'command' => ['find' => 'examples']]];
     }
 }


### PR DESCRIPTION
This was originally a PR on `laravel/boost` (see: https://github.com/laravel/boost/pull/874), but was rejected because third-party packages can register their own tools in the service provider.

This adds a MongoDB-specific database query tool that Boost users can use instead of the SQL-specific Boost equivalent. Boost would otherwise attempt to run SQL on an MDB connection, which, well. Doesn't work. 
