### PR TITLE
PHPLARA-257 Replay query macros when eager loading MorphTo relations

### DIFF
--- a/src/Relations/MorphTo.php
+++ b/src/Relations/MorphTo.php
@@ -31,19 +31,6 @@ class MorphTo extends EloquentMorphTo
         }
     }
 
-    /** @inheritdoc */
-    #[Override]
-    protected function getResultsByType($type)
-    {
-        $instance = $this->createModelByType($type);
-
-        $key = $this->ownerKey ?? $instance->getKeyName();
-
-        $query = $instance->newQuery();
-
-        return $query->whereIn($key, $this->gatherKeysByType($type, $instance->getKeyType()))->get();
-    }
-
     /** Get the name of the "where in" method for eager loading. */
     #[Override]
     protected function whereInMethod(Model $model, $key)

--- a/tests/Models/Photo.php
+++ b/tests/Models/Photo.php
@@ -26,4 +26,9 @@ class Photo extends Model
     {
         return $this->morphTo(ownerKey: 'cclient_id');
     }
+
+    public function hasImageWithTrashed(): MorphTo
+    {
+        return $this->morphTo()->withTrashed();
+    }
 }

--- a/tests/RelationsTest.php
+++ b/tests/RelationsTest.php
@@ -7,6 +7,7 @@ namespace MongoDB\Laravel\Tests;
 use Illuminate\Database\Eloquent\Collection;
 use Mockery;
 use MongoDB\BSON\ObjectId;
+use MongoDB\Laravel\Relations\MorphTo;
 use MongoDB\Laravel\Tests\Models\Address;
 use MongoDB\Laravel\Tests\Models\Book;
 use MongoDB\Laravel\Tests\Models\Client;
@@ -678,6 +679,62 @@ class RelationsTest extends TestCase
         $relations = $check->getRelations();
         $this->assertArrayHasKey('hasImageWithCustomOwnerKey', $relations);
         $this->assertInstanceOf(Client::class, $check->hasImageWithCustomOwnerKey);
+    }
+
+    public function testMorphToWithTrashed(): void
+    {
+        $soft = Soft::create(['name' => 'Young Gerald']);
+
+        $photo = Photo::create(['url' => 'https://graph.facebook.com/young.gerald/picture']);
+        $photo->hasImage()->associate($soft);
+        $photo->hasImageWithTrashed()->associate($soft);
+        $photo->save();
+
+        $soft->delete();
+
+        $photo = Photo::first();
+        $this->assertEquals($soft->id, $photo->has_image_id);
+        $this->assertEquals($soft->id, $photo->has_image_with_trashed_id);
+
+        // Lazy loading
+        $this->assertNull($photo->hasImage);
+        $this->assertInstanceOf(Soft::class, $photo->hasImageWithTrashed);
+        $this->assertTrue($photo->hasImageWithTrashed->trashed());
+
+        // Eager loading
+        $photo = Photo::with('hasImage', 'hasImageWithTrashed')->first();
+        $this->assertNull($photo->getRelation('hasImage'));
+        $this->assertInstanceOf(Soft::class, $photo->getRelation('hasImageWithTrashed'));
+        $this->assertEquals($soft->id, $photo->hasImageWithTrashed->id);
+    }
+
+    public function testMorphToConstrainAndMorphWith(): void
+    {
+        $john = User::create(['name' => 'John Doe']);
+        $john->books()->create(['title' => 'Human Action']);
+        $jane = User::create(['name' => 'Jane Doe']);
+
+        Photo::create(['url' => 'john.jpg'])->hasImage()->associate($john)->save();
+        Photo::create(['url' => 'jane.jpg'])->hasImage()->associate($jane)->save();
+
+        $photos = Photo::with([
+            'hasImage' => fn (MorphTo $relation) => $relation->constrain([
+                User::class => fn ($query) => $query->where('name', 'John Doe'),
+            ]),
+        ])->get();
+
+        $this->assertEquals($john->id, $photos->firstWhere('url', 'john.jpg')->hasImage->id);
+        $this->assertNull($photos->firstWhere('url', 'jane.jpg')->getRelation('hasImage'));
+
+        $photos = Photo::with([
+            'hasImage' => fn (MorphTo $relation) => $relation->morphWith([
+                User::class => ['books'],
+            ]),
+        ])->get();
+
+        $john = $photos->firstWhere('url', 'john.jpg')->hasImage;
+        $this->assertTrue($john->relationLoaded('books'));
+        $this->assertEquals('Human Action', $john->books->first()->title);
     }
 
     public function testMorphToMany(): void


### PR DESCRIPTION
[PHPLARA-257](https://jira.mongodb.org/browse/PHPLARA-257)

Eager loading a `morphTo()` relationship with `withTrashed()` returned `null` instead of the soft-deleted related model. Lazy loading was not affected.

```php
class Photo extends Model
{
    public function hasImage(): MorphTo
    {
        return $this->morphTo()->withTrashed();
    }
}

Photo::with('hasImage')->get(); // hasImage was null when the related model is soft-deleted
```

`MongoDB\Laravel\Relations\MorphTo::getResultsByType()` was a stripped-down copy of the Laravel implementation, unchanged since 2015. It built the query with a plain `$instance->newQuery()`, which drops `replayMacros()`. That call is what makes `withTrashed()` work: `MorphTo` cannot apply it to the parent query because the macro only exists on the related model, so it buffers the call and replays it once per morph type. Without the replay the `SoftDeletingScope` is never removed.

The same omission silently disabled `mergeConstraintsFrom()`, `with()` and `withCount()`, which made `morphWith()`, `morphWithCount()` and `constrain()` no-ops on MongoDB.

The two reasons the override existed no longer apply:

- `DocumentModel::qualifyColumn()` returns the column unchanged, so the parent's `$instance->qualifyColumn($ownerKey)` is already correct for MongoDB.
- `whereInMethod()` is separately overridden to return `whereIn` instead of `whereIntegerInRaw`.

So the override is removed and the Laravel implementation is inherited. Tests cover `withTrashed()`, `constrain()` and `morphWith()`, all three failing on the previous code.

Fixes #3454
Fixes #1361