### PR TITLE
PHPLARA-32 Fix attribute masked by a set-only Attribute mutator

### DIFF
--- a/src/Eloquent/DocumentModel.php
+++ b/src/Eloquent/DocumentModel.php
@@ -177,7 +177,7 @@ trait DocumentModel
             method_exists($this, $key)
             && ! method_exists(Model::class, $key)
             && ! method_exists(DocumentModel::class, $key)
-            && ! $this->hasAttributeGetMutator($key)
+            && ! $this->hasAttributeMutator($key)
         ) {
             return $this->getRelationValue($key);
         }

--- a/tests/Models/HiddenAnimal.php
+++ b/tests/Models/HiddenAnimal.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Laravel\Tests\Models;
 
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Model;
 use MongoDB\Laravel\Eloquent\DocumentModel;
 
@@ -11,6 +12,7 @@ use MongoDB\Laravel\Eloquent\DocumentModel;
  * @property string $name
  * @property string $country
  * @property bool $can_be_eaten
+ * @property string $secret
  */
 final class HiddenAnimal extends Model
 {
@@ -21,7 +23,19 @@ final class HiddenAnimal extends Model
         'name',
         'country',
         'can_be_eaten',
+        'secret',
     ];
 
-    protected $hidden = ['country'];
+    protected $hidden = ['country', 'secret'];
+
+    /**
+     * Reproduces laravel/passport Client::secret(): a set-only Attribute mutator
+     * whose method name collides with a hidden attribute.
+     */
+    protected function secret(): Attribute
+    {
+        return Attribute::make(
+            set: fn (?string $value): ?string => $value,
+        );
+    }
 }

--- a/tests/PropertyTest.php
+++ b/tests/PropertyTest.php
@@ -34,4 +34,21 @@ final class PropertyTest extends TestCase
         self::assertArrayNotHasKey('country', $hiddenAnimal->toArray(), 'the country column should be hidden');
         self::assertArrayHasKey('can_be_eaten', $hiddenAnimal->toArray());
     }
+
+    public function testHiddenAttributeWithSetOnlyAttributeMutatorIsAccessible(): void
+    {
+        HiddenAnimal::create([
+            'name' => 'Sheep',
+            'country' => 'Ireland',
+            'can_be_eaten' => true,
+            'secret' => 'shhh',
+        ]);
+
+        $hiddenAnimal = HiddenAnimal::sole();
+        assert($hiddenAnimal instanceof HiddenAnimal);
+
+        self::assertSame('shhh', $hiddenAnimal->secret);
+        self::assertSame('shhh', $hiddenAnimal->getAttributes()['secret']);
+        self::assertArrayNotHasKey('secret', $hiddenAnimal->toArray());
+    }
 }


### PR DESCRIPTION
Fixes [PHPLARA-32](https://jira.mongodb.org/browse/PHPLARA-32), reported from https://github.com/laravel/passport/pull/1850#issuecomment-3490599234.

An attribute whose name collides with a method typed `: Attribute` that declares only a `set:` callback is unreadable: `$model->attr` always returns `null`.

`laravel/passport` `Client` is exactly this shape:

```php
protected $hidden = ['secret'];

protected function secret(): Attribute
{
    return Attribute::make(
        set: function (?string $value): ?string {
            $this->plainSecret = $value;

            return $this->castAttributeAsHashedString('secret', $value);
        },
    );
}
```

`Client::confidential()` could not read the secret, so `createToken()` failed with `Personal access client not found for '$provider' user provider.`. Passport worked around it in laravel/passport#1850 by reading `getAttributes()['secret']` directly, but any userland code doing `$client->secret` is still affected.

Note this has nothing to do with `$hidden`, which only filters serialization. The collision with the mutator method name is what breaks it.

## Cause

`DocumentModel::getAttribute()` short-circuits to `getRelationValue()` when a method matches the attribute name, so that embedded relations take precedence over the raw stored array. It guarded that branch with `hasAttributeGetMutator()`, which returns `false` when the `Attribute` has no `get:` callback. The attribute was therefore treated as a relation.

That path was a dead end: Laravel's `getRelationValue()` calls `isRelation()`, which itself returns `false` as soon as `hasAttributeMutator()` is true, so it fell through to a bare `return;`, hence the `null`.

The fix uses `hasAttributeMutator()`, which is what Laravel core uses in both `hasAttribute()` and `isRelation()`. This removes the disagreement between `getAttribute()` and `isRelation()`.

## Backward compatibility

`hasAttributeMutator()` is a strict superset of `hasAttributeGetMutator()`, so the only keys taking a different path are methods typed `: Attribute` whose `get` is not callable. I ran a matrix over every method/attribute collision shape, before and after:

| Case | Before | After |
| --- | --- | --- |
| `Attribute` get + set | `'GET:stored'` | `'GET:stored'` |
| `Attribute` get only | `'GET:stored'` | `'GET:stored'` |
| **`Attribute` set only** | **`null`** | **`'stored'`** |
| **`Attribute` with neither** | **`null`** | **`'stored'`** |
| Method typed with an unrelated class | `LogicException` | `LogicException` |
| Plain method, no return type | `LogicException` | `LogicException` |
| Legacy `getValAttribute()` accessor | `'LEGACY:stored'` | `'LEGACY:stored'` |
| Genuine embedded relation | relation | relation |

The two rows that change previously returned `null` unconditionally, so there was no reachable behavior to depend on. A method declared `: Attribute` can never return a `Relation` instance either, so it can never legitimately be an embedded relation.

Other points checked:

- `isset($model->attr)` goes from `false` to `true`, which is the same correction and matches Eloquent on SQL.
- Serialization is unchanged: `$hidden` filtering happens in `attributesToArray()`, and the new test asserts the attribute stays out of `toArray()`.
- `hasAttributeMutator()` is public, not `@internal`, not deprecated, and present in both `illuminate/database` 12.x and 13.x, covering the `^12.51|^13.0` constraint.
- The old guard invoked the userland accessor method just to inspect `->get`. The new one only uses reflection, so slightly less work and no userland code executed during an attribute read.

Pre-existing limitation left untouched: a plain method whose name collides with a stored attribute still shadows it and throws `LogicException`. Making the stored attribute win there would break embedded relations, which rely on that precedence.