### PR TITLE
Fix unmatched PHPStan ignore on ext-mongodb 1.x

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -19,6 +19,12 @@ parameters:
     ignoreErrors:
         - '#Unsafe usage of new static#'
         - '#Call to an undefined method [a-zA-Z0-9\\_\<\>\(\)]+::[a-zA-Z]+\(\)#'
+        # Closure is bound to CacheManager at runtime, PHPStan does not detect it.
+        -
+            identifier: arguments.count
+            path: src/MongoDBServiceProvider.php
+            count: 1
+            reportUnmatched: false
 
 services:
     errorFormatter.sarif:

--- a/src/MongoDBServiceProvider.php
+++ b/src/MongoDBServiceProvider.php
@@ -88,7 +88,7 @@ class MongoDBServiceProvider extends ServiceProvider
                 $store = new MongoStore(
                     $app['db']->connection($config['connection'] ?? null),
                     $config['collection'] ?? 'cache',
-                    $this->getPrefix($config), // @phpstan-ignore arguments.count (closure is bound to CacheManager at runtime)
+                    $this->getPrefix($config),
                     $app['db']->connection($config['lock_connection'] ?? $config['connection'] ?? null),
                     $config['lock_collection'] ?? ($config['collection'] ?? 'cache') . '_locks',
                     $config['lock_lottery'] ?? [2, 100],


### PR DESCRIPTION
The `PHP/8.4 Driver/1` static-analysis job fails with:

```
src/MongoDBServiceProvider.php:91
No error with identifier arguments.count is reported on line 91.
```

The inline `@phpstan-ignore arguments.count` added in #3529 for the `getPrefix()` call is unmatched when analysing against `ext-mongodb 1.x`, because the type resolution differs from `ext-mongodb 2.x` and PHPStan does not emit the underlying `arguments.count` error there.

Move the ignore to `phpstan.neon.dist` with `reportUnmatched: false` so it silently applies on driver 2 without failing on driver 1.

Reproduced locally with PHP 8.4 and `ext-mongodb 1.21.5`; PHPStan now reports `[OK] No errors` on both driver flavors.