### PR TITLE
Fix groupBy() building an invalid $group stage when _id is selected

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -319,6 +319,12 @@ class Builder extends BaseBuilder
             // Add the last value of each column when there is no aggregate function.
             if ($this->groups && ! $this->aggregate) {
                 foreach ($columns as $column) {
+                    // The _id field holds the grouping keys and must not be
+                    // overwritten by an accumulator when it is selected.
+                    if ($column === '_id') {
+                        continue;
+                    }
+
                     $key = str_replace('.', '_', $column);
 
                     $group[$key] = ['$last' => '$' . $column];

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -1241,6 +1241,16 @@ class BuilderTest extends TestCase
             fn (Builder $builder) => $builder->groupBy('foo'),
         ];
 
+        yield 'groupBy with _id in select' => [
+            [
+                'aggregate' => [
+                    [['$group' => ['_id' => ['foo' => '$foo'], 'foo' => ['$last' => '$foo']]]],
+                    [], // options
+                ],
+            ],
+            fn (Builder $builder) => $builder->select('_id', 'foo')->groupBy('foo'),
+        ];
+
         yield 'sub-query' => [
             [
                 'find' => [


### PR DESCRIPTION
Fixes #3551.

`Query\Builder` builds the `$group` stage with `_id` holding the grouping-key document. When the selected columns also contain `_id` (e.g. `->groupBy('foo')->select(['_id', 'foo'])`), the last-value loop overwrote that key document with `['$last' => '$_id']` — and inside `_id`, `$last` is parsed as the *array expression operator*, so the server rejects the pipeline with **"$last's argument must be an array"** (exactly the error in the issue).

Two commits:
1. Skip `_id` in the last-value column loop — the grouping key is already emitted as `_id`, so selecting it needs no accumulator.
2. Regression test in `tests/Query/BuilderTest.php` asserting the built pipeline for `select('_id', 'foo')->groupBy('foo')` keeps `_id` as the grouping-key document — **fails without commit 1** (verified).

**Verification (macOS arm64, PHP 8.5, ext-mongodb via pecl, local standalone mongod):** full `vendor/bin/phpunit` run: 826 tests, 3521 assertions — the only error is `ModelTest::testCreateOrFirst` ("did not remove its own error handlers"), which errors **identically on unmodified master** in this environment and is unrelated to this change; 50 skipped (feature-gated).

Prepared with AI assistance (Claude); the root cause and fix were verified against the built pipeline as described.