### PR TITLE
PHPLARA-258 Mutualize PHP + MongoDB extension setup in CI

### DIFF
--- a/.github/actions/setup-php/action.yml
+++ b/.github/actions/setup-php/action.yml
@@ -1,0 +1,72 @@
+name: Setup PHP with MongoDB extension
+description: Resolve the latest stable mongodb PHP extension for the requested major, install PHP with a cached build of that extension.
+
+inputs:
+  php-version:
+    description: PHP version (e.g. 8.4)
+    required: true
+  driver:
+    description: Major version of the mongodb extension to install (1 or 2)
+    required: true
+  extensions:
+    description: Comma-separated list of extra PHP extensions to install alongside mongodb (the mongodb extension is appended automatically)
+    required: false
+    default: ''
+  coverage:
+    description: Coverage driver passed to shivammathur/setup-php (e.g. xdebug, none)
+    required: false
+    default: none
+  tools:
+    description: Tools passed to shivammathur/setup-php
+    required: false
+    default: composer
+
+outputs:
+  extension-version:
+    description: Resolved mongodb extension version (e.g. 2.3.3)
+    value: ${{ steps.resolve.outputs.version }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve latest mongodb extension release
+      id: resolve
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        DRIVER_MAJOR: ${{ inputs.driver }}
+      run: |
+        set -euo pipefail
+        version=$(gh api repos/mongodb/mongo-php-driver/releases \
+          --jq "[.[] | select(.prerelease==false) | .tag_name | select(startswith(\"${DRIVER_MAJOR}.\"))] | .[0] // empty")
+        if [ -z "${version}" ]; then
+          echo "Could not resolve latest mongodb extension for major ${DRIVER_MAJOR}" >&2
+          exit 1
+        fi
+        echo "Resolved mongodb-${version}"
+        echo "version=${version}" >> "$GITHUB_OUTPUT"
+        echo "spec=mongodb-${version}" >> "$GITHUB_OUTPUT"
+
+    - name: Setup cache environment
+      id: extcache
+      uses: shivammathur/cache-extensions@v1
+      with:
+        php-version: ${{ inputs.php-version }}
+        extensions: ${{ steps.resolve.outputs.spec }}
+        key: extcache-php${{ inputs.php-version }}-${{ steps.resolve.outputs.spec }}
+
+    - name: Cache extensions
+      uses: actions/cache@v6
+      with:
+        path: ${{ steps.extcache.outputs.dir }}
+        key: ${{ steps.extcache.outputs.key }}
+        restore-keys: ${{ steps.extcache.outputs.key }}
+
+    - name: Install PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ inputs.php-version }}
+        extensions: ${{ inputs.extensions != '' && format('{0},{1}', inputs.extensions, steps.resolve.outputs.spec) || steps.resolve.outputs.spec }}
+
+        coverage: ${{ inputs.coverage }}
+        tools: ${{ inputs.tools }}

--- a/.github/actions/setup-php/action.yml
+++ b/.github/actions/setup-php/action.yml
@@ -37,8 +37,9 @@ runs:
         DRIVER_MAJOR: ${{ inputs.driver }}
       run: |
         set -euo pipefail
-        version=$(gh api --paginate repos/mongodb/mongo-php-driver/releases \
-          --jq "[.[] | select(.prerelease==false) | .tag_name | select(startswith(\"${DRIVER_MAJOR}.\"))] | .[0] // empty")
+        version=$(gh api graphql \
+          -f query='{ repository(owner: "mongodb", name: "mongo-php-driver") { releases(first: 100, orderBy: {field: CREATED_AT, direction: DESC}) { nodes { tagName isPrerelease } } } }' \
+          --jq "[.data.repository.releases.nodes[] | select(.isPrerelease==false) | .tagName | select(startswith(\"${DRIVER_MAJOR}.\"))] | .[0] // empty")
         if [ -z "${version}" ]; then
           echo "Could not resolve latest mongodb extension for major ${DRIVER_MAJOR}" >&2
           exit 1

--- a/.github/actions/setup-php/action.yml
+++ b/.github/actions/setup-php/action.yml
@@ -37,7 +37,7 @@ runs:
         DRIVER_MAJOR: ${{ inputs.driver }}
       run: |
         set -euo pipefail
