### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,7 +105,6 @@ jobs:
     needs: prepare-release
     name: "Run Static Analysis"
     uses: ./.github/workflows/static-analysis.yml
-    continue-on-error: true
     with:
       ref: refs/tags/${{ inputs.version }}
     permissions:


### PR DESCRIPTION
The `continue-on-error` key added in d5e4c314a268770fdc6293306d6b53e2e08e4fa1 is invalid.