-        version=$(gh api repos/mongodb/mongo-php-driver/releases \
+        version=$(gh api --paginate repos/mongodb/mongo-php-driver/releases \
           --jq "[.[] | select(.prerelease==false) | .tag_name | select(startswith(\"${DRIVER_MAJOR}.\"))] | .[0] // empty")
         if [ -z "${version}" ]; then
           echo "Could not resolve latest mongodb extension for major ${DRIVER_MAJOR}" >&2

--- a/.github/workflows/build-ci-atlas.yml
+++ b/.github/workflows/build-ci-atlas.yml
@@ -35,16 +35,10 @@ jobs:
         timeout-minutes: 5
         run: |
           docker run --name mongodb -p 27017:27017 --detach mongodb/mongodb-atlas-local:latest
-          until docker exec --tty mongodb mongosh --eval "db.runCommand({ ping: 1 })"; do
-            sleep 1
-          done
-          docker exec --tty mongodb mongosh --eval "db.createCollection('connection_test')"
-          until docker exec --tty mongodb mongosh --eval "db.getCollection('connection_test').createSearchIndex({mappings:{dynamic: true}})"; do
-            sleep 1
-          done
-          until docker exec --tty mongodb mongosh --eval "db.runCommand({ serverStatus: 1 })"; do
-            sleep 1
-          done
+          until docker exec --tty mongodb mongosh --eval "db.hello().isWritablePrimary" | grep -q true; do sleep 1; done
+          until docker exec --tty mongodb mongosh --eval "db.createCollection('connection_test')"; do sleep 1; done
+          until docker exec --tty mongodb mongosh --eval "db.getCollection('connection_test').createSearchIndex({mappings:{dynamic: true}})"; do sleep 1; done
+          until docker exec --tty mongodb mongosh --eval "db.runCommand({ serverStatus: 1 })"; do sleep 1; done
 
       - name: Setup PHP with MongoDB extension
         uses: ./.github/actions/setup-php

--- a/.github/workflows/build-ci-atlas.yml
+++ b/.github/workflows/build-ci-atlas.yml
@@ -9,10 +9,6 @@ on:
       - '[0-9]+.[0-9x]+'
       - feature/*
 
-env:
-  MONGODB_EXT_V1: mongodb-1.21.0
-  MONGODB_EXT_V2: stable
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -50,21 +46,13 @@ jobs:
             sleep 1
           done
 
-      - name: Setup cache environment
-        id: extcache
-        uses: shivammathur/cache-extensions@v1
+      - name: Setup PHP with MongoDB extension
+        uses: ./.github/actions/setup-php
         with:
           php-version: ${{ matrix.php }}
-          extensions: ${{ matrix.driver == 1 && env.MONGODB_EXT_V1 || env.MONGODB_EXT_V2 }}
-          key: extcache-v1
-
-      - name: Installing php
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php }}
-          extensions: curl,mbstring,xdebug,${{ matrix.driver == 1 && env.MONGODB_EXT_V1 || env.MONGODB_EXT_V2 }}
+          driver: ${{ matrix.driver }}
+          extensions: curl,mbstring,xdebug
           coverage: xdebug
-          tools: composer
 
       - name: Show Docker version
         if: ${{ runner.debug }}

--- a/.github/workflows/build-ci-atlas.yml
+++ b/.github/workflows/build-ci-atlas.yml
@@ -36,8 +36,9 @@ jobs:
         run: |
           docker run --name mongodb -p 27017:27017 --detach mongodb/mongodb-atlas-local:latest
           until docker exec --tty mongodb mongosh --eval "db.hello().isWritablePrimary" | grep -q true; do sleep 1; done
-          until docker exec --tty mongodb mongosh --eval "db.createCollection('connection_test')"; do sleep 1; done
+          until docker exec --tty mongodb mongosh --eval "db.getCollection('connection_test').insertOne({})"; do sleep 1; done
           until docker exec --tty mongodb mongosh --eval "db.getCollection('connection_test').createSearchIndex({mappings:{dynamic: true}})"; do sleep 1; done
+          docker exec --tty mongodb mongosh --eval "db.getCollection('connection_test').drop()"
           until docker exec --tty mongodb mongosh --eval "db.runCommand({ serverStatus: 1 })"; do sleep 1; done
 
       - name: Setup PHP with MongoDB extension

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -34,15 +34,19 @@ jobs:
           - php: '8.2'
             laravel: 12.*
             mongodb: '4.4'
+            driver: 2
           - php: '8.2'
             laravel: 12.*
             mongodb: '5.0'
+            driver: 2
           - php: '8.2'
             laravel: 12.*
             mongodb: '6.0'
+            driver: 2
           - php: '8.2'
             laravel: 12.*
             mongodb: '7.0'
+            driver: 2
         exclude:
           - laravel: '13.*'
             php: '8.2'

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -9,10 +9,6 @@ on:
       - '[0-9]+.[0-9x]+'
       - feature/*
 
-env:
-  MONGODB_EXT_V1: mongodb-1.21.0
-  MONGODB_EXT_V2: stable
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -69,21 +65,13 @@ jobs:
           if [ "${{ matrix.mongodb }}" = "4.4" ]; then MONGOSH_BIN="mongo"; else MONGOSH_BIN="mongosh"; fi
           docker exec --tty mongodb $MONGOSH_BIN --eval "db.runCommand({ serverStatus: 1 })"
 
-      - name: Setup cache environment
-        id: extcache
-        uses: shivammathur/cache-extensions@v1
+      - name: Setup PHP with MongoDB extension
+        uses: ./.github/actions/setup-php
         with:
           php-version: ${{ matrix.php }}
-          extensions: ${{ matrix.driver == 1 && env.MONGODB_EXT_V1 || env.MONGODB_EXT_V2 }}
-          key: extcache-v1
-
-      - name: Installing php
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php }}
-          extensions: curl,mbstring,xdebug,${{ matrix.driver == 1 && env.MONGODB_EXT_V1 || env.MONGODB_EXT_V2 }}
+          driver: ${{ matrix.driver }}
+          extensions: curl,mbstring,xdebug
           coverage: xdebug
-          tools: composer
 
       - name: Show Docker version
         if: ${{ runner.debug }}

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -55,6 +55,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Create MongoDB Replica Set
+        timeout-minutes: 5
         run: |
           docker run --name mongodb -p 27017:27017 -e MONGO_INITDB_DATABASE=unittest --detach mongo:${{ matrix.mongodb }} mongod --replSet rs --setParameter transactionLifetimeLimitSeconds=5
 

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -11,7 +11,6 @@ on:
 
 env:
   PHP_VERSION: '8.4'
-  DRIVER_VERSION: stable
 
 jobs:
   phpcs:
@@ -27,27 +26,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Setup cache environment
-        id: extcache
-        uses: shivammathur/cache-extensions@v1
+      - name: Setup PHP with MongoDB extension
+        uses: ./.github/actions/setup-php
         with:
           php-version: ${{ env.PHP_VERSION }}
-          extensions: mongodb-${{ env.DRIVER_VERSION }}
-          key: extcache-v1
-
-      - name: Cache extensions
-        uses: actions/cache@v6
-        with:
-          path: ${{ steps.extcache.outputs.dir }}
-          key: ${{ steps.extcache.outputs.key }}
-          restore-keys: ${{ steps.extcache.outputs.key }}
-
-      - name: Install PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          coverage: none
-          extensions: mongodb-${{ env.DRIVER_VERSION }}
-          php-version: ${{ env.PHP_VERSION }}
+          driver: 2
           tools: cs2pr
 
       - name: Show driver information

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -15,12 +15,6 @@ on:
         type: string
         required: true
 
-env:
-  PHP_VERSION: '8.5'
-  DRIVER_VERSION: stable
-  MONGODB_EXT_V1: mongodb-1.21.0
-  MONGODB_EXT_V2: mongodb-mongodb/mongo-php-driver@v2.x
-
 jobs:
   phpstan:
     name: PHP/${{ matrix.php }} Driver/${{ matrix.driver }}
@@ -46,21 +40,13 @@ jobs:
         run: |
           echo CHECKED_OUT_SHA=$(git rev-parse HEAD) >> $GITHUB_ENV
 
-      - name: Setup cache environment
-        id: extcache
-        uses: shivammathur/cache-extensions@v1
+      - name: Setup PHP with MongoDB extension
+        uses: ./.github/actions/setup-php
         with:
           php-version: ${{ matrix.php }}
-          extensions: ${{ matrix.driver == 1 && env.MONGODB_EXT_V1 || env.MONGODB_EXT_V2 }}
-          key: extcache-v1
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php }}
-          extensions: curl,mbstring,${{ matrix.driver == 1 && env.MONGODB_EXT_V1 || env.MONGODB_EXT_V2 }}
+          driver: ${{ matrix.driver }}
+          extensions: curl,mbstring
           tools: composer:v2
-          coverage: none
 
       - name: Cache dependencies
         id: composer-cache


### PR DESCRIPTION
1. Cache the mongodb extension in the PHP setup, via a shared composite action reused by all workflows.
2. Resolve the latest release from the GitHub API (mongodb/mongo-php-driver), which also gives a stable cache key.
3. Use `until` loops to wait for the MongoDB cluster to be ready, to reduce recurring startup failures.

Ref: https://jira.mongodb.org/browse/PHPLARA-258